### PR TITLE
add BETA Bionic Beaver (daily builds)

### DIFF
--- a/content/bootenvs/ubuntu-18.04.yml
+++ b/content/bootenvs/ubuntu-18.04.yml
@@ -1,0 +1,66 @@
+Name: ubuntu-18.04-beta-install
+BootParams: debian-installer/locale=en_US.utf8 console-setup/layoutcode=us keyboard-configuration/layoutcode=us
+  netcfg/dhcp_timeout=120 netcfg/choose_interface=auto url={{.Machine.Url}}/seed netcfg/get_hostname={{.Machine.Name}}
+  root=/dev/ram rw quiet {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
+  -- {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
+Description: (BETA) Ubuntu-18.04 install points to the Daily ISOS Builds.
+Errors: []
+Initrds:
+  - install/netboot/ubuntu-installer/amd64/initrd.gz
+Kernel: install/netboot/ubuntu-installer/amd64/linux
+Meta:
+  color: orange
+  feature-flags: change-stage-v2
+  icon: linux
+  title: Digital Rebar Community Content
+OS:
+  Codename: "Bionic Beaver"
+  Family: ubuntu
+  IsoFile: bionic-server-amd64.iso
+  IsoSha256: ""
+  IsoUrl: http://cdimage.ubuntu.com/ubuntu-server/daily/current/bionic-server-amd64.iso
+  Name: ubuntu-18.04-beta
+  Version: "18.04"
+OnlyUnknown: false
+OptionalParams:
+  - part-scheme
+  - operating-system-disk
+  - provisioner-default-user
+  - provisioner-default-fullname
+  - provisioner-default-uid
+  - provisioner-default-password-hash
+  - kernel-console
+  - proxy-servers
+  - dns-domain
+  - local-repo
+  - proxy-servers
+  - ntp-servers
+  - select-kickseed
+ReadOnly: true
+RequiredParams: []
+Templates:
+  - Contents: ""
+    ID: default-pxelinux.tmpl
+    Name: pxelinux
+    Path: pxelinux.cfg/{{.Machine.HexAddress}}
+  - Contents: ""
+    ID: default-ipxe.tmpl
+    Name: ipxe
+    Path: '{{.Machine.Address}}.ipxe'
+  - Contents: ""
+    ID: default-pxelinux.tmpl
+    Name: pxelinux-mac
+    Path: pxelinux.cfg/{{.Machine.MacAddr "pxelinux"}}
+  - Contents: ""
+    ID: default-ipxe.tmpl
+    Name: ipxe-mac
+    Path: '{{.Machine.MacAddr "ipxe"}}.ipxe'
+  - Contents: ""
+    ID: select-kickseed.tmpl
+    Name: seed
+    Path: '{{.Machine.Path}}/seed'
+  - Contents: ""
+    ID: net-post-install.sh.tmpl
+    Name: net-post-install.sh
+    Path: '{{.Machine.Path}}/post-install.sh'
+

--- a/content/stages/ubuntu-18.04.yml
+++ b/content/stages/ubuntu-18.04.yml
@@ -1,0 +1,19 @@
+BootEnv: ubuntu-18.04-beta-install
+Description: (BETA) Ubuntu 18.04 installation stage.  References Beta BootEnv.
+Errors: []
+Meta:
+  color: yellow
+  icon: download
+  title: Digital Rebar Community Content
+Name: ubuntu-18.04-beta-install
+OptionalParams: []
+Profiles: []
+ReadOnly: true
+Reboot: false
+RequiredParams: []
+RunnerWait: true
+Tasks:
+- ubuntu-drp-only-repos
+- ssh-access
+Templates: []
+


### PR DESCRIPTION
- adds Ubuntu 18.04 (Bionic Beaver) daily ISO builds
- WARNING:  this is a Beta release of Bionic Beaver
- when Ubuntu 18.04 officially releases, a new BootEnv/Stage will be released