### PR TITLE
label nodes - use inventory if available

### DIFF
--- a/krib/params/krib-label-env.yaml
+++ b/krib/params/krib-label-env.yaml
@@ -1,0 +1,12 @@
+---
+Name: "krib/label-env"
+Description: "Value set for env label"
+Documentation: |
+  Used for node specification, labels should be set.
+Schema:
+  type: "string"
+  default: "dev"
+Meta:
+  color: "blue"
+  icon: "tag"
+  title: "Community Content"

--- a/krib/templates/krib-config.sh.tmpl
+++ b/krib/templates/krib-config.sh.tmpl
@@ -119,6 +119,7 @@ if [[ $MASTER_INDEX != notme ]] ; then
     IFS=" " ; while read name ; do
         if kubectl get nodes | egrep -q "^$name[ \t]*Ready"; then
                 echo "Node $name is ready."
+                HOSTNAME=$name
         else
                 echo "Node $name is not yet ready."
                 echo "$(kubectl get nodes)"
@@ -131,6 +132,20 @@ if [[ $MASTER_INDEX != notme ]] ; then
       sleep ${INCREMENT_SECONDS}s
     fi
   done
+
+  # set labels for nodes
+  echo "Adding builder=lron label to machine $HOSTNAME"
+  kubectl label nodes $HOSTNAME builder=krib
+  echo "Adding env={{.Param "krib/label-env"}} label to machine $HOSTNAME"
+  kubectl label nodes $HOSTNAME env={{.Param "krib/label-env"}}
+  {{if .ParamExists "inventory/data" -}}
+    {{range $key, $value := .Param "inventory/data" -}}
+      echo "Adding {{$key}}=\"{{$value | toString | replace " " "_"  | -}}\" label to machine $HOSTNAME"
+      kubectl label nodes $HOSTNAME {{$key}}="{{$value | toString | replace " " "_" -}}" || true
+    {{end }}
+  {{else -}}
+    echo "use of inventory/data to create machine specific labels"
+  {{end -}}
 
   if [[ $MASTER_INDEX == 0 ]] ; then
     echo "Recording 'kubeadm' bootstrap config ..."


### PR DESCRIPTION
includes an env=[dev] label for nodes during KRIB provisioning

if inventory/data is set then all the legal key=value combinations will also be set into the nodes.  This allows operators to use inventory values to help classify nodes in Kubernetes automatically.