### PR TITLE
Switch CentOS 7 mirrors

### DIFF
--- a/content/bootenvs/centos-7.4.1708.yml
+++ b/content/bootenvs/centos-7.4.1708.yml
@@ -6,7 +6,7 @@ OS:
   Name: "centos-7.4.1708"
   IsoFile: "CentOS-7-x86_64-Minimal-1708.iso"
   IsoSha256: "bba314624956961a2ea31dd460cd860a77911c1e0a56e4820a12b9c5dad363f5"
-  IsoUrl: "http://mirrors.kernel.org/centos/7.4.1708/isos/x86_64/CentOS-7-x86_64-Minimal-1708.iso"
+  IsoUrl: "http://mirror.math.princeton.edu/pub/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-1708.iso"
 Kernel: "images/pxeboot/vmlinuz"
 Initrds:
   - "images/pxeboot/initrd.img"

--- a/content/bootenvs/centos-7.yml
+++ b/content/bootenvs/centos-7.yml
@@ -6,7 +6,7 @@ OS:
   Name: "centos-7"
   IsoFile: "CentOS-7-x86_64-Minimal-1708.iso"
   IsoSha256: "bba314624956961a2ea31dd460cd860a77911c1e0a56e4820a12b9c5dad363f5"
-  IsoUrl: "http://mirrors.kernel.org/centos/7.4.1708/isos/x86_64/CentOS-7-x86_64-Minimal-1708.iso"
+  IsoUrl: "http://mirror.math.princeton.edu/pub/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-1708.iso"
 Kernel: "images/pxeboot/vmlinuz"
 Initrds:
   - "images/pxeboot/initrd.img"


### PR DESCRIPTION
- switch the kernel.org mirror for princeton.edu
- kernel.org is taking around 19 minutes to download
- princeton.edu mirror is taking 12 seconds 

Note: Princeton mirrors have been long term stable mirrors.