### PR TITLE
Update Helm Stage with features that enable Rook install

### DIFF
--- a/krib/params/helm-charts.yaml
+++ b/krib/params/helm-charts.yaml
@@ -24,7 +24,7 @@ Documentation: |
   * prekubectl (optional) array of kubectl [request] commands to run before the helm install
   * postkubectl (optional) array of kubectl [request] commands to run after the helm install
   * targz (optional) provides a location for a tar.gz file containing charts to install. Path is relative.
-  * templates (optional) list of DRP templates (must be uploaded!) to render before doing other work.
+  * templates (optional) map of DRP templates keyed to the desired names (must be uploaded!) to render before doing other work.
   * repo (optional) adds the requested repo to the helm using `helm repo add` before installing helm.  syntax is `[repo name] [repo path]`.
 
   example:
@@ -67,6 +67,8 @@ Schema:
         type: "string"
       namespace:
         type: "string"
+      repo:
+        type: "string"
       params:
         type: "object"
         default: {}
@@ -83,6 +85,8 @@ Schema:
       wait:
         type: "boolean"
         default: false
+      templates:
+        type: object
       kubectlbefore:
         type: "array"
         default: []

--- a/krib/params/helm-charts.yaml
+++ b/krib/params/helm-charts.yaml
@@ -24,6 +24,8 @@ Documentation: |
   * prekubectl (optional) array of kubectl [request] commands to run before the helm install
   * postkubectl (optional) array of kubectl [request] commands to run after the helm install
   * targz (optional) provides a location for a tar.gz file containing charts to install. Path is relative.
+  * templates (optional) list of DRP templates (must be uploaded!) to render before doing other work.
+  * repo (optional) adds the requested repo to the helm using `helm repo add` before installing helm.  syntax is `[repo name] [repo path]`.
 
   example:
 

--- a/krib/params/rook-data-dir-host-path.yaml
+++ b/krib/params/rook-data-dir-host-path.yaml
@@ -1,0 +1,17 @@
+---
+Name: "rook/data-dir-host-path"
+Description: "Location of Ceph Storage"
+Documentation: |
+  This should be set to match the desired location
+  for Ceph storage.
+
+  Default: /docker
+
+  In future versions, this should be calculated or inferred based on the system inventory
+Schema:
+  type: "string"
+  default: "/docker"
+Meta:
+  color: "blue"
+  icon: "chess rock"
+  title: "Community Content"

--- a/krib/profiles/helm-reference.yaml
+++ b/krib/profiles/helm-reference.yaml
@@ -1,6 +1,6 @@
 ---
-Name: krib-istio-reference
-Description: Reference Istio Helm Profiles
+Name: helm-reference
+Description: Reference Helm Profiles (Istio, Rook, etc)
 Documentation: |
   DO NOT USE THIS PROFILE!
   Copy the contents of the helm/charts param into the Cluster!
@@ -19,8 +19,12 @@ Params:
       wait: true
       params:
         set: "sidecarInjectorWebhook.enabled=true"
-    - chart: "rook-beta/rook-ceph"
+    - chart: "rook-ceph"
       name: "rook-ceph"
       namespace: "rook-ceph-system"
-      repo: "rook-beta https://charts.rook.io/beta"
       wait: true
+      targz: "https://charts.rook.io/beta/rook-ceph-v0.8.1.tgz"
+      templates:
+        cluster: helm-rook.cfg.tmpl
+      kubectlafter:
+        - "create -f cluster.yaml"

--- a/krib/profiles/helm-reference.yaml
+++ b/krib/profiles/helm-reference.yaml
@@ -10,10 +10,17 @@ Meta:
   title: Community Content
 Params:
   helm/charts:
-    - chart: istio-1.0.1/install/kubernetes/helm/istio
+    - chart: "stable/mysql"
+      name: "mysql"
+    - chart: "istio-1.0.1/install/kubernetes/helm/istio"
       name: "istio"
       targz: https://github.com/istio/istio/releases/download/1.0.1/istio-1.0.1-linux.tar.gz
       namespace: "istio-system"
       wait: true
       params:
         set: "sidecarInjectorWebhook.enabled=true"
+    - chart: "rook-beta/rook-ceph"
+      name: "rook-ceph"
+      namespace: "rook-ceph-system"
+      repo: "rook-beta https://charts.rook.io/beta"
+      wait: true

