### PR TITLE
add custom kernel+initrd and kernel-options to bootenvs

### DIFF
--- a/content/bootenvs/centos-7.5.1804.yml
+++ b/content/bootenvs/centos-7.5.1804.yml
@@ -7,21 +7,25 @@ OS:
   IsoFile: "CentOS-7-x86_64-Minimal-1804.iso"
   IsoSha256: "714acc0aefb32b7d51b515e25546835e55a90da9fb00417fbee2d03a62801efd"
   IsoUrl: "http://mirror.math.princeton.edu/pub/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-1804.iso"
-Kernel: "images/pxeboot/vmlinuz"
+Kernel: '{{if .ParamExists "custom-kernel"}}{{.Param "custom-kernel"}}{{else}}images/pxeboot/vmlinuz{{end}}' 
 Initrds:
-  - "images/pxeboot/initrd.img"
+  - '{{if .ParamExists "custom-initrd"}}{{.Param "custom-initrd"}}{{else}}images/pxeboot/initrd.img{{end}}'
 BootParams: >-
   ksdevice=bootif
   ks={{.Machine.Url}}/compute.ks
   method={{.Env.InstallUrl}}
   inst.geoloc=0
   --
-  {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
+  {{.Param "kernel-console"}}
+  {{.Param "kernel-options"}}
 RequiredParams:
 OptionalParams:
+  - "custom-initrd"
+  - "custom-kernel"
   - "operating-system-disk"
   - "provisioner-default-password-hash"
   - "kernel-console"
+  - "kernel-options"
   - "proxy-servers"
   - "select-kickseed"
 Templates:

--- a/content/bootenvs/centos-7.yml
+++ b/content/bootenvs/centos-7.yml
@@ -7,21 +7,25 @@ OS:
   IsoFile: "CentOS-7-x86_64-Minimal-1804.iso"
   IsoSha256: "714acc0aefb32b7d51b515e25546835e55a90da9fb00417fbee2d03a62801efd"
   IsoUrl: "http://mirror.math.princeton.edu/pub/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-1804.iso"
-Kernel: "images/pxeboot/vmlinuz"
+Kernel: '{{if .ParamExists "custom-kernel"}}{{.Param "custom-kernel"}}{{else}}images/pxeboot/vmlinuz{{end}}'
 Initrds:
-  - "images/pxeboot/initrd.img"
+  - '{{if .ParamExists "custom-initrd"}}{{.Param "custom-initrd"}}{{else}}images/pxeboot/initrd.img{{end}}'
 BootParams: >-
   ksdevice=bootif
   ks={{.Machine.Url}}/compute.ks
   method={{.Env.InstallUrl}}
   inst.geoloc=0
   --
-  {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
+  {{.Param "kernel-console"}}
+  {{.Param "kernel-options"}}
 RequiredParams:
 OptionalParams:
+  - "custom-initrd"
+  - "custom-kernel"
   - "operating-system-disk"
   - "provisioner-default-password-hash"
   - "kernel-console"
+  - "kernel-options"
   - "proxy-servers"
   - "select-kickseed"
 Templates:

--- a/content/bootenvs/debian-8.yml
+++ b/content/bootenvs/debian-8.yml
@@ -9,8 +9,8 @@ OS:
   IsoUrl: "http://mirrors.kernel.org/debian/dists/jessie/main/installer-amd64/current/images/netboot/mini.iso"
   Version: "8.10"
 Initrds:
-  - "initrd.gz"
-Kernel: "linux"
+  - '{{if .ParamExists "custom-initrd"}}{{.Param "custom-initrd"}}{{else}}initrd.gz{{end}}'
+Kernel: '{{if .ParamExists "custom-kernel"}}{{.Param "custom-kernel"}}{{else}}linux{{end}}' 
 BootParams: >-
   priority=critical
   console-tools/archs=at
@@ -32,9 +32,12 @@ BootParams: >-
   numa=off
   rw
   quiet
-  {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
+  {{.Param "kernel-console"}}
+  {{.Param "kernel-options"}}
 RequiredParams:
 OptionalParams:
+  - "custom-kernel"
+  - "custom-initrd"
   - "part-scheme"
   - "operating-system-disk"
   - "provisioner-default-user"
@@ -42,6 +45,7 @@ OptionalParams:
   - "provisioner-default-uid"
   - "provisioner-default-password-hash"
   - "kernel-console"
+  - "kernel-options"
   - "proxy-servers"
   - "dns-domain"
   - "local-repo"

--- a/content/bootenvs/debian-9.yml
+++ b/content/bootenvs/debian-9.yml
@@ -9,8 +9,8 @@ OS:
   IsoUrl: "http://mirrors.kernel.org/debian/dists/stretch/main/installer-amd64/current/images/netboot/mini.iso"
   Version: "9.4"
 Initrds:
-  - "initrd.gz"
-Kernel: "linux"
+  - '{{if .ParamExists "custom-initrd"}}{{.Param "custom-initrd"}}{{else}}initrd.gz{{end}}'
+Kernel: '{{if .ParamExists "custom-kernel"}}{{.Param "custom-kernel"}}{{else}}linux{{end}}' 
 BootParams: >-
   priority=critical
   console-tools/archs=at
@@ -31,9 +31,12 @@ BootParams: >-
   root=/dev/ram
   rw
   quiet
-  {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
+  {{.Param "kernel-console"}}
+  {{.Param "kernel-options"}}
 RequiredParams:
 OptionalParams:
+  - "custom-kernel"
+  - "custom-initrd"
   - "part-scheme"
   - "operating-system-disk"
   - "provisioner-default-user"
@@ -41,6 +44,7 @@ OptionalParams:
   - "provisioner-default-uid"
   - "provisioner-default-password-hash"
   - "kernel-console"
+  - "kernel-options"
   - "proxy-servers"
   - "dns-domain"
   - "local-repo"

--- a/content/bootenvs/discovery.yml
+++ b/content/bootenvs/discovery.yml
@@ -7,9 +7,9 @@ OS:
   Name: "sledgehammer/9c1ad5cb7483928e6aba1d93ba363de929169f37"
   IsoFile: "sledgehammer-9c1ad5cb7483928e6aba1d93ba363de929169f37.tar"
   IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/9c1ad5cb7483928e6aba1d93ba363de929169f37/sledgehammer-9c1ad5cb7483928e6aba1d93ba363de929169f37.tar"
-Kernel: "vmlinuz0"
+Kernel: '{{if .ParamExists "custom-kernel"}}{{.Param "custom-kernel"}}{{else}}vmlinuz0{{end}}'
 Initrds:
-  - "stage1.img"
+  - '{{if .ParamExists "custom-initrd"}}{{.Param "custom-initrd"}}{{else}}stage1.img{{end}}'
 BootParams: >-
   rootflags=loop
   root=live:/sledgehammer.iso
@@ -21,9 +21,13 @@ BootParams: >-
   rd_NO_DM
   provisioner.web={{.ProvisionerURL}}
   --
-  {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
+  {{.Param "kernel-console"}}
+  {{.Param "kernel-options"}}
 OptionalParams:
+  - "custom-initrd"
+  - "custom-kernel"
   - "kernel-console"
+  - "kernel-options"
 Templates:
   - Name: "pxelinux"
     Path: "pxelinux.cfg/default"

--- a/content/bootenvs/sledgehammer.yml
+++ b/content/bootenvs/sledgehammer.yml
@@ -9,9 +9,9 @@ OS:
   Name: "sledgehammer/9c1ad5cb7483928e6aba1d93ba363de929169f37"
   IsoFile: "sledgehammer-9c1ad5cb7483928e6aba1d93ba363de929169f37.tar"
   IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/9c1ad5cb7483928e6aba1d93ba363de929169f37/sledgehammer-9c1ad5cb7483928e6aba1d93ba363de929169f37.tar"
-Kernel: "vmlinuz0"
+  Kernel: '{{if .ParamExists "custom-kernel"}}{{.Param "custom-kernel"}}{{else}}vmlinuz0{{end}}'
 Initrds:
-  - "stage1.img"
+  - '{{if .ParamExists "custom-initrd"}}{{.Param "custom-initrd"}}{{else}}stage1.img{{end}}'
 BootParams: >-
   rootflags=loop
   root=live:/sledgehammer.iso
@@ -24,10 +24,14 @@ BootParams: >-
   provisioner.web={{.ProvisionerURL}}
   rs.uuid={{.Machine.UUID}}
   --
-  {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
+  {{.Param "kernel-console"}}
+  {{.Param "kernel-options"}}
 RequiredParams:
 OptionalParams:
+  - "custom-initrd"
+  - "custom-kernel"
   - "kernel-console"
+  - "kernel-options"
 Templates:
   - Name: "pxelinux"
     Path: "pxelinux.cfg/{{.Machine.HexAddress}}"

--- a/content/bootenvs/ubuntu-16.04.yml
+++ b/content/bootenvs/ubuntu-16.04.yml
@@ -9,8 +9,8 @@ OS:
   IsoUrl: "http://mirror.math.princeton.edu/pub/ubuntu-iso/16.04/ubuntu-16.04.4-server-amd64.iso"
   Version: "16.04"
 Initrds:
-  - "install/netboot/ubuntu-installer/amd64/initrd.gz"
-Kernel: "install/netboot/ubuntu-installer/amd64/linux"
+  - '{{if .ParamExists "custom-initrd"}}{{.Param "custom-initrd"}}{{else}}install/netboot/ubuntu-installer/amd64/initrd.gz{{end}}'
+Kernel: '{{if .ParamExists "custom-kernel"}}{{.Param "custom-kernel"}}{{else}}install/netboot/ubuntu-installer/amd64/linux{{end}}' 
 BootParams: >-
   debian-installer/locale=en_US.utf8
   console-setup/layoutcode=us
@@ -22,11 +22,14 @@ BootParams: >-
   root=/dev/ram
   rw
   quiet
-  {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
+  {{.Param "kernel-console"}}
   --
-  {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
+  {{.Param "kernel-console"}}
+  {{.Param "kernel-options"}}
 RequiredParams:
 OptionalParams:
+  - "custom-initrd"
+  - "custom-kernel"
   - "part-scheme"
   - "operating-system-disk"
   - "provisioner-default-user"
@@ -34,6 +37,7 @@ OptionalParams:
   - "provisioner-default-uid"
   - "provisioner-default-password-hash"
   - "kernel-console"
+  - "kernel-options"
   - "proxy-servers"
   - "dns-domain"
   - "local-repo"

--- a/content/bootenvs/ubuntu-18.04.yml
+++ b/content/bootenvs/ubuntu-18.04.yml
@@ -1,66 +1,81 @@
-Name: ubuntu-18.04-install
-BootParams: debian-installer/locale=en_US.utf8 console-setup/layoutcode=us keyboard-configuration/layoutcode=us
-  netcfg/dhcp_timeout=120 netcfg/choose_interface=auto url={{.Machine.Url}}/seed netcfg/get_hostname={{.Machine.Name}}
-  root=/dev/ram rw quiet {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
-  -- {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
-Description: Ubuntu-18.04 install
+---
+Name: "ubuntu-18.04-install"
+BootParams: >-
+  debian-installer/locale=en_US.utf8 
+  console-setup/layoutcode=us 
+  keyboard-configuration/layoutcode=us
+  netcfg/dhcp_timeout=120 
+  netcfg/choose_interface=auto 
+  url={{.Machine.Url}}/seed 
+  netcfg/get_hostname={{.Machine.Name}}
+  root=/dev/ram 
+  rw 
+  quiet 
+  {{.Param "kernel-console"}}
+  --
+  {{.Param "kernel-console"}}
+  {{.Param "kernel-options"}}
+Description: "Ubuntu-18.04 install"
 Errors: []
 Initrds:
-  - install/netboot/ubuntu-installer/amd64/initrd.gz
-Kernel: install/netboot/ubuntu-installer/amd64/linux
+  - '{{if .ParamExists "custom-initrd"}}{{.Param "custom-initrd"}}{{else}}install/netboot/ubuntu-installer/amd64/initrd.gz{{end}}'
+Kernel: '{{if .ParamExists "custom-kernel"}}{{.Param "custom-kernel"}}{{else}}install/netboot/ubuntu-installer/amd64/linux{{end}}' 
 Meta:
-  color: orange
-  feature-flags: change-stage-v2
-  icon: linux
-  title: Digital Rebar Community Content
+  color: "orange"
+  feature-flags: "change-stage-v2"
+  icon: "linux"
+  title: "Digital Rebar Community Content"
 OS:
   Codename: "Bionic Beaver"
-  Family: ubuntu
-  IsoFile: ubuntu-18.04-server-amd64.iso
+  Family: "ubuntu"
+  IsoFile: "ubuntu-18.04-server-amd64.iso"
   IsoSha256: "a7f5c7b0cdd0e9560d78f1e47660e066353bb8a79eb78d1fc3f4ea62a07e6cbc"
-  IsoUrl: http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04-server-amd64.iso
-  Name: ubuntu-18.04
+  IsoUrl: "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04-server-amd64.iso"
+  Name: "ubuntu-18.04"
   Version: "18.04"
 OnlyUnknown: false
 OptionalParams:
-  - part-scheme
-  - operating-system-disk
-  - provisioner-default-user
-  - provisioner-default-fullname
-  - provisioner-default-uid
-  - provisioner-default-password-hash
-  - kernel-console
-  - proxy-servers
-  - dns-domain
-  - local-repo
-  - proxy-servers
-  - ntp-servers
-  - select-kickseed
+  - "custom-initrd"
+  - "custom-kernel"
+  - "part-scheme"
+  - "operating-system-disk"
+  - "provisioner-default-user"
+  - "provisioner-default-fullname"
+  - "provisioner-default-uid"
+  - "provisioner-default-password-hash"
+  - "kernel-console"
+  - "kernel-options"
+  - "proxy-servers"
+  - "dns-domain"
+  - "local-repo"
+  - "proxy-servers"
+  - "ntp-servers"
+  - "select-kickseed"
 ReadOnly: true
 RequiredParams: []
 Templates:
   - Contents: ""
-    ID: default-pxelinux.tmpl
-    Name: pxelinux
-    Path: pxelinux.cfg/{{.Machine.HexAddress}}
+    ID: "default-pxelinux.tmpl"
+    Name: "pxelinux"
+    Path: "pxelinux.cfg/{{.Machine.HexAddress}}"
   - Contents: ""
-    ID: default-ipxe.tmpl
-    Name: ipxe
+    ID: "default-ipxe.tmpl"
+    Name: "ipxe"
     Path: '{{.Machine.Address}}.ipxe'
   - Contents: ""
-    ID: default-pxelinux.tmpl
-    Name: pxelinux-mac
-    Path: pxelinux.cfg/{{.Machine.MacAddr "pxelinux"}}
+    ID: "default-pxelinux.tmpl"
+    Name: "pxelinux-mac"
+    Path: 'pxelinux.cfg/{{.Machine.MacAddr "pxelinux"}}'
   - Contents: ""
-    ID: default-ipxe.tmpl
-    Name: ipxe-mac
+    ID: "default-ipxe.tmpl"
+    Name: "ipxe-mac"
     Path: '{{.Machine.MacAddr "ipxe"}}.ipxe'
   - Contents: ""
-    ID: select-kickseed.tmpl
-    Name: seed
+    ID: "select-kickseed.tmpl"
+    Name: "seed"
     Path: '{{.Machine.Path}}/seed'
   - Contents: ""
-    ID: net-post-install.sh.tmpl
-    Name: net-post-install.sh
-    Path: '{{.Machine.Path}}/post-install.sh'
+    ID: "net-post-install.sh.tmpl"
+    Name: "net-post-install.sh"
+    Path: "{{.Machine.Path}}/post-install.sh"
 

--- a/content/params/custom-initrd.yaml
+++ b/content/params/custom-initrd.yaml
@@ -1,0 +1,18 @@
+---
+Name: "custom-initrd"
+Description: "Specify an alternate custom initrd to use for the BootEnv"
+Documentation: |
+  Overrides the default bootenv initrd to use for the machine. 
+  The initrd path is relative to the exploded ISO image in the 
+  DRP data 'tftpboot/<bootenv>' directory structure.
+  
+  No default is provided as the presence of any value on the 
+  Machine will use the Param specified value.
+
+Schema:
+  type: "string"
+
+Meta:
+  icon: "desktop"
+  color: "blue"
+  title: "Digital Rebar Community Content"

--- a/content/params/custom-kernel.yaml
+++ b/content/params/custom-kernel.yaml
@@ -1,0 +1,18 @@
+---
+Name: "custom-kernel"
+Description: "Specify an alternate custom kernel to use for the BootEnv"
+Documentation: |
+  Overrides the default bootenv kernel to use for the machine. 
+  The kernel path is relative to the exploded ISO image in the 
+  DRP data 'tftpboot/<bootenv>' directory structure.
+  
+  No default is provided as the presence of any value on the 
+  Machine will use the Param specified value.
+
+Schema:
+  type: "string"
+
+Meta:
+  icon: "desktop"
+  color: "blue"
+  title: "Digital Rebar Community Content"

--- a/content/params/kernel-console.yaml
+++ b/content/params/kernel-console.yaml
@@ -8,6 +8,7 @@ Documentation: |
 
 Schema:
   type: "string"
+  default: ""
 
 Meta:
   icon: "desktop"

--- a/content/params/kernel-options.yaml
+++ b/content/params/kernel-options.yaml
@@ -1,0 +1,17 @@
+---
+Name: "kernel-options"
+Description: "Additional kernel options for boot environments"
+Documentation: |
+  This string defines additional options to append to the 
+  the kernel boot process.
+
+  e.g. debug noapic
+
+Schema:
+  type: "string"
+  default: ""
+
+Meta:
+  icon: "desktop"
+  color: "blue"
+  title: "Digital Rebar Community Content"


### PR DESCRIPTION
- adds `kernel-options` to add to kernel boot arguments
- adds `custom-kernel` and `custom-initrd` Params to override the BootEnv ISO defaults
- minor cleanup to quoting on a few BootEnvs
- added new Params to the Optional-Params sections
