### PR TITLE
Add helm and tiller to KRIB workflows

### DIFF
--- a/krib/params/helm-charts.yaml
+++ b/krib/params/helm-charts.yaml
@@ -3,11 +3,12 @@ Name: "helm/charts"
 Description: "List charts to run on cluster"
 Documentation: |
   Allows operators to install Charts using Helm stage
+  For example, using ["stable/mysql"] will install mysql.
 Schema:
   type: "array"
   items:
     type: "string"
-  default: ["stable/mysql"]
+  default: []
 Meta:
   color: "blue"
   icon: "map"

--- a/krib/params/helm-charts.yaml
+++ b/krib/params/helm-charts.yaml
@@ -1,0 +1,14 @@
+---
+Name: "helm/charts"
+Description: "List charts to run on cluster"
+Documentation: |
+  Allows operators to install Charts using Helm stage
+Schema:
+  type: "array"
+  items:
+    type: "string"
+  default: ["stable/mysql"]
+Meta:
+  color: "blue"
+  icon: "map"
+  title: "Community Content"

--- a/krib/params/helm-version.yaml
+++ b/krib/params/helm-version.yaml
@@ -1,0 +1,14 @@
+---
+Name: "helm/version"
+Description: "Version of the helm to use in cluster"
+Documentation: |
+  Allows operators to determine the version of etcd to install
+  Note: Changes should be coordinate with KRIB Kubernetes version
+Schema:
+  type: "string"
+  default: "latest"
+Meta:
+  color: "blue"
+  icon: "book"
+  title: "Community Content"
+  render: "semver"

--- a/krib/stages/krib-helm.yaml
+++ b/krib/stages/krib-helm.yaml
@@ -1,0 +1,10 @@
+---
+Name: "krib-helm"
+Description: "KRIB install helm and tiller on the cluster"
+RunnerWait: true
+Tasks:
+  - "krib-helm"
+Meta:
+  icon: "ship"
+  color: "blue"
+  title: "Community Content"

--- a/krib/tasks/krib-dev-reset.yaml
+++ b/krib/tasks/krib-dev-reset.yaml
@@ -8,6 +8,7 @@ RequiredParams:
   - etcd/cluster-profile
 OptionalParams:
   - krib/cluster-is-production
+  - unsafe/rs-password
 Templates:
 - Contents: |-
     #!/bin/bash

--- a/krib/tasks/krib-dev-reset.yaml
+++ b/krib/tasks/krib-dev-reset.yaml
@@ -48,7 +48,7 @@ Templates:
       drpcli -U "rocketskates" -P "$PASSWORD" plugins runaction certs deleteroot certs/root {{.Param "etcd/name"}}-client-ca
       drpcli -U "rocketskates" -P "$PASSWORD" plugins runaction certs deleteroot certs/root {{.Param "etcd/name"}}-server-ca
       drpcli -U "rocketskates" -P "$PASSWORD" plugins runaction certs deleteroot certs/root {{.Param "etcd/name"}}-peer-ca
-      RS_TOKEN=$HOLD_TOKEN
+      export RS_TOKEN=$HOLD_TOKEN
     else
       echo "  No CA root detected - no reset required"
     fi

--- a/krib/tasks/krib-helm.yaml
+++ b/krib/tasks/krib-helm.yaml
@@ -10,10 +10,12 @@ OptionalParams:
   - helm/charts
   - helm/version
 Templates:
+  - ID: "krib-helm.cfg.tmpl"
+    Name: "Service Account for Tiller"
+    Path: "tiller-rbac.yaml"
   - ID: "krib-helm-init.sh.tmpl"
     Name: "Bringing up Helm and Tiller on Master"
     Path: ""
-Templates:
   - ID: "krib-helm.sh.tmpl"
     Name: "Running Helm Charts on Master"
     Path: ""

