### PR TITLE
Add Sonobuoy Stage

### DIFF
--- a/krib/params/sonobuoy-binary.yaml
+++ b/krib/params/sonobuoy-binary.yaml
@@ -1,0 +1,13 @@
+---
+Name: "sonobuoy/binary"
+Description: "Go binary with Sonobuoy tooling for test"
+Documentation: |
+  Downloads tgz with compiled sonobuoy executable.
+  The full path is included so that operators can choose the correct version and archtiecture
+Schema:
+  type: "string"
+  default: "https://github.com/heptio/sonobuoy/releases/download/v0.11.6/sonobuoy_0.11.6_linux_amd64.tar.gz"
+Meta:
+  color: "blue"
+  icon: "sound"
+  title: "Community Content"

--- a/krib/params/sonobuoy-wait-mins.yaml
+++ b/krib/params/sonobuoy-wait-mins.yaml
@@ -1,0 +1,17 @@
+---
+Name: "sonobuoy/wait-mins"
+Description: "Minutes to wait for Sonobuoy run to complete"
+Documentation: |
+  Default is -1 so that stages do not wait for complete.
+
+  Typical runs may take 60 minutes.
+
+  If <0 then code does wait and assumes you will run it again to retrieve the results.
+  Task is idempotent so you can re-start a run after you have started to check on results.
+Schema:
+  type: "number"
+  default: -1
+Meta:
+  color: "black"
+  icon: "time"
+  title: "Community Content"

--- a/krib/stages/krib-sonobuoy.yaml
+++ b/krib/stages/krib-sonobuoy.yaml
@@ -1,0 +1,20 @@
+---
+Name: "krib-sonobuoy"
+Description: "KRIB install Sonobuoy and conformance test the cluster"
+Documentation: |
+  Installs and runs Sonobuoy after a cluster has been constructed.
+  This stage is idempotent and can be run multiple times.
+  The purpose is to ensure that the KRIB cluster is conformant with standards
+
+  If credentials are required so that the results of the run are pushed back to DRP files.
+
+  Roadmap items:
+  * eliminate need for DRPCLI credentials
+  * make "am I running" detection smarter
+RunnerWait: true
+Tasks:
+  - "krib-sonobuoy"
+Meta:
+  icon: "sound"
+  color: "blue"
+  title: "Community Content"

--- a/krib/tasks/krib-sonobuoy.yaml
+++ b/krib/tasks/krib-sonobuoy.yaml
@@ -1,0 +1,25 @@
+---
+Description: "A task to install Sonobuoy"
+Name: "krib-sonobuoy"
+Documentation: |
+  Installs Sonobuoy and runs it against the cluster on the leader.
+  This uses the Digital Rebar Cluster pattern so krib/cluster-profile must be set.
+
+  NOTE: Sonobuoy may take over an HOUR to complete.  The task will be in process during this time.
+
+  The tasks only run on the leader so it must be included in the workflow.  All other
+  machines will be skipped so it is acceptable to run the task on all machines
+  in the cluster.
+RequiredParams:
+  - krib/cluster-profile
+OptionalParams:
+  - sonobuoy/binary
+Templates:
+  - ID: "krib-sonobuoy.sh.tmpl"
+    Name: "Running Sonobuoy on Master"
+    Path: ""
+Meta:
+  icon: "sound"
+  color: "blue"
+  title: "Community Content"
+  feature-flags: "sane-exit-codes"

--- a/krib/templates/krib-sonobuoy.sh.tmpl
+++ b/krib/templates/krib-sonobuoy.sh.tmpl
@@ -33,26 +33,48 @@ if [[ $MASTER_INDEX != notme ]] ; then
     ./sonobuoy run || true
 
     # needs some time to resolve before we can check status
-    sleep 5
-
     set +e
-    echo "Wait upto {{.Param "sonobuoy/wait-mins"}} minutes until sonobuoy is complete"
-    CNT=$(./sonobuoy status | egrep "^e2e(\s*)complete")
-    ESCAPE={{.Param "sonobuoy/wait-mins" | mul 4}}
+    echo "waiting for sonobuoy namespace to be active..."
+    CNT=$(kubectl get ns | egrep "^heptio-sonobuoy(\s*)Active")
+    ESCAPE=30
     while [[ -z $CNT && $ESCAPE -gt 0 ]] ; do
