### PR TITLE
Helm Install with Advanced Directives

### DIFF
--- a/krib/params/helm-charts-advanced.yaml
+++ b/krib/params/helm-charts-advanced.yaml
@@ -15,14 +15,12 @@ Documentation: |
         {
           "targz": "https://github.com/istio/istio/releases/download/1.0.1/istio-1.0.1-linux.tar.gz",
           "chart": "istio-1.0.1/install/kubernetes/helm/istio",
+          "name": "istio",
+          "namespace": "istio-system",
           "params": {
-            "name": "istio",
-            "namespace": "istio-system",
             "set": "sidecarInjectorWebhook.enabled=true"
           },
           "sleep": 10,
-          "waitname": "istio",
-          "waitnamespace": "istio-system",
           "kubectlbefore": ["get nodes"],
           "kubectlafter": ["get nodes"]
         }
@@ -35,20 +33,21 @@ Schema:
     type: "object"
     required:
       - "chart"
+      - "name"
     properties:
       targz:
         type: "string"
       chart:
         type: "string"
+      name:
+        type: "string"
+      namespace:
+        type: "string"
       params:
         type: "object"
         default: {}
         properties:
-          name:
-            type: "string"
           repo:
-            type: "string"
-          namespace:
             type: "string"
           values:
             type: "string"

--- a/krib/params/helm-charts-advanced.yaml
+++ b/krib/params/helm-charts-advanced.yaml
@@ -13,17 +13,16 @@ Documentation: |
 
       [
         {
-          "chart": "install/kubernetes/helm/istio",
+          "targz": "https://github.com/istio/istio/releases/download/1.0.1/istio-1.0.1-linux.tar.gz",
+          "chart": "istio-1.0.1/install/kubernetes/helm/istio",
           "params": {
             "name": "istio",
             "namespace": "istio-system",
             "set": "sidecarInjectorWebhook.enabled=true"
           },
           "sleep": 10,
-          "wait": [
-            "name",
-            "namespace"
-          ],
+          "waitname": "istio",
+          "waitnamespace": "istio-system",
           "kubectlbefore": ["get nodes"],
           "kubectlafter": ["get nodes"]
         }
@@ -37,6 +36,8 @@ Schema:
     required:
       - "chart"
     properties:
+      targz:
+        type: "string"
       chart:
         type: "string"
       params:
@@ -56,11 +57,10 @@ Schema:
       sleep:
         type: "integer"
         default: 10
-      wait:
-        type: "array"
-        default: []
-        items:
-          type: "string"
+      waitname:
+        type: "string"
+      waitnamespace:
+        type: "string"
       kubectlbefore:
         type: "array"
         default: []

--- a/krib/params/helm-charts-advanced.yaml
+++ b/krib/params/helm-charts-advanced.yaml
@@ -24,8 +24,8 @@ Documentation: |
             "name",
             "namespace"
           ],
-          "kubectl-before": ["get nodes"],
-          "kubectl-after": ["get nodes"]
+          "kubectlbefore": ["get nodes"],
+          "kubectlafter": ["get nodes"]
         }
       ]
 
@@ -61,12 +61,12 @@ Schema:
         default: []
         items:
           type: "string"
-      kubectl-before:
+      kubectlbefore:
         type: "array"
         default: []
         items:
           type: "string"
-      kubectl-after:
+      kubectlafter:
         type: "array"
         default: []
         items:

--- a/krib/params/helm-charts-advanced.yaml
+++ b/krib/params/helm-charts-advanced.yaml
@@ -1,7 +1,9 @@
 ---
-Name: "helm/directives"
-Description: "Hash providing additional Helm install directives"
+Name: "helm/charts-advanced"
+Description: "Advanced Install for Helm Charts"
 Documentation: |
+  List charts to install via Helm
+
   Used to inject additional control flags into helm install instructions
   including name, namespace, wait (for service up), and extra kubectl commands
 
@@ -9,8 +11,9 @@ Documentation: |
 
     ::
 
