### PR TITLE
krib-ha updates for kubernetes 1.11

### DIFF
--- a/krib/params/etcd-version.yaml
+++ b/krib/params/etcd-version.yaml
@@ -3,7 +3,7 @@ Name: "etcd/version"
 Description: "Version of the etcd to use in cluster"
 Schema:
   type: "string"
-  default: "3.2.15"
+  default: "3.2.17"
 Meta:
   color: "blue"
   icon: "book"

--- a/krib/templates/krib-settings.sh.tmpl
+++ b/krib/templates/krib-settings.sh.tmpl
@@ -27,7 +27,7 @@ if [[ $MASTER_INDEX == 0 ]] ; then
   export KUBECONFIG=/etc/kubernetes/admin.conf
 
   echo "Up the DNS replica count"
-  kubectl scale --replicas=$MASTER_COUNT -n kube-system deployment/kube-dns
+  kubectl scale --replicas=$MASTER_COUNT -n kube-system deployment/coredns
 
   API_PORT=6443
   if [[ $MASTER_COUNT -gt 1 ]] ; then


### PR DESCRIPTION
After getting the cert plugin up and running I have found issues etcd version and that the kubeadm after kubernetes 1.11 uses coredns instead of kube-dns.

These fixes are related to #101