### PR TITLE
This addresses #53 and moves all the partman*

### DIFF
--- a/content/templates/net-seed.tmpl
+++ b/content/templates/net-seed.tmpl
@@ -88,25 +88,6 @@ d-i clock-setup/ntp boolean false
 {{end -}}
 d-i time/zone string UTC
 
-# Partitioner Label Default (GPT)
-d-i partman/choose_label string gpt
-d-i partman-basicfilesystems/choose_label string gpt
-d-i partman-partitioning/choose_label string gpt
-d-i partman/default_label string gpt
-d-i partman-basicfilesystems/default_label string gpt
-d-i partman-partitioning/default_label string gpt
-# Partitioner Prompt Confirmations
-d-i partman-auto/purge_lvm_from_device boolean true
-d-i partman-md/confirm boolean true
-d-i partman-md/device_remove_md boolean true
-d-i partman-md/confirm_nochanges boolean true
-d-i partman-md/confirm_nooverwrite boolean true
-d-i partman-lvm/confirm boolean true
-d-i partman-lvm/device_remove_lvm boolean true
-d-i partman-lvm/device_remove_lvm_span boolean true
-d-i partman-lvm/confirm_nochanges boolean true
-d-i partman-lvm/confirm_nooverwrite boolean true
-d-i partman-basicfilesystems/no_swap boolean false
 #Partitioning Scheme
 {{if .ParamExists "part-scheme" -}}
 {{$templateName := (printf "part-scheme-%s.tmpl" (.Param "part-scheme")) -}}
@@ -114,10 +95,16 @@ d-i partman-basicfilesystems/no_swap boolean false
 {{else -}}
 {{template "part-scheme-default.tmpl" .}}
 {{end -}}
-d-i partman/confirm_write_new_label boolean true
-d-i partman/choose_partition select finish
-d-i partman/confirm boolean true
-d-i partman/confirm_nooverwrite boolean true
+
+# Grub Pieces
+{{if .ParamExists "operating-system-disk" -}}
+d-i grub-installer/choose_bootdev select /dev/{{.Param "operating-system-disk"}}
+d-i grub-installer/bootdev string /dev/{{.Param "operating-system-disk"}}
+{{else -}}
+d-i grub-installer/choose_bootdev select /dev/sda
+d-i grub-installer/bootdev string /dev/sda
+{{end -}}
+d-i grub-installer/only_debian boolean true
 
 {{if (and (eq "ubuntu" .Env.OS.Family)  (lt "12.10" .Env.OS.Version)) -}}
 d-i live-installer/net-image string {{.Env.InstallUrl}}/install/filesystem.squashfs

--- a/content/templates/part-scheme-default.tmpl
+++ b/content/templates/part-scheme-default.tmpl
@@ -1,14 +1,31 @@
+# Partitioner Label Default (GPT)
+d-i partman/choose_label string gpt
+d-i partman/default_label string gpt
+d-i partman/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman-basicfilesystems/choose_label string gpt
+d-i partman-basicfilesystems/default_label string gpt
+d-i partman-basicfilesystems/no_swap boolean false
+d-i partman-partitioning/choose_label string gpt
+d-i partman-partitioning/default_label string gpt
+# Partitioner Prompt Confirmations
+d-i partman-md/confirm boolean true
+d-i partman-md/device_remove_md boolean true
+d-i partman-md/confirm_nochanges boolean true
+d-i partman-md/confirm_nooverwrite boolean true
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman-lvm/device_remove_lvm_span boolean true
+d-i partman-lvm/confirm_nochanges boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-auto-lvm/guided_size string max
 {{if .ParamExists "operating-system-disk" -}}
 d-i partman-auto/disk string /dev/{{.Param "operating-system-disk"}}
-d-i grub-installer/choose_bootdev select /dev/{{.Param "operating-system-disk"}}
-d-i grub-installer/bootdev string /dev/{{.Param "operating-system-disk"}}
 {{else -}}
 d-i partman-auto/disk string /dev/sda
-d-i grub-installer/choose_bootdev select /dev/sda
-d-i grub-installer/bootdev string /dev/sda
 {{end -}}
-d-i partman-auto/method string lvm
-d-i partman-auto-lvm/guided_size string max
-d-i partman-auto-lvm/new_vg_name string {{.Machine.ShortName}}
+d-i partman-auto/purge_lvm_from_device boolean true
 d-i partman-auto/choose_recipe select atomic
-d-i grub-installer/only_debian boolean true
+d-i partman-auto/method string lvm


### PR DESCRIPTION
pieces into the schema file.

This is works, but will require community warning to pull in.

Also, may want to allow for expert substitution.