### PR TITLE
Debian Support

### DIFF
--- a/bootenvs/ce-debian-8.yml
+++ b/bootenvs/ce-debian-8.yml
@@ -1,0 +1,58 @@
+---
+Name: "ce-debian-8-install"
+OS:
+  Name: "debian-8"
+  Family: "debian"
+  IsoFile: "debian-8-amd64-mini.iso"
+  IsoSha256: "2d8c429068edbbac3c61c01f50576fa74958ce563352e9caf62ba47c429258d0"
+  IsoUrl: "http://mirrors.kernel.org/debian/dists/jessie/main/installer-amd64/current/images/netboot/mini.iso"
+  Version: "8.8"
+Initrds:
+  - "initrd.gz"
+Kernel: "linux"
+BootParams: >-
+  priority=critical
+  console-tools/archs=at
+  console-setup/charmap=UTF-8
+  console-keymaps-at/keymap=us
+  popularity-contest/participate=false
+  passwd/root-login=false
+  keyboard-configuration/xkb-keymap=us
+  netcfg/get_domain=unassigned-domain
+  console-setup/ask_detect=false
+  debian-installer/locale=en_US.utf8
+  console-setup/layoutcode=us
+  keyboard-configuration/layoutcode=us
+  netcfg/dhcp_timeout=120
+  netcfg/choose_interface=auto
+  url={{.Machine.Url}}/seed
+  netcfg/get_hostname={{.Machine.Name}}
+  root=/dev/ram
+  rw
+  quiet
+  {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
+RequiredParams:
+OptionalParams:
+  - "operating-system-disk"
+  - "provisioner-default-user"
+  - "provisioner-default-fullname"
+  - "provisioner-default-uid"
+  - "provisioner-default-password-hash"
+  - "access-keys"
+  - "kernel-console"
+Templates:
+  - ID: "ce-default-pxelinux.tmpl"
+    Name: "pxelinux"
+    Path: "pxelinux.cfg/{{.Machine.HexAddress}}"
+  - ID: "ce-default-elilo.tmpl"
+    Name: "elilo"
+    Path: "{{.Machine.HexAddress}}.conf"
+  - ID: "ce-default-ipxe.tmpl"
+    Name: "ipxe"
+    Path: "{{.Machine.Address}}.ipxe"
+  - ID: "ce-net-seed.tmpl"
+    Name: "seed"
+    Path: "{{.Machine.Path}}/seed"
+  - ID: "ce-net-post-install.sh.tmpl"
+    Name: "net-post-install.sh"
+    Path: "{{.Machine.Path}}/post-install.sh"

--- a/bootenvs/ce-debian-9.yml
+++ b/bootenvs/ce-debian-9.yml
@@ -1,0 +1,58 @@
+---
+Name: "ce-debian-9-install"
+OS:
+  Name: "debian-9"
+  Family: "debian"
+  IsoFile: "debian-9-amd64-mini.iso"
+  IsoSha256: "83fea524a48e66c0f0ba144ff96bca7d57022c664cb474b83fdc8b61f751d688"
+  IsoUrl: "http://mirrors.kernel.org/debian/dists/stretch/main/installer-amd64/current/images/netboot/mini.iso"
+  Version: "9.2"
+Initrds:
+  - "initrd.gz"
+Kernel: "linux"
+BootParams: >-
+  priority=critical
+  console-tools/archs=at
+  console-setup/charmap=UTF-8
+  console-keymaps-at/keymap=us
+  popularity-contest/participate=false
+  passwd/root-login=false
+  keyboard-configuration/xkb-keymap=us
+  netcfg/get_domain=unassigned-domain
+  console-setup/ask_detect=false
+  debian-installer/locale=en_US.utf8
+  console-setup/layoutcode=us
+  keyboard-configuration/layoutcode=us
+  netcfg/dhcp_timeout=120
+  netcfg/choose_interface=auto
+  url={{.Machine.Url}}/seed
+  netcfg/get_hostname={{.Machine.Name}}
+  root=/dev/ram
+  rw
+  quiet
+  {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
+RequiredParams:
+OptionalParams:
+  - "operating-system-disk"
+  - "provisioner-default-user"
+  - "provisioner-default-fullname"
+  - "provisioner-default-uid"
+  - "provisioner-default-password-hash"
+  - "access-keys"
+  - "kernel-console"
+Templates:
+  - ID: "ce-default-pxelinux.tmpl"
+    Name: "pxelinux"
+    Path: "pxelinux.cfg/{{.Machine.HexAddress}}"
+  - ID: "ce-default-elilo.tmpl"
+    Name: "elilo"
+    Path: "{{.Machine.HexAddress}}.conf"
+  - ID: "ce-default-ipxe.tmpl"
+    Name: "ipxe"
+    Path: "{{.Machine.Address}}.ipxe"
+  - ID: "ce-net-seed.tmpl"
+    Name: "seed"
+    Path: "{{.Machine.Path}}/seed"
+  - ID: "ce-net-post-install.sh.tmpl"
+    Name: "net-post-install.sh"
+    Path: "{{.Machine.Path}}/post-install.sh"

--- a/templates/ce-net-post-install.sh.tmpl
+++ b/templates/ce-net-post-install.sh.tmpl
@@ -25,6 +25,8 @@ cat > /target/update_system2.sh <<'EOF2341'
 set -x
 export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]}): '
 