--- a/krib/templates/helm-rook.cfg.tmpl
+++ b/krib/templates/helm-rook.cfg.tmpl
@@ -1,0 +1,72 @@
+# Rook Yaml - See https://rook.io/docs/rook/master/ceph-quickstart.html
+# This example first defines some necessary namespace and RBAC security objects.
+# The actual Ceph Cluster CRD example can be found at the bottom of this example.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rook-ceph
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rook-ceph-cluster
+  namespace: rook-ceph
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-cluster
+  namespace: rook-ceph
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: [ "get", "list", "watch", "create", "update", "delete" ]
+---
+# Allow the operator to create resources in this cluster's namespace
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-cluster-mgmt
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-cluster-mgmt
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-system
+  namespace: rook-ceph-system
+---
+# Allow the pods in this namespace to work with configmaps
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-cluster
+  namespace: rook-ceph
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-cluster
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-cluster
+  namespace: rook-ceph
+---
+#################################################################################
+# The Ceph Cluster CRD example
+#################################################################################
+apiVersion: ceph.rook.io/v1beta1
+kind: Cluster
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph
+spec:
+  dataDirHostPath: {{.Param "rook/data-dir-host-path"}}
+  dashboard:
+    enabled: true
+  storage:
+    useAllNodes: true
+    useAllDevices: false
+    config:
+      databaseSizeMB: "1024"
+      journalSizeMB: "1024"

--- a/krib/templates/krib-helm.sh.tmpl
+++ b/krib/templates/krib-helm.sh.tmpl
@@ -44,7 +44,13 @@ if [[ $MASTER_INDEX != notme ]] ; then
         {{end}}
 
         {{if $chart.targz}}
+        echo "retrieving chart from {{$chart.targz}}"
         curl -L "{{$chart.targz}}" | tar xz
+        {{end}}
+
+        {{if $chart.repo}}
+        echo "adding chart repo {{$chart.repo}}"
+        helm repo add {{$chart.repo}}
         {{end}}
 
         helm install {{$chart.chart}} --name {{$chart.name}} \

--- a/krib/templates/krib-helm.sh.tmpl
+++ b/krib/templates/krib-helm.sh.tmpl
@@ -34,12 +34,21 @@ if [[ $MASTER_INDEX != notme ]] ; then
     fi
 
     echo "Running Helm Install for all helm/charts"
+    {{$render := .}}
     {{range $index, $chart := .Param "helm/charts"}}
       echo "Installing {{$chart.name}} (from {{$chart.chart}})..."
 
       if [[ -z $(helm list {{$chart.name}}) ]] ; then
 
+        {{ range $name, $template := $chart.templates }}
+        echo "expanding template {{$template}} as {{$name}}.yaml"
+        cat > {{$name}}.yaml << EOF
+{{ $render.CallTemplate $template $render }}
+EOF
+        {{end}}
+
         {{range $index, $before := $chart.kubectlbefore}}
+        echo "running kubectl {{$before}} ({{$index}})"
         kubectl {{$before}}
         {{end}}
 
@@ -51,6 +60,7 @@ if [[ $MASTER_INDEX != notme ]] ; then
         {{if $chart.repo}}
         echo "adding chart repo {{$chart.repo}}"
         helm repo add {{$chart.repo}}
+        helm init
         {{end}}
 
         helm install {{$chart.chart}} --name {{$chart.name}} \
@@ -97,6 +107,7 @@ if [[ $MASTER_INDEX != notme ]] ; then
         {{end}}
 
         {{range $index, $after := $chart.kubectlafter}}
+        echo "running kubectl {{$after}} ({{$index}})"
         kubectl {{$after}}
         {{end}}
 


### PR DESCRIPTION
The Rook install needs a Helm Chart AND a kubectl from a template.  These small addition allows rendering templates BEFORE running Helm.  These templates can then be used by helm or kubectl.

In the Rook example, we use the rook operator chart and then build the cluster.yaml needed by rook.  The rook yaml REQUIRES an injected parameter.

This pattern is very powerful for testing advanced helm charts where we want to inject parameters.

Ultimately, we'll want a rook stage.  This improves helm while we are iterating.