### PR TITLE
Create centos-6.10.yml

### DIFF
--- a/contrib/bootenvs/centos-6.10.yml
+++ b/contrib/bootenvs/centos-6.10.yml
@@ -1,0 +1,47 @@
+---
+Name: "centos-6.10-install"
+Description: "CentOS-6.10 install bootenv"
+OS:
+  Family: "redhat"
+  Name: "centos-6.10"
+  IsoFile: "CentOS-6.10-x86_64-bin-DVD1.iso"
+  IsoSha256: "a68e46970678d4d297d46086ae2efdd3e994322d6d862ff51dcce25a0759e41c"
+  IsoUrl: "http://mirrors.edge.kernel.org/centos/6.10/isos/x86_64/CentOS-6.10-x86_64-bin-DVD1.iso"
+Kernel: "images/pxeboot/vmlinuz"
+Initrds:
+  - "images/pxeboot/initrd.img"
+BootParams: >-
+  ksdevice=bootif
+  ks={{.Machine.Url}}/compute.ks
+  method={{.Env.InstallUrl}}
+  --
+  {{ if .ParamExists "kernel-console"}}{{.Param "kernel-console" }}{{ end }}
+OptionalParams:
+  - "operating-system-disk"
+  - "provisioner-default-password-hash"
+  - "proxy-servers"
+  - "kernel-console"
+Templates:
+  - Name: "kexec"
+    ID: "kexec.tmpl"
+    Path: "{{.Machine.Path}}/kexec"
+  - ID: "default-pxelinux.tmpl"
+    Name: "pxelinux"
+    Path: "pxelinux.cfg/{{.Machine.HexAddress}}"
+  - ID: "default-ipxe.tmpl"
+    Name: "ipxe"
+    Path: "{{.Machine.Address}}.ipxe"
+  - ID: "default-pxelinux.tmpl"
+    Name: "pxelinux-mac"
+    Path: 'pxelinux.cfg/{{.Machine.MacAddr "pxelinux"}}'
+  - ID: "default-ipxe.tmpl"
+    Name: "ipxe-mac"
+    Path: '{{.Machine.MacAddr "ipxe"}}.ipxe'
+  - ID: "centos-6.ks.tmpl"
+    Name: "compute.ks"
+    Path: "{{.Machine.Path}}/compute.ks"
+Meta:
+  feature-flags: "sane-exit-codes"
+  icon: "linux"
+  color: "black"
+  title: "Digital Rebar Community Content"


### PR DESCRIPTION
As CentOS versions 6.0, 6.1, 6.2, 6.3, 6.4 , 6.5, 6.6, 6.7, 6.8 and 6.9 no longer get any updates, nor
any security fix's. Need to have 6.10 bootenv.