+wget "{{.Machine.Url}}/seed" -O /var/log/provision.seed
+
 {{template "ce-root-remote-access.tmpl" .}}
 {{template "ce-update-drp-local.tmpl" .}}
 

--- a/templates/ce-net-seed.tmpl
+++ b/templates/ce-net-seed.tmpl
@@ -1,4 +1,5 @@
-# Rebar seed file for Debian installs
+# Rebar seed file for Debian/Ubuntu installs
+# Locale and Language Settings
 d-i debian-installer/locale string en_US.UTF-8
 d-i console-setup/ask_detect boolean false
 d-i console-setup/layoutcode string us
@@ -8,74 +9,111 @@ d-i console-tools/archs select at
 d-i console-keymaps-at/keymap select American English
 d-i debian-installer/keymap string us
 d-i keyboard-configuration/toggle select No toggling
+
+# Serial Console
+d-i debian-installer/serial-console boolean true
+d-i finish-install/keep-consoles boolean true
+
+# Network Configuration
 d-i netcfg/choose_interface select auto
 d-i netcfg/dhcp_timeout string 120
 d-i netcfg/get_hostname string {{.Machine.ShortName}}
+
+# Mirror Configuration
 d-i mirror/country string manual
-{{if (eq "debian" .Env.OS.Family)}}
+{{if (eq "debian" .Env.OS.Family) -}}
 d-i mirror/protocol string http
 d-i mirror/http/hostname string http.us.debian.org
 d-i mirror/http/directory string /debian
-{{else}}
+d-i apt-setup/security_host string security.debian.org/debian-security
+{{else -}}
 d-i mirror/http/hostname string archive.ubuntu.com
 d-i mirror/http/directory string /ubuntu
-{{end}}
+d-i apt-setup/security_host string archive.ubuntu.com
+d-i apt-setup/security_path string /ubuntu
+{{end -}}
 d-i mirror/http/proxy string
-d-i apt-setup/security_host string
-d-i apt-setup/security_path string
+
+# Clock
 d-i clock-setup/utc boolean true
 d-i time/zone string UTC
 d-i clock-setup/ntp boolean false
-{{if .ParamExists "operating-system-disk"}}
-d-i partman-auto/disk string /dev/{{.Param "operating-system-disk"}}
-{{else}}
-d-i partman-auto/disk string /dev/sda
-{{end}}
-d-i partman-auto/method string lvm
+
+# Partitioner Label Default (GPT)
+d-i partman/choose_label string gpt
+d-i partman-basicfilesystems/choose_label string gpt
+d-i partman-partitioning/choose_label string gpt
+d-i partman/default_label string gpt
+d-i partman-basicfilesystems/default_label string gpt
+d-i partman-partitioning/default_label string gpt
+# Partitioner Prompt Confirmations
+d-i partman-auto/purge_lvm_from_device boolean true
+d-i partman-md/confirm boolean true
+d-i partman-md/device_remove_md boolean true
+d-i partman-md/confirm_nochanges boolean true
+d-i partman-md/confirm_nooverwrite boolean true
+d-i partman-lvm/confirm boolean true
 d-i partman-lvm/device_remove_lvm boolean true
 d-i partman-lvm/device_remove_lvm_span boolean true
-d-i partman-auto/purge_lvm_from_device boolean true
-d-i partman-md/device_remove_md boolean true
-d-i partman-lvm/confirm boolean true
 d-i partman-lvm/confirm_nochanges boolean true
 d-i partman-lvm/confirm_nooverwrite boolean true
-d-i partman-auto-lvm/guided_size string max
-d-i partman-auto-lvm/new_vg_name string {{.Machine.ShortName}}
-d-i partman-auto/choose_recipe select custom_lvm
 d-i partman/confirm_write_new_label boolean true
+d-i partman-basicfilesystems/no_swap boolean false
 d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true
+#Partitioning Scheme
+{{if .ParamExists "operating-system-disk" -}}
+d-i partman-auto/disk string /dev/{{.Param "operating-system-disk"}}
+{{else -}}
+d-i partman-auto/disk string /dev/sda
+{{end -}}
+d-i partman-auto/method string lvm
+d-i partman-auto-lvm/guided_size string max
+d-i partman-auto-lvm/new_vg_name string {{.Machine.ShortName}}
+d-i partman-auto/choose_recipe select custom_lvm
 d-i partman/auto expert_recipe string \
     custom_lvm::  \
       500 50 1024 free $iflabel{ gpt } $reusemethod{ } method{ efi } format{ } . \
       128 50 256  ext2 $defaultignore{ } method{ format } format{ } use_filesystem{ } filesystem{ ext2 } mountpoint{ /boot } . \
       10240 20 10240 ext4 $lvmok{ } mountpoint{ / } lv_name{ root } in_vg{ {{.Machine.ShortName}} } method{ format } format{ } use_filesystem{ } filesystem{ ext4 } . \
       50% 20 100% linux-swap $lvmok{ } lv_name{ swap } in_vg{ {{.Machine.ShortName}} } method{ swap } format{ } .
