### PR TITLE
Use parameter to skip gohai

### DIFF
--- a/content/params/gohai-skip.yaml
+++ b/content/params/gohai-skip.yaml
@@ -1,0 +1,13 @@
+---
+Name: "gohai/skip"
+Description: "Skips gohai run during discovery"
+Documentation: |
+  Allows machines to stop using the discover-nogohai stage.
+  When true, the gohai part of the discovery stage will be skipped
+Schema:
+  type: "boolean"
+  default: false
+Meta:
+  icon: "search minus"
+  color: "blue"
+  title: "Digital Rebar Community Content"

--- a/content/stages/discover-no-gohai.yaml
+++ b/content/stages/discover-no-gohai.yaml
@@ -1,6 +1,10 @@
 ---
 Name: "discover-no-gohai"
-Description: "Discovery stage used to discover new machines - no inventory"
+Description: "DEPRECATED - Discovery stage used to discover new machines - no inventory"
+Documentation: |
+  DEPRECATED! Use the discover Stage with gohai/skip Param instead.
+
+  Pre gohai/skip Parameter, used to run discovery without gohai action.
 BootEnv: "sledgehammer"
 RunnerWait: true
 Tasks:

--- a/content/stages/discover-no-gohai.yaml
+++ b/content/stages/discover-no-gohai.yaml
@@ -10,6 +10,7 @@ RunnerWait: true
 Tasks:
   - "ssh-access"
 Meta:
-  icon: "spinner"
-  color: "purple"
+  deprecated: "25 June 2018"
+  icon: "ban"
+  color: "gray"
   title: "Digital Rebar Community Content"

--- a/content/tasks/gohai.yaml
+++ b/content/tasks/gohai.yaml
@@ -1,8 +1,19 @@
 ---
 Name: "gohai"
 Description: "Get basic system inventory using Gohai"
+Documentation: |
+  Sets Param: gohai-inventory
+
+  Collect inventory from machines using drpcli gohai command
+  and store the result in the gohai-inventory Param on the machine.
+
+  If you want to disable this behavior, set the gohai/skip Param to true.
+
+  Hint: this can be A LOT of data added to the machine param!  You may
+  want to use ?slim in the API to skip returning it on list requests.
 OptionalParams:
   - gohai/skip
+  - gohai-inventory
 Templates:
   - Name: "gohai"
     Contents: |

--- a/content/tasks/gohai.yaml
+++ b/content/tasks/gohai.yaml
@@ -1,16 +1,22 @@
 ---
 Name: "gohai"
 Description: "Get basic system inventory using Gohai"
+OptionalParams:
+  - gohai/skip
 Templates:
   - Name: "gohai"
     Contents: |
       #!/usr/bin/env bash
-      drpcli machines set {{.Machine.UUID}} param gohai-inventory to '{}'
-      if drpcli gohai --help >/dev/null 2>/dev/null ; then
-        drpcli gohai | drpcli machines set {{.Machine.UUID}} param gohai-inventory to -
-      else
-        gohai | drpcli machines set {{.Machine.UUID}} param gohai-inventory to -
-      fi
+      {{if .Param "gohai/skip" -}}
+        echo "Skipping drpcli gohai because Param gohai/skip is true"
+      {{else -}}
+        echo "Running drpcli gohai (skip by setting gohai/skip to true)"
+        if drpcli gohai --help >/dev/null 2>/dev/null ; then
+          drpcli gohai | drpcli machines set {{.Machine.UUID}} param gohai-inventory to -
+        else
+          gohai | drpcli machines set {{.Machine.UUID}} param gohai-inventory to -
+        fi
+      {{end -}}
 Meta:
   icon: "search"
   color: "blue"


### PR DESCRIPTION
Replaces the need for discover-no-gohai in a more DRP native way using a parameter

Includes deprecation warnings for discover-no-gohai

Also, updates docs for models