### PR TITLE
Correct incorrect partman syntax and sequence partman options

### DIFF
--- a/content/templates/net-seed.tmpl
+++ b/content/templates/net-seed.tmpl
@@ -106,11 +106,7 @@ d-i partman-lvm/device_remove_lvm boolean true
 d-i partman-lvm/device_remove_lvm_span boolean true
 d-i partman-lvm/confirm_nochanges boolean true
 d-i partman-lvm/confirm_nooverwrite boolean true
-d-i partman/confirm_write_new_label boolean true
 d-i partman-basicfilesystems/no_swap boolean false
-d-i partman/choose_partition select finish
-d-i partman/confirm boolean true
-d-i partman/confirm_nooverwrite boolean true
 #Partitioning Scheme
 {{if .ParamExists "part-scheme" -}}
 {{$templateName := (printf "part-seed-%s.tmpl" (.Param "part-scheme")) -}}
@@ -118,6 +114,10 @@ d-i partman/confirm_nooverwrite boolean true
 {{else -}}
 {{template "part-scheme-default.tmpl" .}}
 {{end -}}
+d-i partman/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
 
 {{if (and (eq "ubuntu" .Env.OS.Family)  (lt "12.10" .Env.OS.Version)) -}}
 d-i live-installer/net-image string {{.Env.InstallUrl}}/install/filesystem.squashfs

--- a/content/templates/part-scheme-default.tmpl
+++ b/content/templates/part-scheme-default.tmpl
@@ -11,7 +11,7 @@ d-i partman-auto/method string lvm
 d-i partman-auto-lvm/guided_size string max
 d-i partman-auto-lvm/new_vg_name string {{.Machine.ShortName}}
 d-i partman-auto/choose_recipe select custom_lvm
-d-i partman/auto expert_recipe string \
+d-i partman-auto/expert_recipe string \
     custom_lvm::  \
       500 50 1024 free $iflabel{ gpt } $reusemethod{ } method{ efi } format{ } . \
       128 50 256  ext2 $defaultignore{ } method{ format } format{ } use_filesystem{ } filesystem{ ext2 } mountpoint{ /boot } . \


### PR DESCRIPTION
Please observe that I have not tested this exact change since I've done some more customisation in the seed I run myself, but these config changes should resolve an issue with custom partitioning schemes not being implemented.

`d-i partman/auto expert_recipe string` is incorrect syntax which (my guess, not preseed expert) cause partman to fall back on default atomic scheme.

Using correct syntax cause another problem; Installer can't find a valid root partition if you opt for custom partitions, as there isn't one defined yet. Move the following options:
```
d-i partman/confirm_write_new_label boolean true
d-i partman/choose_partition select finish
d-i partman/confirm boolean true
d-i partman/confirm_nooverwrite boolean true
```
To execute after part scheme.