### PR TITLE
Add Terraform deploy, docs and fix etcd version

### DIFF
--- a/integrations/krib/new-packet-cluster.tf
+++ b/integrations/krib/new-packet-cluster.tf
@@ -25,7 +25,7 @@ resource "drp_workflow" "discover-krib-live-cluster" {
   Description = "Terraform Added"
   Stages = [
   	"discover", "packet-discover", "ssh-access", "mount-local-disks", "docker-install", 
-  	"kubernetes-install", "etcd-config", "krib-config", "krib-live-wait"
+  	"kubernetes-install", "krib-config", "krib-live-wait"
   ]
   Meta {
   	icon = "ship"

--- a/integrations/krib/new-packet-cluster.tf
+++ b/integrations/krib/new-packet-cluster.tf
@@ -1,7 +1,17 @@
+variable "api_url" { 
+  default = "https://127.0.0.1:8092"
+}
+variable "api_user" { 
+  default = "rocketskates"
+}
+variable "api_password" { 
+  default = "r0cketsk8ts"
+}
+
 provider "drp" {
-  api_user     = "rocketskates"
-  api_password = "r0cketsk8ts"
-  api_url      = "https://147.75.64.249:8092"
+  api_user     = "${var.api_user}"
+  api_password = "${var.api_password}"
+  api_url      = "${var.api_url}"
 }
 
 resource "drp_profile" "krib-auto" {
@@ -15,6 +25,7 @@ resource "drp_profile" "krib-auto" {
   Meta {
   	icon = "ship"
   	color = "blue"
+  	render = "kubernetes"
   }
 }
 

--- a/integrations/krib/new-packet-cluster.tf
+++ b/integrations/krib/new-packet-cluster.tf
@@ -83,3 +83,7 @@ resource "drp_machine" "krib-machines" {
   decommission_color = "purple"
   decommission_icon = "server"
 }
+
+output "admin.conf" {
+  value = "drpcli -E ${var.api_url} profiles params ${var.cluster_profile} krib/cluster-admin-conf > admin.conf"
+}

--- a/integrations/krib/new-packet-cluster.tf
+++ b/integrations/krib/new-packet-cluster.tf
@@ -1,0 +1,63 @@
+provider "drp" {
+  api_user     = "rocketskates"
+  api_password = "r0cketsk8ts"
+  api_url      = "https://147.75.64.249:8092"
+}
+
+resource "drp_profile" "krib-auto" {
+  count = 1	
+  Name = "krib-auto"
+  Description = "Terraform Added"
+  Params {
+  	"etcd/cluster-profile" = "krib-auto"
+  	"krib/cluster-profile" = "krib-auto"
+  }
+  Meta {
+  	icon = "ship"
+  	color = "blue"
+  }
+}
+
+resource "drp_workflow" "discover-krib-live-cluster" {
+  count = 1	
+  depends_on = ["drp_profile.krib-auto"]
+  Name = "discover-krib-live-cluster"
+  Description = "Terraform Added"
+  Stages = [
+  	"discover", "packet-discover", "ssh-access", "mount-local-disks", "docker-install", 
+  	"kubernetes-install", "etcd-config", "krib-config", "krib-live-wait"
+  ]
+  Meta {
+  	icon = "ship"
+  	color = "green"
+  }
+}
+
+resource "drp_raw_machine" "packet-machines" {
+  count = 3
+  Description = "Terraform Added RAW"
+  Workflow = "discover"
+  Name = "tfkrib${count.index}"
+  Params {
+  	"machine-plugin" = "packet-ipmi"
+  	"packet/plan" ="baremetal_0"
+  	"terraform/managed" = "true"
+  	"terraform/allocated" = "false"
+  }
+  Meta {
+  	icon = "rocket"
+  	color = "yellow"
+  }
+}
+
+resource "drp_machine" "krib-machines" {
+  count = 3
+  depends_on = ["drp_workflow.discover-krib-live-cluster", "drp_raw_machine.packet-machines"]
+  Description = "KRIB via TF"
+  Workflow = "discover-krib-live-cluster"
+  add_profiles = ["krib-auto"]
+  Meta {
+  	icon = "rocket"
+  	color = "green"
+  }
+}

--- a/integrations/krib/new-packet-cluster.tf
+++ b/integrations/krib/new-packet-cluster.tf
@@ -7,6 +7,15 @@ variable "api_user" {
 variable "api_password" { 
   default = "r0cketsk8ts"
 }
+variable "cluster_profile" { 
+  default = "krib-auto"
+}
+variable "cluster_count" { 
+  default = 4
+}
+variable "workflow" { 
+  default = "discover-krib-live-cluster"
+}
 
 provider "drp" {
   api_user     = "${var.api_user}"
@@ -15,22 +24,22 @@ provider "drp" {
 }
 
 resource "drp_profile" "krib-auto" {
-  count = 1	
-  Name = "krib-auto"
+  count = 1
+  Name = "${var.cluster_profile}"
   Description = "Terraform Added"
   Params {
-  	"etcd/cluster-profile" = "krib-auto"
-  	"krib/cluster-profile" = "krib-auto"
+  	"etcd/cluster-profile" = "${var.cluster_profile}"
+  	"krib/cluster-profile" = "${var.cluster_profile}"
   }
   Meta {
   	icon = "ship"
-  	color = "blue"
+  	color = "green"
   	render = "kubernetes"
   }
 }
 
 resource "drp_workflow" "discover-krib-live-cluster" {
-  count = 1	
+  count = 1
   depends_on = ["drp_profile.krib-auto"]
   Name = "discover-krib-live-cluster"
   Description = "Terraform Added"
@@ -45,7 +54,7 @@ resource "drp_workflow" "discover-krib-live-cluster" {
 }
 
 resource "drp_raw_machine" "packet-machines" {
-  count = 3
+  count = "${var.cluster_count}"
   Description = "Terraform Added RAW"
   Workflow = "discover"
   Name = "tfkrib${count.index}"
@@ -56,19 +65,21 @@ resource "drp_raw_machine" "packet-machines" {
   	"terraform/allocated" = "false"
   }
   Meta {
-  	icon = "rocket"
-  	color = "yellow"
+  	icon = "map"
+  	color = "purple"
   }
 }
 
 resource "drp_machine" "krib-machines" {
-  count = 3
+  count = "${var.cluster_count}"
   depends_on = ["drp_workflow.discover-krib-live-cluster", "drp_raw_machine.packet-machines"]
-  Description = "KRIB via TF"
-  Workflow = "discover-krib-live-cluster"
-  add_profiles = ["krib-auto"]
+  Description = "KRIB via Terraform"
+  Workflow = "${var.workflow}"
   Meta {
-  	icon = "rocket"
-  	color = "green"
+  	icon = "map"
+  	color = "yellow"
   }
+  add_profiles = ["${var.cluster_profile}"]
+  decommission_color = "purple"
+  decommission_icon = "server"
 }

--- a/krib/._Description.meta
+++ b/krib/._Description.meta
@@ -1,1 +1,1 @@
-Kubernetes Rebar Immutable Bootstrap (KRIB)
+Kubernetes Rebar Integrated Bootstrap (KRIB)

--- a/krib/params/docker-working-dir.yaml
+++ b/krib/params/docker-working-dir.yaml
@@ -1,6 +1,8 @@
 ---
 Name: "docker/working-dir"
 Description: "The docker working directory."
+Documentation: |
+  Allows operators to change the Docker working directory
 Schema:
   type: "string"
   default: "/docker"

--- a/krib/params/etcd-client-ca-name.yaml
+++ b/krib/params/etcd-client-ca-name.yaml
@@ -1,6 +1,9 @@
 ---
 Name: "etcd/client-ca-name"
 Description: "Name of the certificate root for the etcd client certs"
+Documentation: |
+  Allows operators to set the CA name for the client certificate
+  Requires Cert Plugin  
 Schema:
   type: "string"
 Meta:

--- a/krib/params/etcd-client-ca-pw.yaml
+++ b/krib/params/etcd-client-ca-pw.yaml
@@ -1,6 +1,9 @@
 ---
 Name: "etcd/client-ca-pw"
 Description: "Password to access the etcd client CA"
+Documentation: |
+  Allows operators to set the CA password for the client certificate
+  Requires Cert Plugin  
 Schema:
   type: "string"
 Meta:

--- a/krib/params/etcd-client-port.yaml
+++ b/krib/params/etcd-client-port.yaml
@@ -1,6 +1,8 @@
 ---
 Name: "etcd/client-port"
 Description: "Port clients use to talk to etcd servers"
+Documentation: |
+  Allows operators to set the port used by etcd clients
 Schema:
   type: "integer"
   default: 2379

--- a/krib/params/etcd-cluster-profile.yaml
+++ b/krib/params/etcd-cluster-profile.yaml
@@ -11,3 +11,4 @@ Meta:
   color: "blue"
   icon: "book"
   title: "Community Content"
+  render: "profile"

--- a/krib/params/etcd-cluster-profile.yaml
+++ b/krib/params/etcd-cluster-profile.yaml
@@ -1,6 +1,10 @@
 ---
 Name: "etcd/cluster-profile"
 Description: "Name of the profile for this etcd cluster"
+Documentation: |
+  Part of the Digital Rebar Cluster pattern, this parameter is used
+  to identify the machines used in the etcd cluster
+  This parameter is REQUIRED for KRIB and etcd cluster contruction
 Schema:
   type: "string"
 Meta:

--- a/krib/params/etcd-name.yaml
+++ b/krib/params/etcd-name.yaml
@@ -1,6 +1,8 @@
 ---
 Name: "etcd/name"
 Description: "Name of the etcd cluster"
+Documentation: |
+  Allows operators to set a name for the etcd cluster
 Schema:
   type: "string"
   default: "etcd-cluster"

--- a/krib/params/etcd-peer-ca-name.yaml
+++ b/krib/params/etcd-peer-ca-name.yaml
@@ -1,6 +1,9 @@
 ---
 Name: "etcd/peer-ca-name"
 Description: "Name of the certificate root for the etcd peer certs"
+Documentation: |
+  Allows operators to set the CA name for the peer certificate
+  Requires Cert Plugin
 Schema:
   type: "string"
 Meta:

--- a/krib/params/etcd-peer-ca-pw.yaml
+++ b/krib/params/etcd-peer-ca-pw.yaml
@@ -1,6 +1,10 @@
 ---
 Name: "etcd/peer-ca-pw"
 Description: "Password to access the etcd peer CA"
+Documentation: |
+  Allows operators to set the CA password for the peer certificate
+  If missing, will be generated
+  Requires Cert Plugin
 Schema:
   type: "string"
 Meta:

--- a/krib/params/etcd-peer-port.yaml
+++ b/krib/params/etcd-peer-port.yaml
@@ -1,6 +1,8 @@
 ---
 Name: "etcd/peer-port"
 Description: "Port peers use to talk to each other"
+Documentation: |
+  Allows operators to set the port for the cluster peers
 Schema:
   type: "integer"
   default: 2380

--- a/krib/params/etcd-server-ca-name.yaml
+++ b/krib/params/etcd-server-ca-name.yaml
@@ -1,6 +1,9 @@
 ---
 Name: "etcd/server-ca-name"
 Description: "Name of the certificate root for the etcd server certs"
+Documentation: |
+  Allows operators to set the CA name for the server certificate
+  Requires Cert Plugin
 Schema:
   type: "string"
 Meta:

--- a/krib/params/etcd-server-ca-pw.yaml
+++ b/krib/params/etcd-server-ca-pw.yaml
@@ -1,6 +1,9 @@
 ---
 Name: "etcd/server-ca-pw"
 Description: "Password to access the etcd server CA"
+Documentation: |
+  Allows operators to set the CA password for the server certificate
+  Requires Cert Plugin
 Schema:
   type: "string"
 Meta:

--- a/krib/params/etcd-server-count.yaml
+++ b/krib/params/etcd-server-count.yaml
@@ -1,6 +1,11 @@
 ---
 Name: "etcd/server-count"
 Description: "Number of servers to expected"
+Documentation: |
+  Allows operators to set the number of machines required for the
+  etcd cluster.
+  Machines will be automatically added until the number is met.
+  NOTE: should be an odd number
 Schema:
   type: "integer"
   default: 1

--- a/krib/params/etcd-servers-done.yaml
+++ b/krib/params/etcd-servers-done.yaml
@@ -1,6 +1,8 @@
 ---
 Name: "etcd/servers-done"
 Description: "List of the servers in the cluster that are complete"
+Documentation: |
+  Param is set (output) by the etcd cluster building process
 Schema:
   type: "array"
   items:

--- a/krib/params/etcd-servers-done.yaml
+++ b/krib/params/etcd-servers-done.yaml
@@ -18,3 +18,4 @@ Meta:
   color: "blue"
   icon: "book"
   title: "Community Content"
+  render: "machines_map"

--- a/krib/params/etcd-servers.yaml
+++ b/krib/params/etcd-servers.yaml
@@ -18,3 +18,4 @@ Meta:
   color: "blue"
   icon: "book"
   title: "Community Content"
+  render: "machines_map"

--- a/krib/params/etcd-servers.yaml
+++ b/krib/params/etcd-servers.yaml
@@ -1,6 +1,8 @@
 ---
 Name: "etcd/servers"
 Description: "List of the server UUIDs in the cluster"
+Documentation: |
+  Param is set (output) by the etcd cluster building process
 Schema:
   type: "array"
   items:

--- a/krib/params/etcd-version.yaml
+++ b/krib/params/etcd-version.yaml
@@ -6,8 +6,9 @@ Documentation: |
   Note: Changes should be coordinate with KRIB Kubernetes version
 Schema:
   type: "string"
-  default: "3.2.15"
+  default: "3.3.8"
 Meta:
   color: "blue"
   icon: "book"
   title: "Community Content"
+  render: "semver"

--- a/krib/params/etcd-version.yaml
+++ b/krib/params/etcd-version.yaml
@@ -1,6 +1,9 @@
 ---
 Name: "etcd/version"
 Description: "Version of the etcd to use in cluster"
+Documentation: |
+  Allows operators to determine the version of etcd to install
+  Note: Changes should be coordinate with KRIB Kubernetes version
 Schema:
   type: "string"
   default: "3.2.15"

--- a/krib/params/krib-cluster-admin-conf.yaml
+++ b/krib/params/krib-cluster-admin-conf.yaml
@@ -1,6 +1,8 @@
 ---
 Name: "krib/cluster-admin-conf"
 Description: "Admin config file"
+Documentation: |
+  Param is set (output) by the cluster building process
 Meta:
   color: "blue"
   icon: "ship"

--- a/krib/params/krib-cluster-join.yaml
+++ b/krib/params/krib-cluster-join.yaml
@@ -1,6 +1,8 @@
 ---
 Name: "krib/cluster-join-command"
 Description: "kubeadm command to join the cluster"
+Documentation: |
+  Param is set (output) by the cluster building process
 Schema:
   type: "string"
 Meta:

--- a/krib/params/krib-cluster-master-certs.yaml
+++ b/krib/params/krib-cluster-master-certs.yaml
@@ -9,3 +9,4 @@ Meta:
   color: "blue"
   icon: "ship"
   title: "Community Content"
+  password: "hideme"

--- a/krib/params/krib-cluster-master-certs.yaml
+++ b/krib/params/krib-cluster-master-certs.yaml
@@ -1,6 +1,8 @@
 ---
 Name: "krib/cluster-master-certs"
 Description: "Kubeadm requires the master to have the same ca that it generates. Base 64 tgz string"
+Documentation: |
+  Requires Cert Plugin
 Schema:
   type: "string"
 Meta:

--- a/krib/params/krib-cluster-master-count.yaml
+++ b/krib/params/krib-cluster-master-count.yaml
@@ -1,6 +1,11 @@
 ---
 Name: "krib/cluster-master-count"
 Description: "Number of masters to create"
+Documentation: |
+  Allows operators to set the number of machines required for the
+  Kubernetes cluster.
+  Machines will be automatically added until the number is met.
+  NOTE: should be an odd number
 Schema:
   type: "integer"
   default: 1

--- a/krib/params/krib-cluster-master-vip.yaml
+++ b/krib/params/krib-cluster-master-vip.yaml
@@ -1,6 +1,9 @@
 ---
 Name: "krib/cluster-master-vip"
 Description: "Virtual IP for the Master Servers"
+Documentation: |
+  For High Availability (HA) configurations, a floating IP is required
+  by the load balancer.
 Schema:
   type: "string"
 Meta:

--- a/krib/params/krib-cluster-masters-on-etcds.yaml
+++ b/krib/params/krib-cluster-masters-on-etcds.yaml
@@ -1,6 +1,10 @@
 ---
 Name: "krib/cluster-masters-on-etcds"
 Description: "Should the masters run on the etcd servers"
+Documentation: |
+  For development clusters, allows running etcd on the same
+  machines as the Kubernetes masters
+  RECOMMENDED: set to false for production clusters
 Schema:
   type: "boolean"
   default: true

--- a/krib/params/krib-cluster-masters.yaml
+++ b/krib/params/krib-cluster-masters.yaml
@@ -1,6 +1,9 @@
 ---
 Name: "krib/cluster-masters"
 Description: "Masters of Kubernetes cluster"
+Documentation: |
+  List of the machine(s) assigned as cluster master(s).
+  If not set, the automation will elect leaders and populate the list automatically.
 Schema:
   type: "array"
   items:

--- a/krib/params/krib-cluster-masters.yaml
+++ b/krib/params/krib-cluster-masters.yaml
@@ -19,3 +19,4 @@ Meta:
   color: "blue"
   icon: "ship"
   title: "Community Content"
+  render: "machines_map"

--- a/krib/params/krib-cluster-name.yaml
+++ b/krib/params/krib-cluster-name.yaml
@@ -1,6 +1,8 @@
 ---
 Name: "krib/cluster-name"
 Description: "Name of Kubernetes cluster"
+Documentation: |
+  Allows operators to set the Kubernetes cluster name
 Schema:
   type: "string"
   default: "k8s-cluster"

--- a/krib/params/krib-cluster-profile.yaml
+++ b/krib/params/krib-cluster-profile.yaml
@@ -11,3 +11,4 @@ Meta:
   color: "blue"
   icon: "ship"
   title: "Community Content"
+  render: "profile"

--- a/krib/params/krib-cluster-profile.yaml
+++ b/krib/params/krib-cluster-profile.yaml
@@ -1,6 +1,10 @@
 ---
 Name: "krib/cluster-profile"
 Description: "Name of the profile for this kubernetes cluster"
+Documentation: |
+  Part of the Digital Rebar Cluster pattern, this parameter is used
+  to identify the machines used in the Kubernetes cluster
+  This parameter is REQUIRED for KRIB and etcd cluster contruction
 Schema:
   type: "string"
 Meta:

--- a/krib/params/krib-operate-on-node.yaml
+++ b/krib/params/krib-operate-on-node.yaml
@@ -23,3 +23,4 @@ Meta:
   color: "blue"
   icon: "ship"
   title: "Community Content"
+  render: "machine"

--- a/krib/tasks/docker-install.yaml
+++ b/krib/tasks/docker-install.yaml
@@ -1,6 +1,10 @@
 ---
 Description: "A task to install docker"
 Name: "docker-install"
+Documentation: |
+  Installs Docker using O/S packages
+OptionalParams:
+  - docker/working-dir
 Templates:
   - ID: "docker-install.sh.tmpl"
     Name: "Install Docker from internet repo"

--- a/krib/tasks/etcd-config.yaml
+++ b/krib/tasks/etcd-config.yaml
@@ -1,6 +1,22 @@
 ---
 Description: "A task to configure etcd"
 Name: "etcd-config"
+Documentation: |
+  Sets Param: etcd/servers
+RequredParams:
+  - etcd/cluster-profile
+OptionalParams:
+  - etcd/client-ca-name
+  - etcd/client-ca-pw
+  - etcd/client-port
+  - etcd/name
+  - etcd/peer-ca-name
+  - etcd/peer-ca-pw
+  - etcd/peer-port
+  - etcd/server-ca-name
+  - etcd/server-ca-pw
+  - etcd/server-count
+  - etcd/version
 Templates:
   - ID: "etcd-config.sh.tmpl"
     Name: "Config Etcd"

--- a/krib/tasks/etcd-config.yaml
+++ b/krib/tasks/etcd-config.yaml
@@ -3,6 +3,7 @@ Description: "A task to configure etcd"
 Name: "etcd-config"
 Documentation: |
   Sets Param: etcd/servers
+  If installing Kubernetes via Kubeadm, make sure you install a supported version!
   This uses the Digital Rebar Cluster pattern so etcd/cluster-profile must be set
 RequredParams:
   - etcd/cluster-profile

--- a/krib/tasks/etcd-config.yaml
+++ b/krib/tasks/etcd-config.yaml
@@ -3,6 +3,7 @@ Description: "A task to configure etcd"
 Name: "etcd-config"
 Documentation: |
   Sets Param: etcd/servers
+  This uses the Digital Rebar Cluster pattern so etcd/cluster-profile must be set
 RequredParams:
   - etcd/cluster-profile
 OptionalParams:

--- a/krib/tasks/krib-config.yaml
+++ b/krib/tasks/krib-config.yaml
@@ -1,6 +1,14 @@
 ---
 Description: "A task to configure kubernetes via kubeadm"
 Name: "krib-config"
+Documentation: |
+  Configure Kubernetes using Kubeadm
+  This uses the Digital Rebar Cluster pattern so krib/cluster-profile must be set
+RequiredParams:
+  - krib/cluster-profile
+OptionalParams:
+  - krib/cluster-name
+  - krib/cluster-is-production
 Templates:
   - ID: "krib-kubeadm.cfg.tmpl"
     Name: "Kubeadm config file"

--- a/krib/tasks/kubernetes-install.yaml
+++ b/krib/tasks/kubernetes-install.yaml
@@ -1,6 +1,22 @@
 ---
 Description: "A task to install kubernetes and kubeadm"
 Name: "kubernetes-install"
+Documentation: |
+  Sets Param: krib/cluster-join, krib/cluster-admin-conf
+RequredParams:
+  - krib/cluster-profile
+OptionalParams:
+  - krib/cluster-name
+  - krib/cluster-is-production
+  - krib/cluster-join
+  - krib/cluster-master-certs
+  - krib/cluster-master-count
+  - krib/cluster-master-vip
+  - krib/cluster-master-on-etcds    
+  - krib/cluster-masters
+  - krib/operate-action  
+  - krib/operate-on-node
+  - krib/operate-options
 Templates:
   - ID: "kubernetes-install.sh.tmpl"
     Name: "Install Kubernetes and Kubeadm"

--- a/krib/templates/docker-install.sh.tmpl
+++ b/krib/templates/docker-install.sh.tmpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Kubernetes Rebar Immutable Boot (KRIB) Docker Install
+# Kubernetes Rebar Integrated Boot (KRIB) Docker Install
 set -e
 
 # Get access and who we are.

--- a/krib/templates/etcd-config.sh.tmpl
+++ b/krib/templates/etcd-config.sh.tmpl
@@ -46,7 +46,7 @@ drpcli -T "$PROFILE_TOKEN" profiles add "$CLUSTER_PROFILE" param "etcd/servers-d
 ETCD_SERVER_COUNT={{.Param "etcd/server-count"}}
 echo "Creating $ETCD_SERVER_COUNT servers"
 
-echo "Electing Members to $CLUSTER_PROFILE"
+echo "Electing etcd members to cluster profile: $CLUSTER_PROFILE"
 ETCD_INDEX=$(add_me_if_not_count "etcd/servers" $ETCD_SERVER_COUNT)
 if [[ $ETCD_INDEX == notme ]] ; then
   echo "I am not an ETCD server.  Move on."
@@ -58,17 +58,22 @@ CLIENT_CA=${ETCD_CLUSTER_NAME}-client-ca
 SERVER_CA=${ETCD_CLUSTER_NAME}-server-ca
 PEER_CA=${ETCD_CLUSTER_NAME}-peer-ca
 
+{{if .ParamExists "certs/root" -}}
 # If we are INDEX=0, let's setup the root certs for building keys
 if [[ $ETCD_INDEX == "0" ]] ; then
+  echo "We are first machine in cluster, setting up the root certs..."
   # Are certs built yet?
   if ! drpcli machines runaction $RS_UUID getca certs/root $CLIENT_CA 2>/dev/null >/dev/null ; then
     CLIENT_CA_PW=$(drpcli machines runaction $RS_UUID makeroot certs/root $CLIENT_CA | jq -r .)
+    echo "  Client CA created as $CLIENT_CA and now adding to profile: $CLUSTER_PROFILE"
     drpcli -T "$PROFILE_TOKEN" profiles add "$CLUSTER_PROFILE" param "etcd/client-ca-name" to "$CLIENT_CA" || true
     drpcli -T "$PROFILE_TOKEN" profiles add "$CLUSTER_PROFILE" param "etcd/client-ca-pw" to "$CLIENT_CA_PW" || true
   else
     if [[ $(get_param "etcd/client-ca-pw") == null ]] ; then
-      echo "Client CA Exists, but we didn't set password.  Need to reset!!"
+      echo "  Client CA Exists, but we did not set password.  Need to reset!!"
       exit 1
+    else
+      echo "  Client CA $CLIENT_CA configured"
     fi
   fi
 
@@ -78,7 +83,7 @@ if [[ $ETCD_INDEX == "0" ]] ; then
     drpcli -T "$PROFILE_TOKEN" profiles add "$CLUSTER_PROFILE" param "etcd/server-ca-pw" to "$SERVER_CA_PW" || true
   else
     if [[ $(get_param "etcd/server-ca-pw") == null ]] ; then
-      echo "SERVER CA Exists, but we didn't set password.  Need to reset!!"
+      echo "  SERVER CA Exists, but we did not set password.  Need to reset data in certs-data profile!!"
       exit 1
     fi
   fi
@@ -89,11 +94,16 @@ if [[ $ETCD_INDEX == "0" ]] ; then
     drpcli -T "$PROFILE_TOKEN" profiles add "$CLUSTER_PROFILE" param "etcd/peer-ca-pw" to "$PEER_CA_PW" || true
   else
     if [[ $(get_param "etcd/peer-ca-pw") == null ]] ; then
-      echo "PEER CA Exists, but we didn't set password.  Need to reset!!"
+      echo "  PEER CA Exists, but we didn't set password.  Need to reset!!"
       exit 1
     fi
   fi
 fi
+{{else -}}
+  echo "STAGE REQUIRES CERT PLUGIN!!  Contact RackN for access."
+  exit 1
+{{end}}
+
 
 wait_for_count "etcd/servers" $ETCD_SERVER_COUNT
 

--- a/krib/templates/etcd-config.sh.tmpl
+++ b/krib/templates/etcd-config.sh.tmpl
@@ -59,6 +59,8 @@ SERVER_CA=${ETCD_CLUSTER_NAME}-server-ca
 PEER_CA=${ETCD_CLUSTER_NAME}-peer-ca
 
 {{if .ParamExists "certs/root" -}}
+
+echo "Certs plugin detected....setting up CA"
 # If we are INDEX=0, let's setup the root certs for building keys
 if [[ $ETCD_INDEX == "0" ]] ; then
   echo "We are first machine in cluster, setting up the root certs..."
@@ -99,11 +101,11 @@ if [[ $ETCD_INDEX == "0" ]] ; then
     fi
   fi
 fi
-{{else -}}
-  echo "STAGE REQUIRES CERT PLUGIN!!  Contact RackN for access."
-  exit 1
-{{end}}
 
+{{else -}}
+echo "STAGE REQUIRES CERT PLUGIN!!  Contact RackN for access."
+exit 1
+{{end}}
 
 wait_for_count "etcd/servers" $ETCD_SERVER_COUNT
 
@@ -132,6 +134,7 @@ IFS=" " ; while read ip ; do
 done <<< $(get_param "etcd/servers" | jq -r '.[].Address')
 IFS=$OLD_IFS
 
+echo "Installing etcd v{{.Param "etcd/version"}} (set in Param etcd/version)"
 curl -sSL https://github.com/coreos/etcd/releases/download/v{{.Param "etcd/version"}}/etcd-v{{.Param "etcd/version"}}-linux-amd64.tar.gz | tar -xz --strip-components=1 -C /usr/local/bin/
 rm -rf etcd-v{{.Param "etcd/version"}}-linux-amd64*
 

--- a/krib/templates/krib-config.sh.tmpl
+++ b/krib/templates/krib-config.sh.tmpl
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Kubernetes Rebar Immutable Boot (KRIB) Kubeadm Installer
+# Kubernetes Rebar Integrated Boot (KRIB) Kubeadm Installer
 set -e
 set -x
 

--- a/krib/templates/krib-lib.sh.tmpl
+++ b/krib/templates/krib-lib.sh.tmpl
@@ -72,6 +72,9 @@ add_me_if_not_count() {
     # we're good!
     if [[ $(jq "map(.Uuid) | index(\"${me_uuid}\")" <<< "$cl") != null ]] ; then
       index=$(jq "map(.Uuid) | index(\"${me_uuid}\")" <<< "$cl")
+      # set the machine icon for troubleshooting
+      drpcli machines update $RS_UUID "{\"Meta\":{\"color\":\"yellow\", \"icon\": \"chess queen\"} }" || true
+      echo "   Selected ${me_name} (${me_uuid})"
       break
     fi
     NEW_LEADERS=$(jq ". += [{\"Name\": \"${me_name}\", \"Uuid\": \"${me_uuid}\", \"Address\": \"${me_ip}\"}]" <<< "$cl")


### PR DESCRIPTION
This patch is mainly to add TF plans for building a cluster (WIP)
Had to update the etcd version for kubeadm (note to @svallebro who made similar in #102 ) 
Lots of adding documentation decoration to krib 

Slowing changing name of krib to be INTEGRATION instead of immutable.