### PR TITLE
Add oppourtunistic kexec support to bootenvs that should have it.

### DIFF
--- a/content/bootenvs/centos-7.5.1804.yml
+++ b/content/bootenvs/centos-7.5.1804.yml
@@ -25,6 +25,9 @@ OptionalParams:
   - "proxy-servers"
   - "select-kickseed"
 Templates:
+  - Name: "kexec"
+    ID: "kexec.tmpl"
+    Path: "{{.Machine.Path}}/kexec"
   - ID: "default-pxelinux.tmpl"
     Name: "pxelinux"
     Path: "pxelinux.cfg/{{.Machine.HexAddress}}"

--- a/content/bootenvs/centos-7.yml
+++ b/content/bootenvs/centos-7.yml
@@ -25,6 +25,9 @@ OptionalParams:
   - "proxy-servers"
   - "select-kickseed"
 Templates:
+  - Name: "kexec"
+    ID: "kexec.tmpl"
+    Path: "{{.Machine.Path}}/kexec"
   - ID: "default-pxelinux.tmpl"
     Name: "pxelinux"
     Path: "pxelinux.cfg/{{.Machine.HexAddress}}"

--- a/content/bootenvs/debian-8.yml
+++ b/content/bootenvs/debian-8.yml
@@ -49,6 +49,9 @@ OptionalParams:
   - "ntp-servers"
   - "select-kickseed"
 Templates:
+  - Name: "kexec"
+    ID: "kexec.tmpl"
+    Path: "{{.Machine.Path}}/kexec"
   - ID: "default-pxelinux.tmpl"
     Name: "pxelinux"
     Path: "pxelinux.cfg/{{.Machine.HexAddress}}"

--- a/content/bootenvs/debian-9.yml
+++ b/content/bootenvs/debian-9.yml
@@ -48,6 +48,9 @@ OptionalParams:
   - "ntp-servers"
   - "select-kickseed"
 Templates:
+  - Name: "kexec"
+    ID: "kexec.tmpl"
+    Path: "{{.Machine.Path}}/kexec"
   - ID: "default-pxelinux.tmpl"
     Name: "pxelinux"
     Path: "pxelinux.cfg/{{.Machine.HexAddress}}"

--- a/content/bootenvs/sledgehammer.yml
+++ b/content/bootenvs/sledgehammer.yml
@@ -29,6 +29,9 @@ RequiredParams:
 OptionalParams:
   - "kernel-console"
 Templates:
+  - Name: "kexec"
+    ID: "kexec.tmpl"
+    Path: "{{.Machine.Path}}/kexec"
   - Name: "pxelinux"
     Path: "pxelinux.cfg/{{.Machine.HexAddress}}"
     Contents: |
@@ -110,7 +113,10 @@ Templates:
           done
           printf '[%s]' "${maclist#,}"
       }
-
+      mac_re='BOOTIF=([^ ]+)'
+      if [[ $(cat /proc/cmdline) =~ $mac_re ]]; then
+          drpcli machines set "$RS_UUID" param last-boot-macaddr to "\"${BASH_REMATCH[1]}\""
+      fi
       json="$(drpcli machines show "$RS_UUID")"
       # The machine does not have hardware addresses set, so set them
       if [[ "$(jq '.HardwareAddrs | length' <<< "$json")" = 0 ]]; then

--- a/content/bootenvs/ubuntu-16.04.yml
+++ b/content/bootenvs/ubuntu-16.04.yml
@@ -45,6 +45,9 @@ OptionalParams:
   - "ntp-servers"
   - "select-kickseed"
 Templates:
+  - Name: "kexec"
+    ID: "kexec.tmpl"
+    Path: "{{.Machine.Path}}/kexec"
   - ID: "default-pxelinux.tmpl"
     Name: "pxelinux"
     Path: "pxelinux.cfg/{{.Machine.HexAddress}}"

--- a/content/bootenvs/ubuntu-18.04.yml
+++ b/content/bootenvs/ubuntu-18.04.yml
@@ -43,28 +43,25 @@ OptionalParams:
 ReadOnly: true
 RequiredParams: []
 Templates:
-  - Contents: ""
-    ID: default-pxelinux.tmpl
+  - Name: "kexec"
+    ID: "kexec.tmpl"
+    Path: "{{.Machine.Path}}/kexec"
+  - ID: default-pxelinux.tmpl
     Name: pxelinux
     Path: pxelinux.cfg/{{.Machine.HexAddress}}
