### PR TITLE
Sledgehammer update for Centos 7.6 and new kernel params

### DIFF
--- a/content/bootenvs/discovery.yml
+++ b/content/bootenvs/discovery.yml
@@ -16,11 +16,11 @@ OS:
   Name: "sledgehammer"
   SupportedArchitectures:
     amd64:
-      IsoFile: "sledgehammer-fe5b0dc9c4a89c186d9827da6d045a58a8800a6b.amd64.tar"
-      IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/fe5b0dc9c4a89c186d9827da6d045a58a8800a6b/sledgehammer-fe5b0dc9c4a89c186d9827da6d045a58a8800a6b.amd64.tar"
-      Kernel: "fe5b0dc9c4a89c186d9827da6d045a58a8800a6b/vmlinuz0"
+      IsoFile: "sledgehammer-fb0acd4a69aaf525ad6c0c99c3f8630fef2fddc0.amd64.tar"
+      IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/fb0acd4a69aaf525ad6c0c99c3f8630fef2fddc0/sledgehammer-fb0acd4a69aaf525ad6c0c99c3f8630fef2fddc0.amd64.tar"
+      Kernel: "fb0acd4a69aaf525ad6c0c99c3f8630fef2fddc0/vmlinuz0"
       Initrds:
-        - "fe5b0dc9c4a89c186d9827da6d045a58a8800a6b/stage1.img"
+        - "fb0acd4a69aaf525ad6c0c99c3f8630fef2fddc0/stage1.img"
       BootParams: >-
         rootflags=loop
         root=live:/sledgehammer.iso

--- a/content/bootenvs/sledgehammer.yml
+++ b/content/bootenvs/sledgehammer.yml
@@ -9,11 +9,11 @@ OS:
   Name: "sledgehammer"
   SupportedArchitectures:
     amd64:
-      IsoFile: "sledgehammer-fe5b0dc9c4a89c186d9827da6d045a58a8800a6b.amd64.tar"
-      IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/fe5b0dc9c4a89c186d9827da6d045a58a8800a6b/sledgehammer-fe5b0dc9c4a89c186d9827da6d045a58a8800a6b.amd64.tar"
-      Kernel: "fe5b0dc9c4a89c186d9827da6d045a58a8800a6b/vmlinuz0"
+      IsoFile: "sledgehammer-fb0acd4a69aaf525ad6c0c99c3f8630fef2fddc0.amd64.tar"
+      IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/fb0acd4a69aaf525ad6c0c99c3f8630fef2fddc0/sledgehammer-fb0acd4a69aaf525ad6c0c99c3f8630fef2fddc0.amd64.tar"
+      Kernel: "fb0acd4a69aaf525ad6c0c99c3f8630fef2fddc0/vmlinuz0"
       Initrds:
-        - "fe5b0dc9c4a89c186d9827da6d045a58a8800a6b/stage1.img"
+        - "fb0acd4a69aaf525ad6c0c99c3f8630fef2fddc0/stage1.img"
       BootParams: >-
         rootflags=loop
         root=live:/sledgehammer.iso

--- a/content/params/package-repositories.yaml
+++ b/content/params/package-repositories.yaml
@@ -109,11 +109,11 @@ Schema:
       arch: aarch64
       url: http://mirror.centos.org/altarch/7/os/aarch64/
       installSource: true
-    - tag: centos-7.5.1804
+    - tag: centos-7.6.1810
       os:
-        - centos-7.5.1804
+        - centos-7.6.1810
       arch: x86_64
-      url: http://mirrors.edge.kernel.org/centos/7.5.1804/os/x86_64/
+      url: http://mirrors.edge.kernel.org/centos/7.6.1810/os/x86_64/
       installSource: true
     - tag: centos-7-everything
       os:
@@ -121,6 +121,7 @@ Schema:
         - centos-7.3.1611
         - centos-7.4.1708
         - centos-7.5.1804
+        - centos-7.6.1810
       arch: x86_64
       url: "http://mirrors.edge.kernel.org/centos"
       distribution: "7"
@@ -140,6 +141,7 @@ Schema:
         - centos-7.3.1611
         - centos-7.4.1708
         - centos-7.5.1804
+        - centos-7.6.1810
       arch: aarch64
       url: "http://mirror.centos.org/altarch"
       distribution: "7"
@@ -156,6 +158,7 @@ Schema:
         - centos-7.3.1611
         - centos-7.4.1708
         - centos-7.5.1804
+        - centos-7.6.1810
       arch: any
       url: http://mirrors.kernel.org/fedora-epel/7/$basearch
       distribution: "7"

--- a/content/stages/centos-7.6.1810.yml
+++ b/content/stages/centos-7.6.1810.yml
@@ -1,7 +1,7 @@
 ---
-Name: "centos-7.5.1804-install"
-Description: "CentOS 7.5.1804 install stage."
-BootEnv: "centos-7.5.1804-install"
+Name: "centos-7.6.1810-install"
+Description: "CentOS 7.6.1810 install stage."
+BootEnv: "centos-7.6.1810-install"
 RunnerWait: true
 Tasks:
   - "set-hostname"


### PR DESCRIPTION
1. Fixes centos 7.5 to 7.6.  There were some oversights
   in the previous PR.
2. Updates sledgehammer to centos 7.6 for amd64.  Arm rebuild will be
   required.
3. Sledgehammer now has two new kernel variables that can
   be used to alter start.

The two vars are:
provisioner.postportdelay
   which causes a wait in seconds after the link has been brought
   up, but hasn't started DHCP.  Defaults to unset.
provisioner.wgetretrycount
   which is the number of times to retry the stage2 wget before
   dropping to ash.  The default is 10.