### PR TITLE
improve master taint, helm init, remove debug

### DIFF
--- a/krib/templates/krib-config.sh.tmpl
+++ b/krib/templates/krib-config.sh.tmpl
@@ -135,18 +135,14 @@ if [[ $MASTER_INDEX != notme ]] ; then
   done
 
   if [[ $MASTER_INDEX == 0 ]] ; then
-    OLD_IFS=$IFS
-    IFS=" " ; while read master ; do
-      {{ if eq (.Param "krib/cluster-masters-untainted") true }}
-      echo "Removing taint from master node: $master"
-      kubectl taint nodes $master node-role.kubernetes.io/master- || true
-      {{ else -}}
-      echo "Ensure taint on master: $master"
-      kubectl taint nodes $master node-role.kubernetes.io/master=NoSchedule || true
-      {{end}}
-    done <<< $(get_param $KRIB_MASTERS_PARAM | jq -r '.[].Name' )
-    IFS=$OLD_IFS
-    
+    {{ if eq (.Param "krib/cluster-masters-untainted") true }}
+    echo "Removing taint from master nodes:"
+    kubectl taint nodes -l node-role.kubernetes.io/master node-role.kubernetes.io/master- || true
+    {{ else -}}
+    echo "Ensure taint on master nodes:"
+    kubectl taint nodes -l node-role.kubernetes.io/master node-role.kubernetes.io/master=:NoSchedule || true
+    {{end}}
+
     echo "Recording 'kubeadm' bootstrap config ..."
     drpcli -T $PROFILE_TOKEN profiles add $CLUSTER_PROFILE param $KRIB_CLUSTER_KUBEADM_CFG_PARAM to "$(cat /tmp/kubeadm.cfg)"
 

--- a/krib/templates/krib-config.sh.tmpl
+++ b/krib/templates/krib-config.sh.tmpl
@@ -135,10 +135,15 @@ if [[ $MASTER_INDEX != notme ]] ; then
   done
 
   if [[ $MASTER_INDEX == 0 ]] ; then
-{{if eq (.Param "krib/cluster-masters-untainted") true}}
-    echo "Removing taint from master nodes ..."
-    kubectl taint nodes --all node-role.kubernetes.io/master-
-{{end}}
+    while read master ; do
+      {{ if eq (.Param "krib/cluster-masters-untainted") true }}
+      echo "Removing taint from master node: $master"
+      kubectl taint nodes $master node-role.kubernetes.io/master- || true
+      {{ else -}}
+      echo "Ensure taint on master: $master"
+      kubectl taint nodes $master node-role.kubernetes.io/master=NoSchedule || true
+      {{end}}
+    done <<< $(get_param $KRIB_MASTERS_PARAM | jq -r '.[].Name' )
 
     echo "Recording 'kubeadm' bootstrap config ..."
     drpcli -T $PROFILE_TOKEN profiles add $CLUSTER_PROFILE param $KRIB_CLUSTER_KUBEADM_CFG_PARAM to "$(cat /tmp/kubeadm.cfg)"

--- a/krib/templates/krib-config.sh.tmpl
+++ b/krib/templates/krib-config.sh.tmpl
@@ -135,7 +135,8 @@ if [[ $MASTER_INDEX != notme ]] ; then
   done
 
   if [[ $MASTER_INDEX == 0 ]] ; then
-    while read master ; do
+    OLD_IFS=$IFS
+    IFS=" " ; while read master ; do
       {{ if eq (.Param "krib/cluster-masters-untainted") true }}
       echo "Removing taint from master node: $master"
       kubectl taint nodes $master node-role.kubernetes.io/master- || true
@@ -144,7 +145,8 @@ if [[ $MASTER_INDEX != notme ]] ; then
       kubectl taint nodes $master node-role.kubernetes.io/master=NoSchedule || true
       {{end}}
     done <<< $(get_param $KRIB_MASTERS_PARAM | jq -r '.[].Name' )
-
+    IFS=$OLD_IFS
+    
     echo "Recording 'kubeadm' bootstrap config ..."
     drpcli -T $PROFILE_TOKEN profiles add $CLUSTER_PROFILE param $KRIB_CLUSTER_KUBEADM_CFG_PARAM to "$(cat /tmp/kubeadm.cfg)"
 

--- a/krib/templates/krib-helm-init.sh.tmpl
+++ b/krib/templates/krib-helm-init.sh.tmpl
@@ -45,7 +45,7 @@ if [[ $MASTER_INDEX != notme ]] ; then
     HELM_INSTALL_DIR=$INSTALL_DIR ./get_helm.sh -v {{.Param "helm/version"}}
 
     echo "Create tiller service account"
-    kubectl create -f tiller-rbac.yaml
+    kubectl apply -f tiller-rbac.yaml
 
     echo "Helm initialize"
     helm init --service-account tiller
@@ -82,4 +82,3 @@ fi
 
 echo "Finished successfully"
 exit 0
-

--- a/krib/templates/krib-keepalived.sh.tmpl
+++ b/krib/templates/krib-keepalived.sh.tmpl
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # Kubernetes Rebar Immutable Boot (KRIB) Kubeadm Installer
 set -e
-set -x
 
 # Get access and who we are.
 {{template "setup.tmpl" .}}
@@ -86,4 +85,3 @@ fi
 
 echo "Finished successfully"
 exit 0
-


### PR DESCRIPTION
* use master label to taint or untaint masters with `node-role.kubernetes.io/master=:NoSchedule`
* more reliable helm init (enables re-play of the task)
* remove debug output krib-keepalived script template