-  - Contents: ""
-    ID: default-ipxe.tmpl
+  - ID: default-ipxe.tmpl
     Name: ipxe
     Path: '{{.Machine.Address}}.ipxe'
-  - Contents: ""
-    ID: default-pxelinux.tmpl
+  - ID: default-pxelinux.tmpl
     Name: pxelinux-mac
     Path: pxelinux.cfg/{{.Machine.MacAddr "pxelinux"}}
-  - Contents: ""
-    ID: default-ipxe.tmpl
+  - ID: default-ipxe.tmpl
     Name: ipxe-mac
     Path: '{{.Machine.MacAddr "ipxe"}}.ipxe'
-  - Contents: ""
-    ID: select-kickseed.tmpl
+  - ID: select-kickseed.tmpl
     Name: seed
     Path: '{{.Machine.Path}}/seed'
-  - Contents: ""
-    ID: net-post-install.sh.tmpl
+  - ID: net-post-install.sh.tmpl
     Name: net-post-install.sh
     Path: '{{.Machine.Path}}/post-install.sh'
 

--- a/content/params/kexec-ok.yaml
+++ b/content/params/kexec-ok.yaml
@@ -1,0 +1,15 @@
+---
+Name: kexec-ok
+Description: "Allows the machine agent to kexec instead of rebooting"
+Documentation: |
+  Allows the machine agent to call kexec to switch boot environments
+  as long as the machine is currently running Linux, and the new
+  environment has a template named 'kexec' that contains the
+  kernel, initrds, and command line to use.
+Schema:
+  type: boolean
+  default: false
+Meta:
+  icon: "bolt"
+  color: "yellow"
+  title: "Digital Rebar Community Content"

--- a/content/params/last-boot-macaddr.yaml
+++ b/content/params/last-boot-macaddr.yaml
@@ -1,0 +1,8 @@
+---
+Name: last-boot-macaddr
+Description: "The MAC address the system most recently used to PXE boot"
+Documentation: |
+  Keeps track of the MAC address (in PXELINUX format) that the system
+  most recently PXE booted from.
+Schema:
+  type: string

--- a/content/templates/kexec.tmpl
+++ b/content/templates/kexec.tmpl
@@ -1,0 +1,5 @@
+kernel {{.Env.PathFor "http" .Env.Kernel}}
+{{range $initrd := .Env.Initrds}}
+initrd {{$.Env.PathFor "http" $initrd}}
+{{end}}
+params {{.BootParams}}

--- a/contrib/bootenvs/centos-6.9.yml
+++ b/contrib/bootenvs/centos-6.9.yml
@@ -22,6 +22,9 @@ OptionalParams:
   - "proxy-servers"
   - "kernel-console"
 Templates:
+  - Name: "kexec"
+    ID: "kexec.tmpl"
+    Path: "{{.Machine.Path}}/kexec"
   - ID: "default-pxelinux.tmpl"
     Name: "pxelinux"
     Path: "pxelinux.cfg/{{.Machine.HexAddress}}"

--- a/contrib/bootenvs/centos-6.yml
+++ b/contrib/bootenvs/centos-6.yml
@@ -22,6 +22,9 @@ OptionalParams:
   - "proxy-servers"
   - "kernel-console"
 Templates:
+  - Name: "kexec"
+    ID: "kexec.tmpl"
+    Path: "{{.Machine.Path}}/kexec"
   - ID: "default-pxelinux.tmpl"
     Name: "pxelinux"
     Path: "pxelinux.cfg/{{.Machine.HexAddress}}"

--- a/contrib/bootenvs/ubuntu-14.04.yml
+++ b/contrib/bootenvs/ubuntu-14.04.yml
@@ -40,6 +40,9 @@ OptionalParams:
   - "ntp-servers"
   - "select-kickseed"
 Templates:
+  - Name: "kexec"
+    ID: "kexec.tmpl"
+    Path: "{{.Machine.Path}}/kexec"
   - ID: "default-pxelinux.tmpl"
     Name: "pxelinux"
     Path: "pxelinux.cfg/{{.Machine.HexAddress}}"


### PR DESCRIPTION
This adds support to Sledgehammer and the OS install bootenvs to
allow the Agent to kexec into them instead of rebooting into them.