### PR TITLE
Bump Sledgehammer version.

### DIFF
--- a/content/bootenvs/discovery.yml
+++ b/content/bootenvs/discovery.yml
@@ -4,9 +4,9 @@ Description: "The boot environment to use to have unknown machines boot to defau
 OnlyUnknown: true
 OS:
   Family: "redhat"
-  Name: "sledgehammer/6122f34b46b5b74b668d6779e33f5fcd0f44a8cc"
-  IsoFile: "sledgehammer-6122f34b46b5b74b668d6779e33f5fcd0f44a8cc.tar"
-  IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/6122f34b46b5b74b668d6779e33f5fcd0f44a8cc/sledgehammer-6122f34b46b5b74b668d6779e33f5fcd0f44a8cc.tar"
+  Name: "sledgehammer/9c1ad5cb7483928e6aba1d93ba363de929169f37"
+  IsoFile: "sledgehammer-9c1ad5cb7483928e6aba1d93ba363de929169f37.tar"
+  IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/9c1ad5cb7483928e6aba1d93ba363de929169f37/sledgehammer-9c1ad5cb7483928e6aba1d93ba363de929169f37.tar"
 Kernel: "vmlinuz0"
 Initrds:
   - "stage1.img"

--- a/content/bootenvs/sledgehammer.yml
+++ b/content/bootenvs/sledgehammer.yml
@@ -6,9 +6,9 @@ Name: "sledgehammer"
 Description: "Ram-Only image loaded with tools to allow for discovery and maintenance"
 OS:
   Family: "redhat"
-  Name: "sledgehammer/6122f34b46b5b74b668d6779e33f5fcd0f44a8cc"
-  IsoFile: "sledgehammer-6122f34b46b5b74b668d6779e33f5fcd0f44a8cc.tar"
-  IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/6122f34b46b5b74b668d6779e33f5fcd0f44a8cc/sledgehammer-6122f34b46b5b74b668d6779e33f5fcd0f44a8cc.tar"
+  Name: "sledgehammer/9c1ad5cb7483928e6aba1d93ba363de929169f37"
+  IsoFile: "sledgehammer-9c1ad5cb7483928e6aba1d93ba363de929169f37.tar"
+  IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/9c1ad5cb7483928e6aba1d93ba363de929169f37/sledgehammer-9c1ad5cb7483928e6aba1d93ba363de929169f37.tar"
 Kernel: "vmlinuz0"
 Initrds:
   - "stage1.img"


### PR DESCRIPTION
This makes the discovery and sledgehammer bootenvs use the latest
version of Sledgehammer.  THe new release includes support for
mounting NFS shares.