### PR TITLE
add support for custom seed in Ubuntu/Debian BootEnvs

### DIFF
--- a/content/bootenvs/debian-8.yml
+++ b/content/bootenvs/debian-8.yml
@@ -56,7 +56,7 @@ Templates:
   - ID: "default-ipxe.tmpl"
     Name: "ipxe"
     Path: "{{.Machine.Address}}.ipxe"
-  - ID: "net-seed.tmpl"
+  - ID: "select-seed.tmpl"
     Name: "seed"
     Path: "{{.Machine.Path}}/seed"
   - ID: "net-post-install.sh.tmpl"

--- a/content/bootenvs/debian-9.yml
+++ b/content/bootenvs/debian-9.yml
@@ -56,7 +56,7 @@ Templates:
   - ID: "default-ipxe.tmpl"
     Name: "ipxe"
     Path: "{{.Machine.Address}}.ipxe"
-  - ID: "net-seed.tmpl"
+  - ID: "select-seed.tmpl"
     Name: "seed"
     Path: "{{.Machine.Path}}/seed"
   - ID: "net-post-install.sh.tmpl"

--- a/content/bootenvs/ubuntu-16.04.yml
+++ b/content/bootenvs/ubuntu-16.04.yml
@@ -49,7 +49,7 @@ Templates:
   - ID: "default-ipxe.tmpl"
     Name: "ipxe"
     Path: "{{.Machine.Address}}.ipxe"
-  - ID: "net-seed.tmpl"
+  - ID: "select-seed.tmpl"
     Name: "seed"
     Path: "{{.Machine.Path}}/seed"
   - ID: "net-post-install.sh.tmpl"

--- a/content/params/select-seed.yaml
+++ b/content/params/select-seed.yaml
@@ -1,0 +1,14 @@
+---
+Name: "select-seed"
+Description: "Use an alternate Debian preseed for Debian/Ubuntu based installs"
+Documentation: |
+  The name of a custom preseed template to use for a Debian/Ubuntu install.  If
+  not defined, the default 'net-seed.tmpl' will be used. 
+
+Schema:
+  type: "string"
+
+Meta:
+  icon: "disk outline"
+  color: "blue"
+  title: "Digital Rebar Community Content"

--- a/content/templates/select-seed.tmpl
+++ b/content/templates/select-seed.tmpl
@@ -1,0 +1,25 @@
+# This template allows the operator to use the stock 'net-seed.tmpl'
+# by default, or to specify an alternate seed file to use for local
+# customizations.
+#
+# To use, simply create a Param called "select-seed" with the value
+# set to the template you wish to use.
+#
+# Required Paramters:  none
+# Optional Paramters:  select-seed
+#
+# Defaults:
+# select-seed:  empty
+#
+# Example:
+# drpcli profiles update global ' { "Params": { "select-seed": "my-net-seed.tmpl" } } '
+#
+# Globally sets a custom seed template to 'my-net-seed.tmpl'
+#
+  
+{{if .ParamExists "select-seed"}}
+  {{$templateSeed := (printf "%s" (.Param "select-seed")) -}}
+  {{.CallTemplate $templateSeed .}}
+{{else}}
+  {{template "net-seed.tmpl" .}}
+{{end}}


### PR DESCRIPTION
- modifies debian-8, debian-9, and ubuntu-16.04 to use "seed" of "select-seed.tmpl"
- adds "select-seed.tmpl" which by default uses the original "net-seed.tmpl, or the operators provided template seed file
- adds param of "select-seed" which can be used on Machines or Profiles to specify a custom seed to use

- tested with ubuntu-16.04, debian-8, and debian-9 BootEnvs
