### PR TITLE
create 'setup' template to handle drpcli/jq, and Tokens for later reuse

### DIFF
--- a/content/templates/reset-workflow.tmpl
+++ b/content/templates/reset-workflow.tmpl
@@ -1,16 +1,6 @@
 #!/usr/bin/env bash
 
-# Make sure we have a drpcli somewhere
-if [[ ! -e /usr/local/bin/drpcli ]] ; then
-  ProvURL="{{.ProvisionerURL}}"
-  (mkdir -p /usr/local/bin; cd /usr/local/bin; curl -s -f -L -o drpcli "$ProvURL/files/drpcli.amd64.linux"; chmod 755 drpcli)
-fi
-
-# Get a Machine token that we can use for drpcli actions
-export RS_TOKEN="{{.GenerateToken}}"
-
-# Get API endpoint
-export RS_ENDPOINT="{{.ApiURL}}"
+{{template setup.tmpl .}}
 
 # One day Reset the workflow chain here as well
 

--- a/content/templates/runner.tmpl
+++ b/content/templates/runner.tmpl
@@ -1,15 +1,6 @@
 #!/usr/bin/env bash
 
-# Make sure we have a drpcli somewhere
-ProvURL="{{.ProvisionerURL}}"
-(mkdir -p /usr/local/bin; cd /usr/local/bin; curl -s -f -L -o drpcli "$ProvURL/files/drpcli.amd64.linux"; chmod 755 drpcli)
-
-# Get a Machine token that we can use for drpcli actions
-export RS_TOKEN="{{.GenerateToken}}"
-
-# Get API endpoint
-export RS_ENDPOINT="{{.ApiURL}}"
-
+{{template setup.tmpl .}}
 
 # Create a temp workspace
 temp_dir="$(mktemp -d)"

--- a/content/templates/setup.tmpl
+++ b/content/templates/setup.tmpl
@@ -1,0 +1,36 @@
+
+###
+#  This is a BASH script snippet intended to be run inside other BASH templates.
+#  
+#  Simple helper to prep a system with DRPCLI and JQ.  If not already installed,
+#  download and install the `drpcli` and `jq` binaries in /usr/local/bin and then
+#  source our `helper` tools
+#
+#  To use this in other templates, simply specify:
+#
+#         {{template setup.tmpl .}}
+###
+
+set -e
+
+# Install drpcli into the correct place
+if [[ ! -e /usr/local/bin/drpcli ]] ; then
+    echo "Installing DRPCLI in /usr/local/bin"
+    mkdir -p /usr/local/bin
+    curl -s -f -L -o /usr/local/bin/drpcli "{{.ProvisionerURL}}/files/drpcli.amd64.linux"
+    chmod +x /usr/local/bin/drpcli
+fi
+if [[ ! -e /usr/local/bin/jq ]] ; then
+    echo "Installing jq in /usr/local/bin"
+    curl -s -f -L -o /usr/local/bin/jq "{{.ProvisionerURL}}/files/jq"
+    chmod +x /usr/local/bin/jq
+fi
+
+function _helper(){ echo "Loading helper script"; source ./helper; }
+[[ -r ./helper ]] && _helper || echo "No ./helper script found ... skipping"
+
+# Get a Machine token that we can use for drpcli actions
+export RS_TOKEN="{{.GenerateToken}}"
+
+# Get API endpoint
+export RS_ENDPOINT="{{.ApiURL}}"


### PR DESCRIPTION
- creates a single unified template for snagging `drpcli` and `jq` binaries
- sources the `./helper` script if it exists
- get machine token to auth `drpcli` use
- set the API endpoint for `drpcli` to execute against

includes basic directions on usage - namely, just:

  `{{template setup.tmpl .}}`
