### PR TITLE
Make drpcli zero out the gohai inventory before replacing it

### DIFF
--- a/content/tasks/gohai.yaml
+++ b/content/tasks/gohai.yaml
@@ -5,6 +5,7 @@ Templates:
   - Name: "gohai"
     Contents: |
       #!/usr/bin/env bash
+      drpcli machines set {{.Machine.UUID}} param gohai-inventory to '{}'
       if drpcli gohai --help >/dev/null 2>/dev/null ; then
         drpcli gohai | drpcli machines set {{.Machine.UUID}} param gohai-inventory to -
       else


### PR DESCRIPTION
This avoids intermittent update errors due to random things like the current CPU operating freq changing.