-      echo "Iteration $ESCAPE: 15s loop for sonobuoy status...$(./sonobuoy status)"
-      sleep 15
-      CNT=$(./sonobuoy status | egrep "^e2e(\s*)complete")
+      echo "Namespace $ESCAPE: 2s loop for sonobuoy namespace..."
+      sleep 2
+      CNT=$(kubectl get ns | egrep "^heptio-sonobuoy(\s*)Active")
       ((ESCAPE=ESCAPE-1))
     done
+    echo "sonobuoy namespace active"
+
+    sleep 5
+    echo "checking status (first time)"
+    ./sonobuoy status
+
+    CNT=$(./sonobuoy status | egrep "^e2e(\s*)complete")
+    if [[ {{.Param "sonobuoy/wait-mins"}} -gt 0 ]] ; then
+      echo "Wait up to {{.Param "sonobuoy/wait-mins"}} minutes until sonobuoy is complete"
+      ESCAPE={{.Param "sonobuoy/wait-mins" | mul 4}}
+      while [[ -z $CNT && $ESCAPE -gt 0 ]] ; do
+        echo "Iteration $ESCAPE: 15s loop for sonobuoy status...$(./sonobuoy status)"
+        sleep 15
+        CNT=$(./sonobuoy status | egrep "^e2e(\s*)complete")
+        ((ESCAPE=ESCAPE-1))
+      done
+      echo "exiting loop - $ESCAPE iterations remain"
+    else
+      echo "skipping wait loop (sonobuoy/wait-mins < 0)"
+    fi
     set -e
-    echo "exiting loop...$ESCAPE iterations remaining"
 
-    echo "!!!!!!!!!!!!!!!!!!!!!! start copy the logs into DRP log !!!!!!!!!!!!!!!!!!!!!!!!!"
-    ./sonobuoy logs
-    echo "!!!!!!!!!!!!!!!!!!!!!! end copy the logs into DRP log !!!!!!!!!!!!!!!!!!!!!!!!!!!"
 
-    if [[ -z $CNT ]] ; then
+    # REMOVED FOR NOW - status hangs the job
+    #echo "!!!!!!!!!!!!!!!!!!!!!! start copy the logs into DRP log !!!!!!!!!!!!!!!!!!!!!!!!!"
+    #./sonobuoy logs
+    #echo "!!!!!!!!!!!!!!!!!!!!!! end copy the logs into DRP log !!!!!!!!!!!!!!!!!!!!!!!!!!!"
+
+    echo "checking status (last time)"
+    ./sonobuoy status
+
+    if [[ ! -z $CNT ]] ; then
       echo "Retrieving Results"
       ./sonobuoy retrieve .
       OUTPUT=$(ls | grep _sonobuoy_)
@@ -61,7 +83,7 @@ if [[ $MASTER_INDEX != notme ]] ; then
       {{else}}
         PASSWORD="r0cketsk8ts"
       {{end}}
-      echo "attempting to upload $OUTPUT results fDRP/files (required admin access)"
+      echo "attempting to upload $OUTPUT results DRP/files (required admin access)"
       HOLD_TOKEN=$RS_TOKEN
       unset RS_TOKEN
       drpcli -U "rocketskates" -P "$PASSWORD" files upload $OUTPUT as $OUTPUT