--- a/krib/tasks/krib-helm.yaml
+++ b/krib/tasks/krib-helm.yaml
@@ -1,0 +1,24 @@
+---
+Description: "A task to install Helm and Tiller"
+Name: "krib-helm"
+Documentation: |
+  Installs Helm and runs helm init (which installs Tiller)
+  This uses the Digital Rebar Cluster pattern so krib/cluster-profile must be set
+RequiredParams:
+  - krib/cluster-profile
+OptionalParams:
+  - helm/charts
+  - helm/version
+Templates:
+  - ID: "krib-helm-init.sh.tmpl"
+    Name: "Bringing up Helm and Tiller on Master"
+    Path: ""
+Templates:
+  - ID: "krib-helm.sh.tmpl"
+    Name: "Running Helm Charts on Master"
+    Path: ""
+Meta:
+  icon: "ship"
+  color: "blue"
+  title: "Community Content"
+  feature-flags: "sane-exit-codes"

--- a/krib/templates/krib-helm-init.sh.tmpl
+++ b/krib/templates/krib-helm-init.sh.tmpl
@@ -30,6 +30,7 @@ if [[ $MASTER_INDEX != notme ]] ; then
     set +e
     if [[ ! -z $(kubectl get pods --namespace kube-system | grep tiller) ]] ; then
       echo "Tiller already installed - exiting"
+      helm version
       exit 0
     fi
     set -e
@@ -39,7 +40,11 @@ if [[ $MASTER_INDEX != notme ]] ; then
     chmod 700 get_helm.sh
     ./get_helm.sh -v {{.Param "helm/version"}}
 
-    helm init
+    echo "Create tiller service account"
+    kubectl create -f tiller-rbac.yaml
+
+    echo "Helm initialize"
+    helm init --service-account tiller
 
     set +e
     echo "Wait until Tiller is running"

--- a/krib/templates/krib-helm-init.sh.tmpl
+++ b/krib/templates/krib-helm-init.sh.tmpl
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Kubernetes Rebar Integrated Boot (KRIB) Kubeadm Installer
+set -e
+
+# Get access and who we are.
+{{template "setup.tmpl" .}}
+
+echo "Configure helm on the master (skip for minions)..."
+
+{{if .ParamExists "krib/cluster-profile" -}}
+CLUSTER_PROFILE={{.Param "krib/cluster-profile"}}
+PROFILE_TOKEN={{.GenerateProfileToken (.Param "krib/cluster-profile") 7200}}
+{{else -}}
+echo "Missing krib/cluster-profile on the machine!"
+exit 1
+{{end -}}
+
+{{template "krib-lib.sh.tmpl" .}}
+
+MASTER_INDEX=$(find_me $KRIB_MASTERS_PARAM "Uuid" $RS_UUID)
+echo "My Master index is $MASTER_INDEX"
+if [[ $MASTER_INDEX != notme ]] ; then
+
+  if [[ $MASTER_INDEX == 0 ]] ; then
+
+    echo "I am the elected leader - install helm and helm init"
+
+    # help requires the admin config
+    export KUBECONFIG="/etc/kubernetes/admin.conf"
+    set +e
+    if [[ ! -z $(kubectl get pods --namespace kube-system | grep tiller) ]] ; then
+      echo "Tiller already installed - exiting"
+      exit 0
+    fi
+    set -e
+
+    # todo: provide more options for installing helm
+    curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
+    chmod 700 get_helm.sh
+    ./get_helm.sh -v {{.Param "helm/version"}}
+
+    helm init
+
+    set +e
+    echo "Wait until Tiller is running"
+    CNT=$(kubectl get pods --namespace kube-system --field-selector=status.phase==Running | grep tiller)
+    ESCAPE=0
+    while [[ -z $CNT && $ESCAPE -lt 20 ]] ; do
+      echo "Waiting for Tiller...$(kubectl get pods --namespace kube-system | grep tiller)"
+      sleep 5
+      CNT=$(kubectl get pods --namespace kube-system --field-selector=status.phase==Running | grep tiller)
+      ((ESCAPE=ESCAPE+1))
+    done
+    set -e
+
+    echo "Check versions....(includes 5 second wait for Tiller initialize)"
+    # we need some extra time for Tiller to actually initialize
+    sleep 5
+    helm version
+    rm ./get_helm.sh
+
+  else
+
+    echo "I was not the leader, skipping helm init"
+
+  fi
+
+else
+
+  echo "I am a worker - no helm actions"
+
+fi
+
+echo "Finished successfully"
+exit 0
+