-      { "istio":
+      [
         {
+          "chart": "install/kubernetes/helm/istio",
           "params": {
             "name": "istio",
             "namespace": "istio-system",
@@ -21,17 +24,21 @@ Documentation: |
             "name",
             "namespace"
           ],
-          "kubectl-before": [],
-          "kubectl-after": []
+          "kubectl-before": ["get nodes"],
+          "kubectl-after": ["get nodes"]
         }
-      }    
+      ]
 
 Schema:
-  type: "object"
-  properties:
+  type: "array"
+  default: []
+  items:
     type: "object"
-    default: {}
+    required:
+      - "chart"
     properties:
+      chart:
+        type: "string"
       params:
         type: "object"
         default: {}
@@ -66,5 +73,5 @@ Schema:
           type: "string"
 Meta:
   color: "blue"
-  icon: "tags"
+  icon: "map"
   title: "Community Content"

--- a/krib/params/helm-charts-advanced.yaml
+++ b/krib/params/helm-charts-advanced.yaml
@@ -5,7 +5,11 @@ Documentation: |
   List charts to install via Helm
 
   Used to inject additional control flags into helm install instructions
-  including name, namespace, wait (for service up), and extra kubectl commands
+  including name, namespace, waits for name and namespace, allows pre and post kubectl commands
+
+  chart and name are required.
+
+  targz should be used if the chart is provided from a URL.  Path is relative.
 
   example: 
 
