### PR TITLE
Allow sledgehammer to not always reset the workflow/tasks index

### DIFF
--- a/content/params/start-over.yaml
+++ b/content/params/start-over.yaml
@@ -1,0 +1,16 @@
+---
+Name: start-over
+Description: "Tells sledgehammer to reset the task list on startup."
+Documentation: |
+  Allows the operator to control if booting into sledgehammer should
+  reset the task list on boot up.  This allows things like
+  bios update scripts to set the start-over flag to false and
+  issue a reboot command and start over either at the
+  current task or the next one.
+Schema:
+  type: boolean
+  default: true
+Meta:
+  icon: "repeat"
+  color: "yellow"
+  title: "Digital Rebar Community Content"

--- a/content/templates/reset-workflow.tmpl
+++ b/content/templates/reset-workflow.tmpl
@@ -4,6 +4,12 @@
 
 # One day Reset the workflow chain here as well
 
-# Reset the current task list and mark the machine runnable.
-drpcli machines update "{{.Machine.UUID}}" '{ "Runnable": true, "CurrentTask": -1 }'
-
+v=$(drpcli machines get "{{.Machine.UUID}}" param "start-over" --aggregate | jq -r .)
+if [[ "$v" == "false" ]] ; then
+    # Reset the current task list and mark the machine runnable.
+    drpcli machines remove "{{.Machine.UUID}}" param "start-over" 2>/dev/null >/dev/null || true
+    drpcli machines update "{{.Machine.UUID}}" '{ "Runnable": true }'
+else
+    # Reset the current task list and mark the machine runnable.
+    drpcli machines update "{{.Machine.UUID}}" '{ "Runnable": true, "CurrentTask": -1 }'
+fi


### PR DESCRIPTION
on startup.  If start-over is set to false, leave the task list alone.
Otherwise, operate as normal.  This will also work for all bootenvs
that use reset-workflow template.

The start-over flag is removed from the machine if directly set upon it.
This allows for a one time effect.