--- a/krib/templates/krib-helm.cfg.tmpl
+++ b/krib/templates/krib-helm.cfg.tmpl
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system

--- a/krib/templates/krib-helm.sh.tmpl
+++ b/krib/templates/krib-helm.sh.tmpl
@@ -33,6 +33,9 @@ if [[ $MASTER_INDEX != notme ]] ; then
       exit 1
     fi
 
+    echo "Getting Latest Repos"
+    helm repo update
+
     echo "Running Helm Install for all helm/charts"
     {{range $index, $chart := .Param "helm/charts"}}
       echo "...installing {{$chart}}"

--- a/krib/templates/krib-helm.sh.tmpl
+++ b/krib/templates/krib-helm.sh.tmpl
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Kubernetes Rebar Integrated Boot (KRIB) Kubeadm Installer
+set -e
+
+# Get access and who we are.
+{{template "setup.tmpl" .}}
+
+echo "Run helm install on the master (skip for minions)..."
+
+{{if .ParamExists "krib/cluster-profile" -}}
+CLUSTER_PROFILE={{.Param "krib/cluster-profile"}}
+PROFILE_TOKEN={{.GenerateProfileToken (.Param "krib/cluster-profile") 7200}}
+{{else -}}
+echo "Missing krib/cluster-profile on the machine!"
+exit 1
+{{end -}}
+
+{{template "krib-lib.sh.tmpl" .}}
+
+MASTER_INDEX=$(find_me $KRIB_MASTERS_PARAM "Uuid" $RS_UUID)
+echo "My Master index is $MASTER_INDEX"
+if [[ $MASTER_INDEX != notme ]] ; then
+
+  if [[ $MASTER_INDEX == 0 ]] ; then
+
+    echo "I am the elected leader - I can run helm for the cluster"
+
+    # help requires the admin config
+    export KUBECONFIG="/etc/kubernetes/admin.conf"
+    echo "Making sure Tiller is running"
+    if [[ -z $(kubectl get pods --namespace kube-system --field-selector=status.phase==Running | grep tiller) ]] ; then
+      echo "Tiller NOT running - something went wrong with helm init"
+      exit 1
+    fi
+
+    echo "Running Helm Install for all helm/charts"
+    {{range $index, $chart := .Param "helm/charts"}}
+      echo "...installing {{$chart}}"
+      helm install {{$chart}}
+    {{else}}
+      echo "No charts included in helm/charts to install"
+    {{end}}
+
+  else
+
+    echo "I was not the leader, skipping helm install"
+
+  fi
+
+else
+
+  echo "I am a worker - no helm actions"
+
+fi
+
+echo "Finished successfully"
+exit 0
+

--- a/krib/workflows/krib-install-cluster.yaml
+++ b/krib/workflows/krib-install-cluster.yaml
@@ -16,4 +16,5 @@ Stages:
   - "kubernetes-install"
   - "etcd-config"
   - "krib-config"
+  - "krib-helm"
   - "krib-install-complete"

--- a/krib/workflows/krib-install-cluster.yaml
+++ b/krib/workflows/krib-install-cluster.yaml
@@ -1,10 +1,12 @@
+# Workflow
+---
+Name: "krib-install-cluster"
 Description: "KRIB built kubernetes install-to-disk demo cluster"
 Errors: []
 Meta:
   color: "yellow"
   icon: "ship"
   title: "kubernetes install-to-disk demo cluster"
-Name: "krib-install-cluster"
 ReadOnly: false
 Stages:
   - "centos-7-install"

--- a/krib/workflows/krib-live-cluster.yaml
+++ b/krib/workflows/krib-live-cluster.yaml
@@ -13,4 +13,5 @@ Stages:
   - "kubernetes-install"
   - "etcd-config"
   - "krib-config"
+  - "krib-helm"
   - "krib-live-wait"


### PR DESCRIPTION
This pull adds a helm stage that will install helm and tiller (a service role is also added)
And then install any requested charts from helm/charts array

The helm init is idempotent (it checks if tiller is running) and can be run multiple times.

