### PR TITLE
Update erase disks task to be more thurough.

### DIFF
--- a/content/params/zero-hard-disks-for-os-install.yaml
+++ b/content/params/zero-hard-disks-for-os-install.yaml
@@ -1,0 +1,14 @@
+---
+Name: zero-hard-disks-for-os-install
+Description: "Whether to zero entire hard disks when erasing before install"
+Documentation: |
+  By default, the erase disks for os install task tries to only erase
+  any metadata on the disks that may confuse a next OS install, along with
+  (optionally) attempting to discard all sectors on devices that support
+  discard.  If this is set to true, the task will also zero all sectors
+  on any non-SSD drives.
+Schema:
+  type: boolean
+  default: false
+Meta:
+  title: Digital Rebar Community Content

--- a/content/tasks/erase-hard-disks-for-os-install.yaml
+++ b/content/tasks/erase-hard-disks-for-os-install.yaml
@@ -9,38 +9,87 @@ Meta:
   icon: "erase"
   color: "blue"
   title: "Digital Rebar Community Content"
+RequiredParams:
+  - zero-hard-disks-for-os-install
 Templates:
   - Name: "erase-disks"
     Contents: |
       #!/bin/bash
+      . helper
+      # Deactivate all known lvm and dm devices first, unmounting filesystems as needed.
+      echo "Deactivating all known volume groups"
+      blkdeactivate -u -d force,retry -l retry,wholevg || :
       # Nuke it all.
       declare vg pv maj min blocks name
       # Make sure that the kernel knows about all the partitions
-      for bd in /sys/block/sd*; do
+      for bd in /sys/block/*; do
           [[ -b /dev/${bd##*/} ]] || continue
+          grep -q 'devices/virtual' < <(readlink "$bd") && continue
+          echo "Probing for all partitions on dev/${bd##*/}.  Failures are OK."
           partprobe "/dev/${bd##*/}" || :
       done
       # Zap any volume groups that may be lying around.
       vgscan --ignorelockingfailure -P
       while read vg; do
+          echo "Forcibly removing volume group $vg"
           vgremove -ff -y "$vg" || :
       done < <(vgs --noheadings -o vg_name)
       # Wipe out any LVM metadata that the kernel may have detected.
       pvscan --ignorelockingfailure
       while read pv; do
+          echo "Forcibly removing physical volume $pv"
           pvremove -ff -y "$pv" || :
       done < <(pvs --noheadings -o pv_name)
       # Now zap any partitions along with any RAID metadata that may exist.
       while read maj min blocks name; do
           [[ -b /dev/$name && -w /dev/$name && $name != name ]] || continue
           [[ $name = loop* ]] && continue
-          [[ $name = dm* ]] && continue
           [[ $name = fd* ]] && continue
+          echo "Forcibly removing any RAID metadata on /dev/$name. Failures are OK if readonly"
           mdadm --misc --zero-superblock --force /dev/$name || :
-          if (( blocks >= 2048)); then
-              dd "if=/dev/zero" "of=/dev/$name" "bs=512" "count=2048"
-              dd "if=/dev/zero" "of=/dev/$name" "bs=512" "count=2048" "seek=$(($blocks - 2048))"
+          if (( blocks >= 4096)); then
+              echo "Zeroing the first and last 2 megs of /dev/$name. Failures are OK if readonly"
+              dd "if=/dev/zero" "of=/dev/$name" "bs=512" "count=4096" || :
+              dd "if=/dev/zero" "of=/dev/$name" "bs=512" "count=4096" "seek=$(($blocks - 4096))" || :
           else
-              dd "if=/dev/zero" "of=/dev/$name" "bs=512" "count=$blocks"
+              echo "Zeroing small device /dev/$name.  Failures are OK if readonly"
+              dd "if=/dev/zero" "of=/dev/$name" "bs=512" "count=$blocks" || :
           fi
       done < <(tac /proc/partitions)
+      # For paranoia's sake, try to discard all blocks on the remaining
+      # top-level block devices in parallel.
+      for bd in /sys/block/*; do
+        (
+          [[ -b /dev/${bd##*/} ]] || continue
+          grep -q 'devices/virtual' < <(readlink "$bd") && continue
+          dev="/dev/${bd##*/}"
+          spinner=$(cat "$bd/queue/rotational")
+          want_zero="{{.Param "zero-hard-disks-for-os-install"}}"
+          skip_zero=$(cat "$bd/queue/discard_zeroes_data")
+          if [[ $want_zero = true && $skip_zero != 1 && $spinner = 1 ]]; then
+              # blkdiscard -z does the same job as dd if=/dev/zero,
+              # except the kernel does all the work and it uses
+              # the SCSI command WRITE_SAME if the device supports
+              # it, which can greatly speed up the zeroing process.
+              echo "Zeroing $dev"
+              blkdiscard -z "$dev" || :
+          fi
+          # if discard_max_bytes is zero, then blkdiscard will not work anyways.
+          if [[ $(cat "$bd/queue/discard_max_bytes") != 0 ]]; then
+              # Try secure erase first, then regular discard.
+              echo "Attempting to secure discard $dev."
+              echo "This may fail if the device does not support secure discard."
+              if blkdiscard -s "$dev"; then
+                  echo "Secure discard of $dev finished"
+              else
+                  echo "Sercure discard of $dev failed, attempting normal discard"
+                  if blkdiscard "$dev"; then
+                      echo "Normal discard of $dev finished"
+                  else
+                      echo "Normal discard of $dev failed"
+                  fi
+              fi
+          fi
+        ) &
+      done
+      wait


### PR DESCRIPTION
* Deactivate all volume groups before we do anything else.  This
  should make us more robust in the face of potentially in-use or
  locked logical volumes and volume groups.
* Erase the first and last 2 megs of every device and partition
  instead of just the first and last 1 meg.
* Add param-driven optional full disk zeroing for rotational devices.
* Discard all the blocks on devices we want to erase if the device
  supports it.