--- a/krib/templates/krib-sonobuoy.sh.tmpl
+++ b/krib/templates/krib-sonobuoy.sh.tmpl
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Kubernetes Rebar Integrated Boot (KRIB) Kubeadm Installer
+set -e
+
+# Get access and who we are.
+{{template "setup.tmpl" .}}
+
+echo "Configure Sonobuoy on the master (skip for minions)..."
+
+{{if .ParamExists "krib/cluster-profile" -}}
+CLUSTER_PROFILE={{.Param "krib/cluster-profile"}}
+PROFILE_TOKEN={{.GenerateProfileToken (.Param "krib/cluster-profile") 7200}}
+{{else -}}
+echo "Missing krib/cluster-profile on the machine!"
+exit 1
+{{end -}}
+
+{{template "krib-lib.sh.tmpl" .}}
+
+MASTER_INDEX=$(find_me $KRIB_MASTERS_PARAM "Uuid" $RS_UUID)
+echo "My Master index is $MASTER_INDEX"
+if [[ $MASTER_INDEX != notme ]] ; then
+
+  if [[ $MASTER_INDEX == 0 ]] ; then
+
+    echo "I am the elected leader - install and run sonobuoy"
+
+    # help requires the admin config
+    export KUBECONFIG="/etc/kubernetes/admin.conf"
+    wget -q -O "sonobuoy.tar.gz" {{.Param "sonobuoy/binary"}}
+    tar --extract --file=sonobuoy.tar.gz sonobuoy
+    echo "starting sonobuoy run - will fail if already started, that OK"
+    ./sonobuoy run || true
+
+    # needs some time to resolve before we can check status
+    sleep 5
+
+    set +e
+    echo "Wait upto {{.Param "sonobuoy/wait-mins"}} minutes until sonobuoy is complete"
+    CNT=$(./sonobuoy status | egrep "^e2e(\s*)complete")
+    ESCAPE={{.Param "sonobuoy/wait-mins" | mul 4}}
+    while [[ -z $CNT && $ESCAPE -gt 0 ]] ; do
+      echo "Iteration $ESCAPE: 15s loop for sonobuoy status...$(./sonobuoy status)"
+      sleep 15
+      CNT=$(./sonobuoy status | egrep "^e2e(\s*)complete")
+      ((ESCAPE=ESCAPE-1))
+    done
+    set -e
+    echo "exiting loop...$ESCAPE iterations remaining"
+
+    echo "!!!!!!!!!!!!!!!!!!!!!! start copy the logs into DRP log !!!!!!!!!!!!!!!!!!!!!!!!!"
+    ./sonobuoy logs
+    echo "!!!!!!!!!!!!!!!!!!!!!! end copy the logs into DRP log !!!!!!!!!!!!!!!!!!!!!!!!!!!"
+
+    if [[ -z $CNT ]] ; then
+      echo "Retrieving Results"
+      ./sonobuoy retrieve .
+      OUTPUT=$(ls | grep _sonobuoy_)
+      {{if .ParamExists "unsafe/rs-password"}}
+        PASSWORD="{{.Param "unsafe/rs-password"}}"
+      {{else}}
+        PASSWORD="r0cketsk8ts"
+      {{end}}
+      echo "attempting to upload $OUTPUT results fDRP/files (required admin access)"
+      HOLD_TOKEN=$RS_TOKEN
+      unset RS_TOKEN
+      drpcli -U "rocketskates" -P "$PASSWORD" files upload $OUTPUT as $OUTPUT
+      export RS_TOKEN=$HOLD_TOKEN
+      echo "success: removing sonobuoy"
+      ./sonobuoy delete
+    else
+      echo "Sonobuoy is not complete"
+      if [[ {{.Param "sonobuoy/wait-mins"}} -lt 0 ]] ; then
+        echo "Check back latter...stage is idempotent"
+        exit 0
+      else
+        echo "ERROR: Wait time ({{.Param "sonobuoy/wait-mins"}} mins) expired."
+        exit 1
+      fi
+    fi
+
+  else
+
+    echo "I was not the leader, skipping helm init"
+
+  fi
+
+else
+
+  echo "I am a worker - no helm actions"
+
+fi
+
+echo "Finished successfully"
+exit 0
+


### PR DESCRIPTION
Add stage to run Sonobuoy conformance tests on installed cluster.

By default, starts run and does not wait for result.
Stage is idempotent so it can be run latter to collect results.
At this time, relies on the unsafe/rs-password to upload result files to DRP files

THIS IS NOT INCLUDED IN THE DEFAULT WORKFLOW!