### PR TITLE
tweak join-up script to check for existing from name 

### DIFF
--- a/content/bootenvs/discovery.yml
+++ b/content/bootenvs/discovery.yml
@@ -1,6 +1,15 @@
 ---
 Name: "discovery"
 Description: "The boot environment to use to have unknown machines boot to default Stage/BootEnv"
+Documentation: |
+  Normal option of this bootenv is to provision physical services using sledgehammer.
+
+  To join EXISTING machines or CLOUD machines into DRP, you can use run `join-up.sh`.
+  Add the following line to the machines initialization script:
+    ::
+
+      #!/bin/bash
+      curl -fsSL [internal ip]:8091/machines/join-up.sh | sudo bash --
 OnlyUnknown: true
 OS:
   Family: "redhat"
@@ -153,6 +162,9 @@ Templates:
       # See the License for the specific language governing permissions and
       # limitations under the License.
       #
+      # To use this script start your machine with:
+      #   #!/bin/bash
+      #   curl -fsSL [internal ip]:8091/machines/join-up.sh | sudo bash --
 
       export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 
@@ -195,35 +207,42 @@ Templates:
       set -x
 
       # Code assumes provider has set HOSTNAME correctly!!
-      # See if we have already been created based on dropping uuid file
-      if [[ -f /etc/rs-uuid ]]; then
-          RS_UUID="$(tail -n 1 /etc/rs-uuid)"
-          echo "Machine $HOSTNAME using UUID $RS_UUID based on /etc/rs-uuid file"
+      RS_UUID=$(drpcli machines show Name:$HOSTNAME | jq -r .Uuid)
+
+      if [[ -z $RS_UUID ]]; then
+        # See if we have already been created based on dropping uuid file
+        if [[ -f /etc/rs-uuid ]]; then
+            RS_UUID="$(tail -n 1 /etc/rs-uuid)"
+            echo "Machine $HOSTNAME using UUID $RS_UUID based on /etc/rs-uuid file"
+        else
+            echo "Machine UUID file not found.  Adding $HOSTNAME..."
+            IP=""
+            BOOTDEV="eth0"
+            bootdev_ip4_re='inet ([0-9.]+)/([0-9]+)'
+            bootdev_ip6_re='inet6 ([0-9a-fA-F:.]+)/([0-9]+) scope global'
+            if [[ $(ip -4 -o addr show dev $BOOTDEV) =~ $bootdev_ip4_re ]]; then
+                IP="${BASH_REMATCH[1]}"
+            else
+                if [[ $(ip -6 -o addr show dev $BOOTDEV) =~ $bootdev_ip6_re ]]; then
+                    IP="${BASH_REMATCH[1]}"
+                fi
+            fi
+            # Create a new node for us,
+            while ! JSON="$(drpcli machines create "{\"Name\": \"$HOSTNAME\",
+                                                 \"Address\": \"$IP\",
+                                                 \"Arch\": \"$ARCH\",
+                                                 \"Meta\": {\"icon\":\"cloud\"},
+                                                 \"HardwareAddrs\": $(get_macs)}")"; do
+                echo "We could not create a node for ourself, trying again."
+                sleep 5
+            done
+            RS_UUID="$(jq -r '.Uuid' <<< "$JSON")"
+            echo "${RS_UUID}" > /etc/rs-uuid
+            echo "Machine $HOSTNAME added with UUID $RS_UUID"
+        fi
       else
-          echo "Machine UUID file not found.  Adding $HOSTNAME..."
-          IP=""
-          BOOTDEV="eth0"
-          bootdev_ip4_re='inet ([0-9.]+)/([0-9]+)'
-          bootdev_ip6_re='inet6 ([0-9a-fA-F:.]+)/([0-9]+) scope global'
-          if [[ $(ip -4 -o addr show dev $BOOTDEV) =~ $bootdev_ip4_re ]]; then
-              IP="${BASH_REMATCH[1]}"
-          else
-              if [[ $(ip -6 -o addr show dev $BOOTDEV) =~ $bootdev_ip6_re ]]; then
-                  IP="${BASH_REMATCH[1]}"
-              fi
-          fi
-          # Create a new node for us,
-          while ! JSON="$(drpcli machines create "{\"Name\": \"$HOSTNAME\",
-                                               \"Address\": \"$IP\",
-                                               \"Arch\": \"$ARCH\",
-                                               \"Meta\": {\"icon\":\"cloud\"},
-                                               \"HardwareAddrs\": $(get_macs)}")"; do
-              echo "We could not create a node for ourself, trying again."
-              sleep 5
-          done
-          RS_UUID="$(jq -r '.Uuid' <<< "$JSON")"
-          echo "${RS_UUID}" > /etc/rs-uuid
-          echo "Machine $HOSTNAME added with UUID $RS_UUID"
+        echo "Machine $HOSTNAME found in DRPCLI! Using $RS_UUID"
+        echo "${RS_UUID}" > /etc/rs-uuid
       fi
 
       {{template "profile.tmpl" .}}


### PR DESCRIPTION
My first pass did not use the DRPCLI to confirm if the machine already existed and relied on the /etc/rs_uuid file.  This is not as reliable as actually checking on machine in the API (thanks @galthaus )

This pull fixes that and adds some docs for join-up users.

The rs_uuid file is maintained/created as a backup.  Most of the diff is from indents.

Tested on GCE and works.