-{{if (and (eq "ubuntu" .Env.OS.Family)  (lt "12.10" .Env.OS.Version))}}
+d-i grub-installer/only_debian boolean true
+{{if (not (and (eq "debian" .Env.OS.Family) (gt "7" .Env.OS.Version))) -}}
+{{if .ParamExists "operating-system-disk" -}}
+d-i grub-installer/choose_bootdev select /dev/{{.Param "operating-system-disk"}}
+d-i grub-installer/bootdev string /dev/{{.Param "operating-system-disk"}}
+{{else -}}
+d-i grub-installer/choose_bootdev select /dev/sda
+d-i grub-installer/bootdev string /dev/sda
+{{end -}}
+{{end -}}
+
+{{if (and (eq "ubuntu" .Env.OS.Family)  (lt "12.10" .Env.OS.Version)) -}}
 d-i live-installer/net-image string {{.Env.InstallUrl}}/install/filesystem.squashfs
-{{end}}
-d-i passwd/user-fullname string {{if .ParamExists "provisioner-default-user"}}{{.Param "provisioner-default-user"}}{{else}}rocketskates{{end}}
+{{end -}}
+
+# Default User Setup
+d-i passwd/make-user boolean true
+d-i passwd/user-uid string {{if .ParamExists "provisioner-default-uid"}}{{.Param "provisioner-default-uid"}}{{else}}1000{{end}}
+d-i passwd/user-fullname string {{if .ParamExists "provisioner-default-fullname"}}{{.Param "provisioner-default-fullname"}}{{else if .ParamExists "provisioner-default-user"}}{{.Param "provisioner-default-user"}}{{else}}Rocket Skates{{end}}
 d-i passwd/username string {{if .ParamExists "provisioner-default-user"}}{{.Param "provisioner-default-user"}}{{else}}rocketskates{{end}}
 d-i passwd/user-password-crypted password {{if .ParamExists "provisioner-default-password-hash"}}{{.Param "provisioner-default-password-hash"}}{{else}}$6$drprocksdrprocks$upAIK9ynEEdFmaxJ5j0QRvwmIu2ruJa1A1XB7GZjrnYYXXyNr4qF9FttxMda2j.cmh.TSiLgn4B/7z0iSHkDC1{{end}}
 d-i user-setup/allow-password-weak boolean true
 d-i user-setup/encrypt-home boolean false
+
 d-i debian-installer/allow_unauthenticated string true
-tasksel tasksel/first multiselect ubuntu-standard, openssh-server
+tasksel tasksel/first multiselect standard, server
 d-i pkgsel/include string openssh-server curl efibootmgr
 d-i pkgsel/update-policy select none
-d-i grub-installer/only_debian boolean true
-{{if (not (and (eq "debian" .Env.OS.Family) (gt "7" .Env.OS.Version)))}}
-{{if .ParamExists "operating-system-disk"}}
-d-i grub-installer/choose_bootdev select /dev/{{.Param "operating-system-disk"}}
-d-i grub-installer/bootdev string /dev/{{.Param "operating-system-disk"}}
-{{else}}
-d-i grub-installer/choose_bootdev select /dev/sda
-d-i grub-installer/bootdev string /dev/sda
-{{end}}
-{{end}}
+
+{{if .ParamExists "kernel-console"}}d-i debian-installer/add-kernel-opts string {{.Param "kernel-console"}}{{end}}
+# Completion questions
+d-i cdrom-detect/eject boolean false
 d-i finish-install/reboot_in_progress note
+
 xserver-xorg xserver-xorg/autodetect_monitor boolean true
 xserver-xorg xserver-xorg/config/monitor/selection-method select medium
 xserver-xorg xserver-xorg/config/monitor/mode-list select 1024x768 @ 60 Hz
+
 d-i preseed/late_command string wget {{.Machine.Url}}/post-install.sh -O /target/net-post-install.sh ; chmod +x /target/net-post-install.sh ; /target/net-post-install.sh


### PR DESCRIPTION
- Adds Debian Jessie/Stretch boot environments
- Adds params for further configuring the default user
- Sets kernel parameters for installed Ubuntu/Debian on complete
- Stores a copy of the generated preseed at `/var/log/provision.seed`
- Correctly specifies Debian/Ubuntu packaging endpoints

This is sort of a big change - let me know if I should make any changes or remove anything in particular.