### PR TITLE
Switched from Kernel.org to Princeton mirror; moved to 16.04.4

### DIFF
--- a/content/bootenvs/ubuntu-16.04.yml
+++ b/content/bootenvs/ubuntu-16.04.yml
@@ -4,9 +4,9 @@ Description: "Ubuntu-16.04 install points to the latest release version"
 OS:
   Name: "ubuntu-16.04"
   Family: "ubuntu"
-  IsoFile: "ubuntu-16.04.3-server-amd64.iso"
-  IsoSha256: "a06cd926f5855d4f21fb4bc9978a35312f815fbda0d0ef7fdc846861f4fc4600"
-  IsoUrl: "http://mirrors.kernel.org/ubuntu-releases/16.04/ubuntu-16.04.3-server-amd64.iso"
+  IsoFile: "ubuntu-16.04.4-server-amd64.iso"
+  IsoSha256: "0a03608988cfd2e50567990dc8be96fb3c501e198e2e6efcb846d89efc7b89f2"
+  IsoUrl: "http://mirror.math.princeton.edu/pub/ubuntu-iso/16.04/ubuntu-16.04.4-server-amd64.iso"
   Version: "16.04"
 Initrds:
   - "install/netboot/ubuntu-installer/amd64/initrd.gz"


### PR DESCRIPTION
- switched from kernel.org to princeton Ubuntu mirror
  - kernel.org was taking 15 minutes ... princeton mirror took 10 seconds
- moved from 16.04.3 to 16.04.4 version 