### PR TITLE
Make sure our hostname does not get set to localhost.

### DIFF
--- a/content/bootenvs/discovery.yml
+++ b/content/bootenvs/discovery.yml
@@ -97,7 +97,7 @@ Templates:
           dhcp_ip="$(dhcp_param "$fixed_ip")"
           lookup_1=$(getent hosts $dhcp_ip | awk '{print $2}')
           lookup_2=$(getent hosts $dhcp_ip | awk '{print $2}')
-          if [ ! -z $lookup_1 ] && [ $lookup_1 == $lookup_2 ]; then
+          if [[ $lookup_1 && $lookup_1 == $lookup_2 && $lookup_1 != localhost* ]]; then
               HOSTNAME=$lookup_1
           fi
       fi


### PR DESCRIPTION
If getent hosts fails due to not getting a fixed_ip back, it will
return the host information for the localhost network, resulting in a
system getting "localhost" as a hostname in DRP.  Needless to say,
this is a Bad Idea, so prevent it from happening.