### PR TITLE
Temporarily add a discover stage without gohai to

### DIFF
--- a/content/stages/discover-no-gohai.yaml
+++ b/content/stages/discover-no-gohai.yaml
@@ -1,0 +1,12 @@
+---
+Name: "discover-no-gohai"
+Description: "Discovery stage used to discover new machines - no inventory"
+BootEnv: "sledgehammer"
+RunnerWait: true
+Tasks:
+  - "ssh-access"
+  - "change-stage"
+Meta:
+  icon: "spinner"
+  color: "yellow"
+  title: "Digital Rebar Community Content"


### PR DESCRIPTION
handle cases where gohai is failing.