### PR TITLE
Content tweaks to reflect the drpcli runner changes.

### DIFF
--- a/content/stages/complete-nowait.yaml
+++ b/content/stages/complete-nowait.yaml
@@ -1,6 +1,11 @@
 ---
 Name: "complete-nowait"
-Description: "Stage that represents workflow completion to local disk.  Does NOT wait in the runner."
+Description: "Stage that represents workflow completion to local disk."
+Documentation: |
+  This is deprectated and leaves the runner running, but will exit install bootenvs correctly.
+  The use of this was to exit install workflows.  This will continue to work for that, but
+  should be replaced by finish-install.
+RunnerWait: false
 BootEnv: "local"
 Meta:
   icon: "checkmark"

--- a/content/stages/finish-install.yaml
+++ b/content/stages/finish-install.yaml
@@ -1,7 +1,16 @@
 ---
 Name: "finish-install"
-Description: "Used with the STOP runner action to leave a stage that will have a task on machine boot"
+Description: "Stage to indicate that all the install tasks are done and the system should complete the OS install"
+Documentation: |
+  Originally, this stage was used with the STOP runner action in the change-stage/map and this will
+  continue to work.
+
+  Going forward, the STOP action is not required.  The changing of bootenv from something-install to
+  local will cause the runner to exit.
+
+  The runner will also continue to run regardless of the RunnerWait flag.
 BootEnv: "local"
+RunnerWait: false
 Meta:
   icon: "checkmark"
   color: "yellow"

--- a/content/stages/machine-meta.yaml
+++ b/content/stages/machine-meta.yaml
@@ -1,10 +1,10 @@
-Description: Stage to assign the machine icon and color
+---
+Description: "Stage to assign the machine icon and color"
 Meta:
-  color: yellow
-  icon: info
-Name: machine-meta
+  color: "yellow"
+  icon: "info"
+Name: "machine-meta"
 Reboot: false
 RunnerWait: true
 Tasks:
-- machine-meta-setter
-
+  - "machine-meta-setter"

--- a/content/stages/prep-install.yaml
+++ b/content/stages/prep-install.yaml
@@ -1,11 +1,12 @@
 ---
-Name: prep-install
+Name: "prep-install"
 Description: |
   Prepares system for OS install by zeroing out any data on the disks
   that might confuse the OS install process.
 BootEnv: "sledgehammer"
+RunnerWait: true
 Tasks:
-  - erase-hard-disks-for-os-install
+  - "erase-hard-disks-for-os-install"
 Meta:
   icon: "disk outline"
   color: "yellow"


### PR DESCRIPTION
These changes are associated with the provision #760 PR.  The runner is longer running, but can still be controlled with change-stage/map options.  In general, these are not needed for standard workflows and the content is updated to reflect that. 

The content should continue to function with pre-#760 PR DRP.