@@ -13,9 +17,9 @@ Documentation: |
 
       [
         {
-          "targz": "https://github.com/istio/istio/releases/download/1.0.1/istio-1.0.1-linux.tar.gz",
           "chart": "istio-1.0.1/install/kubernetes/helm/istio",
           "name": "istio",
+          "targz": "https://github.com/istio/istio/releases/download/1.0.1/istio-1.0.1-linux.tar.gz",
           "namespace": "istio-system",
           "params": {
             "set": "sidecarInjectorWebhook.enabled=true"
@@ -56,10 +60,8 @@ Schema:
       sleep:
         type: "integer"
         default: 10
-      waitname:
-        type: "string"
-      waitnamespace:
-        type: "string"
+      wait:
+        type: "boolean"
       kubectlbefore:
         type: "array"
         default: []

--- a/krib/params/helm-charts.yaml
+++ b/krib/params/helm-charts.yaml
@@ -5,7 +5,9 @@ Documentation: |
   Allows operators to install Charts using Helm stage
   For example, using ["stable/mysql"] will install mysql.
 
-  For advanced control of charts, use helm/charts-advanced!
+  WARNING: THIS QUICK APPROACH IS NOT IDEPOTENT!
+
+  For advanced & idepotent control of charts, use helm/charts-advanced!
 
 Schema:
   type: "array"

--- a/krib/params/helm-charts.yaml
+++ b/krib/params/helm-charts.yaml
@@ -1,9 +1,12 @@
 ---
 Name: "helm/charts"
-Description: "List charts to run on cluster"
+Description: "List basic charts to run on cluster"
 Documentation: |
   Allows operators to install Charts using Helm stage
   For example, using ["stable/mysql"] will install mysql.
+
+  For advanced control of charts, use helm/charts-advanced!
+
 Schema:
   type: "array"
   items:

--- a/krib/params/helm-directives.yaml
+++ b/krib/params/helm-directives.yaml
@@ -1,0 +1,20 @@
+---
+Name: "krib/directives"
+Description: "Hash providing additional Helm install directives"
+Documentation: |
+  Used to inject additional control flags into helm install instructions
+  including namespace, wait for up, and extra kubectl commands
+
+  NOTES:
+  * Use krib/label-env to set the env label!
+  * Use inventory/data to set physical characteristics
+Schema:
+  type: "object"
+  items:
+    type: "string"
+  default:
+    builder: "krib"
+  Meta:
+  color: "blue"
+  icon: "tags"
+  title: "Community Content"

--- a/krib/params/helm-directives.yaml
+++ b/krib/params/helm-directives.yaml
@@ -9,56 +9,61 @@ Documentation: |
 
     ::
 
-      {
-        "params": {
-          "name": "istio",
-          "namespace": "istio-system",
-          "set": "sidecarInjectorWebhook.enabled=true"
-        },
-        "sleep": 10,
-        "wait": [
-          "name",
-          "namespace"
-        ],
-        "kubectl-before": [],
-        "kubectl-after": []
+      { "istio":
+        {
+          "params": {
+            "name": "istio",
+            "namespace": "istio-system",
+            "set": "sidecarInjectorWebhook.enabled=true"
+          },
+          "sleep": 10,
+          "wait": [
+            "name",
+            "namespace"
+          ],
+          "kubectl-before": [],
+          "kubectl-after": []
+        }
       }    
 
 Schema:
   type: "object"
   properties:
-    params:
-      type: "object"
-      properties:
-        name:
+    type: "object"
+    default: {}
+    properties:
+      params:
+        type: "object"
+        default: {}
+        properties:
+          name:
+            type: "string"
+          repo:
+            type: "string"
+          namespace:
+            type: "string"
+          values:
+            type: "string"
+          set:
+            type: "string"
+      sleep:
+        type: "integer"
+        default: 10
+      wait:
+        type: "array"
+        default: []
+        items:
           type: "string"
-        repo:
+      kubectl-before:
+        type: "array"
+        default: []
+        items:
           type: "string"
-        namespace:
+      kubectl-after:
+        type: "array"
+        default: []
+        items:
           type: "string"
-        values:
-          type: "string"
-        set:
-          type: "string"
-      default: {}
-    sleep:
-      type: "integer"
-      default: 10
-    wait:
-      type: "array"
-      items:
-        type: "string"
-      default: []
-    kubectl-before:
-      type: "array"
-      items:
-        type: "string"
-      default: []
-    kubectl-after:
-      type: "array"
-      items:
-        type: "string"
-      default: []
 Meta:
   color: "blue"
   icon: "tags"

--- a/krib/params/helm-directives.yaml
+++ b/krib/params/helm-directives.yaml
@@ -1,20 +1,65 @@
 ---
-Name: "krib/directives"
+Name: "helm/directives"
 Description: "Hash providing additional Helm install directives"
 Documentation: |
   Used to inject additional control flags into helm install instructions
-  including namespace, wait for up, and extra kubectl commands
+  including name, namespace, wait (for service up), and extra kubectl commands
 
-  NOTES:
-  * Use krib/label-env to set the env label!
-  * Use inventory/data to set physical characteristics
+  example: 
+
+    ::
+
+      {
+        "params": {
+          "name": "istio",
+          "namespace": "istio-system",
+          "set": "sidecarInjectorWebhook.enabled=true"
+        },
+        "sleep": 10,
+        "wait": [
+          "name",
+          "namespace"
+        ],
+        "kubectl-before": [],
+        "kubectl-after": []
+      }    
+
 Schema:
   type: "object"
-  items:
-    type: "string"
-  default:
-    builder: "krib"
-  Meta:
+  properties:
+    params:
+      type: "object"
+      properties:
+        name:
+          type: "string"
+        repo:
+          type: "string"
+        namespace:
+          type: "string"
+        values:
+          type: "string"
+        set:
+          type: "string"
+      default: {}
+    sleep:
+      type: "integer"
+      default: 10
+    wait:
+      type: "array"
+      items:
+        type: "string"
+      default: []
+    kubectl-before:
+      type: "array"
+      items:
+        type: "string"
+      default: []
+    kubectl-after:
+      type: "array"
+      items:
+        type: "string"
+      default: []
+Meta:
   color: "blue"
   icon: "tags"
   title: "Community Content"

--- a/krib/profiles/krib-istio-reference.yaml
+++ b/krib/profiles/krib-istio-reference.yaml
@@ -13,10 +13,8 @@ Meta:
   render: krib
   reset-keeps: "krib/cluster-profile,etcd/cluster-profile"
 Params:
-  helm/charts: 
-    - install/kubernetes/helm/istio
-  helm/directives:
-    "install/kubernetes/helm/istio":
+  helm/charts-advanced:
+    - chart: "install/kubernetes/helm/istio"
       params:
         name: "istio"
         namespace: "istio-system"

--- a/krib/profiles/krib-istio-reference.yaml
+++ b/krib/profiles/krib-istio-reference.yaml
@@ -23,7 +23,3 @@ Params:
       wait:
         - "name"
         - "namespace"
-      kubectl-before:
-        - "get nodes"
-      kubectl-after:
-        - "get nodes"

--- a/krib/profiles/krib-istio-reference.yaml
+++ b/krib/profiles/krib-istio-reference.yaml
@@ -1,0 +1,30 @@
+---
+Name: krib-istio-reference
+Description: Reference Istio Helm Profiles
+Documentation: |
+  To be included in Helm-Istio Stage
+  Preforms a typical Istio install via Helm
+  
+  Note: Clone for custom installers
+Meta:
+  color: blue
+  icon: grid layout
+  title: Community Content
+  render: krib
+  reset-keeps: "krib/cluster-profile,etcd/cluster-profile"
+Params:
+  helm/charts: 
+    - install/kubernetes/helm/istio
+  helm/directives: 
+    params:
+      name: "istio"
+      namespace: "istio-system"
+      set: "sidecarInjectorWebhook.enabled=true"
+    sleep: 10
+    wait:
+      - "name"
+      - "namespace"
+    kubectl-before:
+      - "get nodes"
+    kubectl-after:
+      - "get nodes"

--- a/krib/profiles/krib-istio-reference.yaml
+++ b/krib/profiles/krib-istio-reference.yaml
@@ -14,12 +14,12 @@ Meta:
   reset-keeps: "krib/cluster-profile,etcd/cluster-profile"
 Params:
   helm/charts-advanced:
-    - chart: "install/kubernetes/helm/istio"
+    - chart: istio-1.0.1/install/kubernetes/helm/istio
+      targz: https://github.com/istio/istio/releases/download/1.0.1/istio-1.0.1-linux.tar.gz
       params:
         name: "istio"
         namespace: "istio-system"
         set: "sidecarInjectorWebhook.enabled=true"
       sleep: 10
-      wait:
-        - "name"
-        - "namespace"
+      waitname: "istio"
+      waitnamespace: "istio-system"

--- a/krib/profiles/krib-istio-reference.yaml
+++ b/krib/profiles/krib-istio-reference.yaml
@@ -15,16 +15,17 @@ Meta:
 Params:
   helm/charts: 
     - install/kubernetes/helm/istio
-  helm/directives: 
-    params:
-      name: "istio"
-      namespace: "istio-system"
-      set: "sidecarInjectorWebhook.enabled=true"
-    sleep: 10
-    wait:
-      - "name"
-      - "namespace"
-    kubectl-before:
-      - "get nodes"
-    kubectl-after:
-      - "get nodes"
+  helm/directives:
+    "install/kubernetes/helm/istio":
+      params:
+        name: "istio"
+        namespace: "istio-system"
+        set: "sidecarInjectorWebhook.enabled=true"
+      sleep: 10
+      wait:
+        - "name"
+        - "namespace"
+      kubectl-before:
+        - "get nodes"
+      kubectl-after:
+        - "get nodes"

--- a/krib/profiles/krib-istio-reference.yaml
+++ b/krib/profiles/krib-istio-reference.yaml
@@ -15,11 +15,8 @@ Meta:
 Params:
   helm/charts-advanced:
     - chart: istio-1.0.1/install/kubernetes/helm/istio
+      name: "istio"
       targz: https://github.com/istio/istio/releases/download/1.0.1/istio-1.0.1-linux.tar.gz
+      namespace: "istio-system"
       params:
-        name: "istio"
-        namespace: "istio-system"
         set: "sidecarInjectorWebhook.enabled=true"
-      sleep: 10
-      waitname: "istio"
-      waitnamespace: "istio-system"

--- a/krib/templates/krib-helm-init.sh.tmpl
+++ b/krib/templates/krib-helm-init.sh.tmpl
@@ -58,9 +58,9 @@ if [[ $MASTER_INDEX != notme ]] ; then
     done
     set -e
 
-    echo "Check versions....(includes 5 second wait for Tiller initialize)"
+    echo "Check versions....(includes 10 second wait for Tiller initialize)"
     # we need some extra time for Tiller to actually initialize
-    sleep 5
+    sleep 10
     helm version
     rm ./get_helm.sh
 

--- a/krib/templates/krib-helm.sh.tmpl
+++ b/krib/templates/krib-helm.sh.tmpl
@@ -34,14 +34,35 @@ if [[ $MASTER_INDEX != notme ]] ; then
     fi
 
     echo "Getting Latest Repos"
+    helm init --client-only
     helm repo update
 
-    echo "Running Helm Install for all helm/charts"
+    echo "Running Simple Helm Install for all helm/charts"
     {{range $index, $chart := .Param "helm/charts"}}
       echo "...installing {{$chart}}"
       helm install {{$chart}}
+      sleep 10
     {{else}}
       echo "No charts included in helm/charts to install"
+    {{end}}
+
+    echo "Running Advanced Helm Install for all helm/charts-advanced"
+    {{range $index, $chart := .Param "helm/charts-advanced"}}
+      echo "...installing {{$chart.chart}} (ADVANCED INSTALL)"
+
+      {{range $index, $before := $chart.kubectlbefore}}
+        kubectl {{$before}}
+      {{end}}
+
+      helm install {{$chart.chart}} {{range $param, $value := $chart.params}}--{{$param}} {{$value}} {{end}}
+      sleep {{$chart.sleep}}
+
+      {{range $index, $after := $chart.kubectlafter}}
+        kubectl {{$after}}
+      {{end}}
+
+    {{else}}
+      echo "No charts included in helm/charts-advanced to install"
     {{end}}
 
   else

--- a/krib/templates/krib-helm.sh.tmpl
+++ b/krib/templates/krib-helm.sh.tmpl
@@ -54,16 +54,18 @@ if [[ $MASTER_INDEX != notme ]] ; then
       curl -L "{{$chart.targz}}" | tar xz
       {{end}}
 
-      helm install {{$chart.chart}} {{range $param, $value := $chart.params}}--{{$param}} {{$value}} {{end}}
+      helm install {{$chart.chart}} --name {{$chart.name}} \
+        {{if $chart.namespace}} --namespace {{$chart.namespace}}{{end}} \
+        {{range $param, $value := $chart.params}} --{{$param}} {{$value}}{{end}}
       sleep {{$chart.sleep}}
 
-      {{if $chart.waitname}}
-      echo "waiting for {{$chart.waitname}}"
+      {{if $chart.name}}
+      echo "waiting for {{$chart.name}}"
       sleep {{$chart.sleep}}
       {{end}}
 
-      {{if $chart.waitnamespace}}
-      echo "waiting for {{$chart.waitnamespace}}"
+      {{if $chart.namespace}}
+      echo "waiting for {{$chart.namespace}}"
       sleep {{$chart.sleep}}
       {{end}}
 
@@ -75,7 +77,6 @@ if [[ $MASTER_INDEX != notme ]] ; then
       echo "No charts included in helm/charts-advanced to install"
     {{end}}
 
-    exit 1
   else
 
     echo "I was not the leader, skipping helm install"

--- a/krib/templates/krib-helm.sh.tmpl
+++ b/krib/templates/krib-helm.sh.tmpl
@@ -46,32 +46,52 @@ if [[ $MASTER_INDEX != notme ]] ; then
     {{range $index, $chart := .Param "helm/charts-advanced"}}
       echo "...installing {{$chart.chart}} (ADVANCED INSTALL)"
 
-      {{range $index, $before := $chart.kubectlbefore}}
-      kubectl {{$before}}
-      {{end}}
+      if [[ -z $(helm list {{$chart.name}}) ]] ; then
 
-      {{if $chart.targz}}
-      curl -L "{{$chart.targz}}" | tar xz
-      {{end}}
+        {{range $index, $before := $chart.kubectlbefore}}
+        kubectl {{$before}}
+        {{end}}
 
-      helm install {{$chart.chart}} --name {{$chart.name}} \
-        {{if $chart.namespace}} --namespace {{$chart.namespace}}{{end}} \
-        {{range $param, $value := $chart.params}} --{{$param}} {{$value}}{{end}}
-      sleep {{$chart.sleep}}
+        {{if $chart.targz}}
+        curl -L "{{$chart.targz}}" | tar xz
+        {{end}}
 
-      {{if $chart.name}}
-      echo "waiting for {{$chart.name}}"
-      sleep {{$chart.sleep}}
-      {{end}}
+        helm install {{$chart.chart}} --name {{$chart.name}} \
+          {{if $chart.namespace}} --namespace {{$chart.namespace}}{{end}} \
+          {{range $param, $value := $chart.params}} --{{$param}} {{$value}}{{end}}
 
-      {{if $chart.namespace}}
-      echo "waiting for {{$chart.namespace}}"
-      sleep {{$chart.sleep}}
-      {{end}}
+        {{if $chart.sleep}}
+          echo "sleep {{$chart.sleep}}"
+          sleep {{$chart.sleep}}
+        {{else}}
+          sleep 10s
+        {{end}}
 
-      {{range $index, $after := $chart.kubectlafter}}
-      kubectl {{$after}}
-      {{end}}
+        {{if $chart.name}}
+          echo "FUTURE waiting for {{$chart.name}}"
+          {{if $chart.sleep}}
+            sleep {{$chart.sleep}}
+          {{else}}
+            sleep 10
+          {{end}}
+        {{end}}
+
+        {{if $chart.namespace}}
+          echo "FUTURE waiting for {{$chart.namespace}}"
+          {{if $chart.sleep}}
+            sleep {{$chart.sleep}}
+          {{else}}
+            sleep 10
+          {{end}}
+        {{end}}
+
+        {{range $index, $after := $chart.kubectlafter}}
+        kubectl {{$after}}
+        {{end}}
+
+      else
+        echo "skipping {{$chart.name}}.  It is already installed"
+      fi
 
     {{else}}
       echo "No charts included in helm/charts-advanced to install"

--- a/krib/templates/krib-helm.sh.tmpl
+++ b/krib/templates/krib-helm.sh.tmpl
@@ -33,10 +33,6 @@ if [[ $MASTER_INDEX != notme ]] ; then
       exit 1
     fi
 
-    echo "Getting Latest Repos"
-    helm init --client-only
-    helm repo update
-
     echo "Running Simple Helm Install for all helm/charts"
     {{range $index, $chart := .Param "helm/charts"}}
       echo "...installing {{$chart}}"
@@ -51,20 +47,35 @@ if [[ $MASTER_INDEX != notme ]] ; then
       echo "...installing {{$chart.chart}} (ADVANCED INSTALL)"
 
       {{range $index, $before := $chart.kubectlbefore}}
-        kubectl {{$before}}
+      kubectl {{$before}}
+      {{end}}
+
+      {{if $chart.targz}}
+      curl -L "{{$chart.targz}}" | tar xz
       {{end}}
 
       helm install {{$chart.chart}} {{range $param, $value := $chart.params}}--{{$param}} {{$value}} {{end}}
       sleep {{$chart.sleep}}
 
+      {{if $chart.waitname}}
+      echo "waiting for {{$chart.waitname}}"
+      sleep {{$chart.sleep}}
+      {{end}}
+
+      {{if $chart.waitnamespace}}
+      echo "waiting for {{$chart.waitnamespace}}"
+      sleep {{$chart.sleep}}
+      {{end}}
+
       {{range $index, $after := $chart.kubectlafter}}
-        kubectl {{$after}}
+      kubectl {{$after}}
       {{end}}
 
     {{else}}
       echo "No charts included in helm/charts-advanced to install"
     {{end}}
 
+    exit 1
   else
 
     echo "I was not the leader, skipping helm install"

--- a/krib/templates/krib-kubeadm.cfg.tmpl
+++ b/krib/templates/krib-kubeadm.cfg.tmpl
@@ -35,7 +35,7 @@ etcd:
     keyFile: /etc/kubernetes/pki/etcd/client-key.pem
     endpoints:
 {{ $port := .Param "etcd/client-port" -}}
-{{ range $elem := .Param "etcd/servers" -}}
+{{ range $elem := .Param "etcd/servers"}}
     - https://{{ $elem.Address }}:{{ $port }}
 {{ end -}}
 kubeProxy:


### PR DESCRIPTION
This update creates advanced options for helm install that include pre and post actions, namespace and names.  This is parallel to the basic charts and is much better than the very simple helm/charts array.

The example includes an istio install chart.

TODO: charts should wait to make sure they are running before moving to the next.

Also fixes config bug.