### PR TITLE
add google discovery stage

### DIFF
--- a/content/stages/gce-discover.yaml
+++ b/content/stages/gce-discover.yaml
@@ -1,0 +1,12 @@
+---
+Name: "gce-discover"
+Description: "Stage to dynamically determine if machine is in GCE and record metadata"
+Documentation: |
+  Collect information about Google cloud
+RunnerWait: true
+Tasks:
+  - "gce-discover"
+Meta:
+  icon: "cloud"
+  color: "yellow"
+  title: "RackN Content"

--- a/content/tasks/gce-discover.yaml
+++ b/content/tasks/gce-discover.yaml
@@ -1,0 +1,44 @@
+---
+Name:  "gce-discover"
+Description: "A task to discover GCE metadata of a node automatically."
+Documentation: |
+  Collect information about Google cloud
+Templates:
+  - Name: "discover-gce-metadata"
+    Contents: |
+      #!/bin/bash
+
+      # This will contain a token appropriate for the path being
+      # used below.  Either a create or update/show token
+      export RS_UUID="{{.Machine.UUID}}"
+      export RS_TOKEN="{{.GenerateToken}}"
+
+      # Ubuntu Path is different than Centos Path - fix it.
+      export PATH=$PATH:/usr/bin:/usr/sbin:/bin:/sbin
+
+      INSTANCEID=$(curl -sfL -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/id)
+      echo "Looking for GCE Instance ID, found \"$INSTANCEID\""
+
+      if [[ $INSTANCEID != "" && $INSTANCEID != "null" ]] ; then
+          drpcli machines set $RS_UUID param cloud/provider to "GCE" 
+          drpcli machines set $RS_UUID param cloud/instance-id to "$INSTANCEID" 
+
+          value=$(curl -sfL -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/machine-type)
+          drpcli machines set $RS_UUID param cloud/instance-type to "$value" 
+
+          value=$(curl -sfL -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/zone)
+          drpcli machines set $RS_UUID param cloud/placement/availability-zone to "$value" 
+
+          value=$(curl -sfL -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
+          drpcli machines set $RS_UUID param cloud/public-ipv4 to "$value" 
+
+          unset value
+      else
+          echo "Could not find a GCE Instance ID - Skipping"
+      fi
+      exit 0
+Meta:
+  icon: "cloud"
+  color: "blue"
+  title: "RackN Content"
+  feature-flags: "sane-exit-codes"


### PR DESCRIPTION
Use the GCE metadata API to get special data about the instances.  Map to existing params.

GCE has more limited data than AWS.  I used the AWS vars because AWS.