### PR TITLE
adding more flexibility for templatebefore and templateafer

### DIFF
--- a/krib/params/helm-charts.yaml
+++ b/krib/params/helm-charts.yaml
@@ -25,9 +25,9 @@ Documentation: |
   * postkubectl (optional) array of kubectl [request] commands to run after the helm install
   * targz (optional) provides a location for a tar.gz file containing charts to install. Path is relative.
   * templates (optional) map of DRP templates keyed to the desired names (must be uploaded!) to render before doing other work.
-  * repo (optional) adds the requested repo to the helm using `helm repo add` before installing helm.  syntax is `[repo name] [repo path]`.
-  * templatebefore (optional) expands the provided template file inline before the helm install happens
-  * templateafter (optional) expands the provided template file inline after the helm install happens
+  * repos (optional) adds the requested repos to helm using `helm repo add` before installing helm.  syntax is `[repo name]: [repo path]`.
+  * templatesbefore (optional) expands the provided template files inline before the helm install happens.
+  * templatesafter (optional) expands the provided template files inline after the helm install happens
 
   example:
 
@@ -59,8 +59,15 @@ Documentation: |
           "repos": {
             "rook-stable": "https://charts.rook.io/stable"
           },
-          "templateafter": "helm-rook.after.sh.tmpl",
-          "templatebefore": "helm-rook.before.sh.tmpl",
+          "templatesafter": [{
+            "name": "helm-rook.after.sh.tmpl"
+            "nodes": "leader",
+          }],
+          "templatesbefore": [{
+            "name": "helm-rook.before.sh.tmpl",
+            "nodes": "all",
+            "runIfInstalled": true
+          }],
           "templates": {
             "cluster": "helm-rook.cfg.tmpl"
           },
@@ -69,56 +76,74 @@ Documentation: |
       ]
 
 Schema:
-  type: "array"
   default: []
   items:
-    type: "object"
-    required:
-      - "chart"
-      - "name"
     properties:
-      targz:
-        type: "string"
       chart:
-        type: "string"
+        type: string
+      kubectlafter:
+        default: []
+        items:
+          type: string
+        type: array
+      kubectlbefore:
+        default: []
+        items:
+          type: string
+        type: array
       name:
-        type: "string"
+        type: string
       namespace:
-        type: "string"
-      repos:
-        type: "object"
+        type: string
       params:
-        type: "object"
         default: {}
         properties:
           repo:
-            type: "string"
-          values:
-            type: "string"
+            type: string
           set:
-            type: "string"
+            type: string
+          values:
+            type: string
+        type: object
+      repos:
+        type: object
       sleep:
-        type: "integer"
         default: 10
-      wait:
-        type: "boolean"
-        default: false
+        type: integer
+      targz:
+        type: string
       templates:
         type: object
-      kubectlbefore:
-        type: "array"
+      templatesafter:
         default: []
         items:
-          type: "string"
-      kubectlafter:
-        type: "array"
+          type: object
+        type: array
+      templatesbefore:
         default: []
         items:
-          type: "string"
-      templatebefore:
-        type: "string"
-      templateafter:
-        type: "string"
+          properties:
+            name:
+              type: string
+            nodes:
+              type: string
+              values:
+                - all
+                - masters
+                - leader
+            runIfInstalled:
+              default: false
+              type: boolean
+          type: object
+        type: array
+      wait:
+        default: false
+        type: boolean
+    required:
+      - chart
+      - name
+    type: object
+  type: array
 Meta:
   color: "blue"
   icon: "map"

--- a/krib/profiles/helm-reference.yaml
+++ b/krib/profiles/helm-reference.yaml
@@ -10,24 +10,35 @@ Meta:
   title: Community Content
 Params:
   helm/charts:
-    - chart: "stable/mysql"
-      name: "mysql"
-    - chart: "istio-1.0.1/install/kubernetes/helm/istio"
-      name: "istio"
-      targz: https://github.com/istio/istio/releases/download/1.0.1/istio-1.0.1-linux.tar.gz
-      namespace: "istio-system"
-      wait: true
+    - chart: stable/mysql
+      name: mysql
+
+    - chart: istio-1.0.1/install/kubernetes/helm/istio
+      name: istio
+      targz: 'https://github.com/istio/istio/releases/download/1.0.1/istio-1.0.1-linux.tar.gz'
+      namespace: istio-system
       params:
-        set: "sidecarInjectorWebhook.enabled=true"
-    - chart: "rook-stable/rook-ceph"
-      name: "rook-ceph"
-      namespace: "rook-ceph-system"
+        set: sidecarInjectorWebhook.enabled=true
+      sleep: 10
       wait: true
+      kubectlbefore:
+        - get nodes
+      kubectlafter:
+        - get nodes
+    - chart: rook-stable/rook-ceph
+      kubectlafter:
+        - apply -f cluster.yaml
+      name: rook-ceph
+      namespace: rook-ceph-system
       repos:
-        rook-stable: "https://charts.rook.io/stable"
+        rook-stable: 'https://charts.rook.io/stable'
+      templatesafter:
+        - name: helm-rook.after.sh.tmpl
+        - nodes: leader
+      templatesbefore:
+        - name: helm-rook.before.sh.tmpl
+          nodes: all
+          runIfInstalled: true
       templates:
         cluster: helm-rook.cfg.tmpl
-      kubectlafter:
-        - "apply -f cluster.yaml"
-      templatebefore: "helm-rook.before.sh.tmpl"
-      templateafter: "helm-rook.after.sh.tmpl"
+      wait: true

--- a/krib/stages/krib-helm-charts.yaml
+++ b/krib/stages/krib-helm-charts.yaml
@@ -1,0 +1,17 @@
+---
+Name: "krib-helm-charts"
+Description: "KRIB install helm charts on the cluster"
+Documentation: |
+  Installs and runs Helm Charts after a cluster has been constructed.
+  This stage is idempotent and can be run multiple times.
+  This allows operators to create workflows with multiple instances of this stage.
+  The charts to run are determined by the helm/charts parameter.
+
+  Due to helm downloads, this stage requires internet access.
+RunnerWait: true
+Tasks:
+  - "krib-helm-charts"
+Meta:
+  icon: "ship"
+  color: "blue"
+  title: "Community Content"

--- a/krib/stages/krib-helm-init.yaml
+++ b/krib/stages/krib-helm-init.yaml
@@ -1,0 +1,17 @@
+---
+Name: "krib-helm-init"
+Description: "KRIB install helm and tiller on the cluster"
+Documentation: |
+  This stage is idempotent and can be run multiple times.
+  This allows operators to create workflows with multiple instances of this stage.
+  Due to helm downloads, this stage requires internet access.
+
+  This stage also creats a tiller service account.  For advanced security, this
+  configuration may not be desirable.
+RunnerWait: true
+Tasks:
+  - "krib-helm-init"
+Meta:
+  icon: "ship"
+  color: "blue"
+  title: "Community Content"

--- a/krib/tasks/krib-helm-charts.yaml
+++ b/krib/tasks/krib-helm-charts.yaml
@@ -1,26 +1,17 @@
 ---
-Description: "A task to install Helm and Tiller and any defined Charts"
-Name: "krib-helm"
+Description: "A task to install Helm charts"
+Name: "krib-helm-charts"
 Documentation: |
-  Installs Helm and runs helm init (which installs Tiller) on the leader.
   Installs Charts defined in helm/charts.
   This uses the Digital Rebar Cluster pattern so krib/cluster-profile must be set.
-
   The install checks to see if tiller is running and may skip initialization.
 RequiredParams:
   - krib/cluster-profile
 OptionalParams:
   - helm/charts
-  - helm/version
 Templates:
-  - ID: "krib-helm.cfg.tmpl"
-    Name: "Service Account for Tiller"
-    Path: "tiller-rbac.yaml"
-  - ID: "krib-helm-init.sh.tmpl"
-    Name: "Bringing up Helm and Tiller on Master"
-    Path: ""
   - ID: "krib-helm.sh.tmpl"
-    Name: "Running Helm Charts"
+    Name: "Running Helm Charts on nodes"
     Path: ""
 Meta:
   icon: "ship"

--- a/krib/tasks/krib-helm-init.yaml
+++ b/krib/tasks/krib-helm-init.yaml
@@ -1,16 +1,18 @@
 ---
-Description: "A task to install Helm and Tiller and any defined Charts"
-Name: "krib-helm"
+Description: "A task to install Helm and Tiller"
+Name: "krib-helm-init"
 Documentation: |
   Installs Helm and runs helm init (which installs Tiller) on the leader.
-  Installs Charts defined in helm/charts.
   This uses the Digital Rebar Cluster pattern so krib/cluster-profile must be set.
 
-  The install checks to see if tiller is running and may skip initialization.
+  The install checks to see if tiller is running and may skip initialization. 
+
+  The tasks only run on the leader so it must be included in the workflow.  All other
+  machines will be skipped so it is acceptable to run the task on all machines
+  in the cluster.
 RequiredParams:
   - krib/cluster-profile
 OptionalParams:
-  - helm/charts
   - helm/version
 Templates:
   - ID: "krib-helm.cfg.tmpl"
@@ -18,9 +20,6 @@ Templates:
     Path: "tiller-rbac.yaml"
   - ID: "krib-helm-init.sh.tmpl"
     Name: "Bringing up Helm and Tiller on Master"
-    Path: ""
-  - ID: "krib-helm.sh.tmpl"
-    Name: "Running Helm Charts"
     Path: ""
 Meta:
   icon: "ship"

--- a/krib/templates/etcd-config.sh.tmpl
+++ b/krib/templates/etcd-config.sh.tmpl
@@ -12,8 +12,7 @@ export RS_IP="{{.Machine.Address}}"
 CLUSTER_PROFILE={{.Param "etcd/cluster-profile"}}
 PROFILE_TOKEN={{.GenerateProfileToken (.Param "etcd/cluster-profile") 7200}}
 {{else -}}
-echo "Missing etcd/cluster-profile on the machine!"
-exit 1
+xiterr 1 "Missing etcd/cluster-profile on the machine!"
 {{end -}}
 
 {{template "krib-lib.sh.tmpl" .}}
@@ -72,8 +71,7 @@ if [[ $ETCD_INDEX == "0" ]] ; then
     drpcli -T "$PROFILE_TOKEN" profiles add "$CLUSTER_PROFILE" param "etcd/client-ca-pw" to "$CLIENT_CA_PW" || true
   else
     if [[ $(get_param "etcd/client-ca-pw") == null ]] ; then
-      echo "  Client CA Exists, but we did not set password.  Need to reset!!"
-      exit 1
+      xiterr 1 "Client CA Exists, but we did not set password.  Need to reset!!"
     else
       echo "  Client CA $CLIENT_CA configured"
     fi
@@ -85,8 +83,7 @@ if [[ $ETCD_INDEX == "0" ]] ; then
     drpcli -T "$PROFILE_TOKEN" profiles add "$CLUSTER_PROFILE" param "etcd/server-ca-pw" to "$SERVER_CA_PW" || true
   else
     if [[ $(get_param "etcd/server-ca-pw") == null ]] ; then
-      echo "  SERVER CA Exists, but we did not set password.  Need to reset data in certs-data profile!!"
-      exit 1
+      xiterr 1 "SERVER CA Exists, but we did not set password.  Need to reset data in certs-data profile!!"
     fi
   fi
 
@@ -96,15 +93,13 @@ if [[ $ETCD_INDEX == "0" ]] ; then
     drpcli -T "$PROFILE_TOKEN" profiles add "$CLUSTER_PROFILE" param "etcd/peer-ca-pw" to "$PEER_CA_PW" || true
   else
     if [[ $(get_param "etcd/peer-ca-pw") == null ]] ; then
-      echo "  PEER CA Exists, but we didn't set password.  Need to reset!!"
-      exit 1
+      xiterr 1 " PEER CA Exists, but we didn't set password.  Need to reset!!"
     fi
   fi
 fi
 
 {{else -}}
-echo "STAGE REQUIRES CERT PLUGIN!!  It is freely available, download from RackN SaaS."
-exit 1
+xiterr 1 "STAGE REQUIRES CERT PLUGIN!!  It is freely available, download from RackN SaaS."
 {{end}}
 
 wait_for_count "etcd/servers" $ETCD_SERVER_COUNT

--- a/krib/templates/krib-config.sh.tmpl
+++ b/krib/templates/krib-config.sh.tmpl
@@ -12,8 +12,7 @@ CLUSTER_NAME={{ .Param "krib/cluster-name" }}
 CLUSTER_PROFILE={{ .Param "krib/cluster-profile" }}
 PROFILE_TOKEN={{ .GenerateProfileToken (.Param "krib/cluster-profile") 7200 }}
 {{ else -}}
-echo "Missing krib/cluster-profile on the machine!"
-exit 1
+xiterr 1 "Missing krib/cluster-profile on the machine!"
 {{ end -}}
 
 {{ template "krib-lib.sh.tmpl" .}}
@@ -175,7 +174,7 @@ fi
 
 while [ ! -f /etc/kubernetes/kubelet.conf ] ;
 do
-      sleep 2
+  sleep 2
 done
 
 AC=$(wait_for_variable $KRIB_ADMIN_CONF_PARAM)
@@ -188,7 +187,7 @@ kubectl --kubeconfig=label.conf label nodes $HOSTNAME env={{.Param "krib/label-e
 # using adhoc labels
 {{if .ParamExists "krib/labels" -}}
   {{range $key, $value := .Param "krib/labels" -}}
-    echo "Adding {{$key}}=\"{{$value | toString | replace " " "_"  | -}}\" label to machine $HOSTNAME from krib/labels"
+    echo "Adding {{$key}}=\"{{$value | toString | replace " " "_" -}}\" label to machine $HOSTNAME from krib/labels"
     kubectl --kubeconfig=label.conf label nodes $HOSTNAME {{$key}}="{{$value | toString | replace " " "_" -}}" --overwrite=true || true
   {{end -}}
 {{else -}}
@@ -197,7 +196,7 @@ kubectl --kubeconfig=label.conf label nodes $HOSTNAME env={{.Param "krib/label-e
 # using inventory
 {{if .ParamExists "inventory/data" -}}
   {{range $key, $value := .Param "inventory/data" -}}
-    echo "Adding {{$key}}=\"{{$value | toString | replace " " "_"  | -}}\" label to machine $HOSTNAME from inventory/data"
+    echo "Adding {{$key}}=\"{{$value | toString | replace " " "_" -}}\" label to machine $HOSTNAME from inventory/data"
     kubectl --kubeconfig=label.conf label nodes $HOSTNAME {{$key}}="{{$value | toString | replace " " "_" -}}" --overwrite=true || true
   {{end }}
 {{else -}}
@@ -217,8 +216,7 @@ fi
 sed -i "s#server:.*#server: https://${MASTER_VIP}:${API_PORT}#g" /etc/kubernetes/kubelet.conf
 systemctl restart kubelet
 {{ else -}}
-echo "Missing required krib/cluster-master-vip"
-exit 1
+xiterr 1 "Missing required krib/cluster-master-vip"
 {{ end -}}
 
 # Clean up

--- a/krib/templates/krib-contrail.sh.tmpl
+++ b/krib/templates/krib-contrail.sh.tmpl
@@ -11,8 +11,7 @@ echo "Run Contrail install on the master (skip for minions)..."
 CLUSTER_PROFILE={{.Param "krib/cluster-profile"}}
 PROFILE_TOKEN={{.GenerateProfileToken (.Param "krib/cluster-profile") 7200}}
 {{else -}}
-echo "Missing krib/cluster-profile on the machine!"
-exit 1
+xiterr 1 "Missing krib/cluster-profile on the machine!"
 {{end -}}
 
 {{template "krib-lib.sh.tmpl" .}}

--- a/krib/templates/krib-dashboard.sh.tmpl
+++ b/krib/templates/krib-dashboard.sh.tmpl
@@ -10,8 +10,7 @@ set -x
 CLUSTER_PROFILE={{.Param "krib/cluster-profile"}}
 PROFILE_TOKEN={{.GenerateProfileToken (.Param "krib/cluster-profile") 7200}}
 {{else -}}
-echo "Missing krib/cluster-profile on the machine!"
-exit 1
+xiterr 1 "Missing krib/cluster-profile on the machine!"
 {{end -}}
 
 {{template "krib-lib.sh.tmpl" .}}

--- a/krib/templates/krib-dev-reset.sh.tmpl
+++ b/krib/templates/krib-dev-reset.sh.tmpl
@@ -3,8 +3,7 @@
 # this snippet is called by the krib-dev-reset task
 
 {{if .Param "krib/cluster-is-production" -}}
-  echo "CANNOT USE RESET WHEN CLUSTER IS PRODUCTION"
-  exit 1
+  xiterr 1 "CANNOT USE RESET WHEN CLUSTER IS PRODUCTION"
 {{else -}}
 
   for p in "${WIPE_PARAMS[@]}"; do

--- a/krib/templates/krib-get-masters.sh.tmpl
+++ b/krib/templates/krib-get-masters.sh.tmpl
@@ -15,8 +15,7 @@ CLUSTER_NAME={{.Param "krib/cluster-name"}}
 CLUSTER_PROFILE={{.Param "krib/cluster-profile"}}
 PROFILE_TOKEN={{.GenerateProfileToken (.Param "krib/cluster-profile") 7200}}
 {{else -}}
-echo "Missing krib/cluster-profile on the machine!"
-exit 1
+xiterr 1 "Missing krib/cluster-profile on the machine!"
 {{end -}}
 
 {{template "krib-lib.sh.tmpl" .}}
@@ -76,8 +75,7 @@ if (( $KRIB_MASTER_COUNT > 1 )) ; then
   {{if .ParamExists "krib/cluster-master-vip" -}}
     MASTER_VIP={{.Param "krib/cluster-master-vip"}}
   {{else -}}
-    echo "Missing krib/cluster-master-vip on the machine!"
-    exit 1
+    xiterr 1 "Missing krib/cluster-master-vip on the machine!"
   {{end -}}
 
   drpcli machines tasks add {{.Machine.UUID}} at 0 krib-keepalived krib-haproxy

--- a/krib/templates/krib-haproxy.sh.tmpl
+++ b/krib/templates/krib-haproxy.sh.tmpl
@@ -11,8 +11,7 @@ set -x
 CLUSTER_PROFILE={{.Param "krib/cluster-profile"}}
 PROFILE_TOKEN={{.GenerateProfileToken (.Param "krib/cluster-profile") 7200}}
 {{else -}}
-echo "Missing etcd/cluster-profile on the machine!"
-exit 1
+xiterr 1 "Missing etcd/cluster-profile on the machine!"
 {{end -}}
 
 {{template "krib-lib.sh.tmpl" .}}

--- a/krib/templates/krib-helm-init.sh.tmpl
+++ b/krib/templates/krib-helm-init.sh.tmpl
@@ -11,8 +11,7 @@ echo "Configure helm on the master (skip for minions)..."
 CLUSTER_PROFILE={{.Param "krib/cluster-profile"}}
 PROFILE_TOKEN={{.GenerateProfileToken (.Param "krib/cluster-profile") 7200}}
 {{else -}}
-echo "Missing krib/cluster-profile on the machine!"
-exit 1
+xiterr 1 "Missing krib/cluster-profile on the machine!"
 {{end -}}
 
 {{template "krib-lib.sh.tmpl" .}}
@@ -27,13 +26,12 @@ if [[ $MASTER_INDEX != notme ]] ; then
 
     # help requires the admin config
     export KUBECONFIG="/etc/kubernetes/admin.conf"
-    set +e
-    if [[ ! -z $(kubectl get pods --namespace kube-system | grep tiller) ]] ; then
+
+    if [[ ! -z $(kubectl -n kube-system rollout status deploy/tiller-deploy -w=0 | grep success) ]] ; then
       echo "Tiller already installed - exiting"
       helm version
       exit 0
     fi
-    set -e
 
     # todo: provide more options for installing helm
     curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
@@ -52,12 +50,12 @@ if [[ $MASTER_INDEX != notme ]] ; then
 
     set +e
     echo "Wait until Tiller is running"
-    CNT=$(kubectl get pods --namespace kube-system --field-selector=status.phase==Running | grep tiller)
+    CNT=$(kubectl -n kube-system rollout status deploy/tiller-deploy -w=0 | grep success)
     ESCAPE=0
     while [[ -z $CNT && $ESCAPE -lt 20 ]] ; do
-      echo "Waiting for Tiller...$(kubectl get pods --namespace kube-system | grep tiller)"
+      echo $(kubectl -n kube-system rollout status deploy/tiller-deploy -w=0)
       sleep 5
-      CNT=$(kubectl get pods --namespace kube-system --field-selector=status.phase==Running | grep tiller)
+      CNT=$(kubectl -n kube-system rollout status deploy/tiller-deploy -w=0 | grep success)
       ((ESCAPE=ESCAPE+1))
     done
     set -e

--- a/krib/templates/krib-helm.sh.tmpl
+++ b/krib/templates/krib-helm.sh.tmpl
@@ -5,155 +5,196 @@ set -e
 # Get access and who we are.
 {{template "setup.tmpl" .}}
 
-echo "Run helm install on the master (skip for minions)..."
-
-{{if .ParamExists "krib/cluster-profile" -}}
+{{ if .ParamExists "krib/cluster-profile" -}}
 CLUSTER_PROFILE={{.Param "krib/cluster-profile"}}
 PROFILE_TOKEN={{.GenerateProfileToken (.Param "krib/cluster-profile") 7200}}
-{{else -}}
-echo "Missing krib/cluster-profile on the machine!"
-exit 1
-{{end -}}
+{{ else -}}
+xiterr 1 "Missing krib/cluster-profile on the machine!"
+{{ end -}}
 
 {{template "krib-lib.sh.tmpl" .}}
 
+CFG=$(mktemp /tmp/.XXXXXXXXXXX.conf)
+chmod 600 $CFG
+{{ if .ParamExists "krib/cluster-admin-conf" -}}
+cat > $CFG << 'EOFCFG'
+{{.ParamAsJSON "krib/cluster-admin-conf"}}
+EOFCFG
+{{ else -}}
+drpcli machines update $RS_UUID '{"Meta":{"color":"red", "icon": "exclamation triangle"}}'
+xiterr 1 "Required 'krib/cluster-admin-conf' Param not set - is this a KRIB cluster ???"
+{{ end -}}
+
+[[ ! -s "$CFG" ]] && xiterr 1 "generated admin config file has zero size"
+export KUBECONFIG=$CFG
+
 MASTER_INDEX=$(find_me $KRIB_MASTERS_PARAM "Uuid" $RS_UUID)
 echo "My Master index is $MASTER_INDEX"
-if [[ $MASTER_INDEX != notme ]] ; then
 
-  if [[ $MASTER_INDEX == 0 ]] ; then
+{{$render := .}}
 
-    echo "I am the elected leader - I can run helm for the cluster"
+{{- range $index, $chart := .Param "helm/charts" -}}
 
-    # help requires the admin config
-    export KUBECONFIG="/etc/kubernetes/admin.conf"
-    echo "Making sure Tiller is running"
-    if [[ -z $(kubectl get pods --namespace kube-system --field-selector=status.phase==Running | grep tiller) ]] ; then
-      echo "Tiller NOT running - something went wrong with helm init"
-      exit 1
-    fi
-
-    mkdir -p .helm
-    export HELM_HOME=$(cd .helm && pwd)
-
-    echo "Helm initialize"
-    helm init -c --service-account tiller
-    helm repo update
-
-    echo "Running Helm Install for all helm/charts"
-    {{$render := .}}
-    {{range $index, $chart := .Param "helm/charts"}}
-      echo "Installing {{$chart.name}} (from {{$chart.chart}})..."
-
-      if [[ -z $(helm list {{$chart.name}}) ]] ; then
-
-        {{ range $name, $template := $chart.templates }}
-        echo "expanding template {{$template}} as {{$name}}.yaml"
-        cat > {{$name}}.yaml << EOF
-{{ $render.CallTemplate $template $render }}
-EOF
-        {{end}}
-
-        {{- if $chart.templatebefore}}
-        echo "expanding templatebefore {{$chart.templatebefore}}"
-{{ $render.CallTemplate $chart.templatebefore $render }}
-        echo "========= done {{$chart.templatebefore}} ==========="
-        {{- end}}
-
-        {{range $index, $before := $chart.kubectlbefore}}
-        echo "running kubectl {{$before}} ({{$index}})"
-        kubectl {{$before}}
-        {{end}}
-
-        {{if $chart.targz}}
-        echo "retrieving chart from {{$chart.targz}}"
-        curl -gL "{{$chart.targz}}" | tar xz
-        {{end}}
-
-        {{if $chart.repos}}
-        {{range $name, $url := $chart.repos}}
-        echo "adding chart repo {{$name}}"
-        helm repo add {{$name}} {{$url}}
-        {{end}}
-        helm repo update
-        {{end}}
-
-        helm install {{$chart.chart}} --name {{$chart.name}} \
-          {{if $chart.namespace}} --namespace {{$chart.namespace}}{{end}} \
-          {{range $param, $value := $chart.params}} --{{$param}} {{$value}}{{end}}
-
-        {{if $chart.sleep}}
-          echo "sleep {{$chart.sleep}}"
-          sleep {{$chart.sleep}}
-        {{else}}
-          sleep 10s
-        {{end}}
-
-        {{if $chart.wait}}
-          set +e
-          ESCAPE=0
-          while [[ $ESCAPE -lt 30 && -z $(helm list {{$chart.name}} | grep DEPLOYED) ]] ; do
-            echo "helm list {{$chart.name}} is not deployed. $ESCAPE"
-            {{if $chart.sleep}}
-              sleep {{$chart.sleep}}
-            {{else}}
-              sleep 10
-            {{end}}
-            ((ESCAPE=ESCAPE+1))
-          done
-          set -e
-        {{else}}
-          echo "let's go! I'm not waiting for chart to be ready"
-        {{end}}
-
-        {{if and $chart.wait $chart.namespace}}
-          set +e
-          ESCAPE=0
-          while [[ $ESCAPE -lt 30 && ! -z $(kubectl get pods --namespace={{$chart.namespace}} | grep ContainerCreating) ]] ; do
-            echo "kubectl get pods --namespace={{$chart.namespace}} is still creating containers. $ESCAPE"
-            {{if $chart.sleep}}
-              sleep {{$chart.sleep}}
-            {{else}}
-              sleep 10
-            {{end}}
-            ((ESCAPE=ESCAPE+1))
-          done
-          set -e
-        {{end}}
-
-        {{range $index, $after := $chart.kubectlafter}}
-        echo "running kubectl {{$after}} ({{$index}})"
-        kubectl {{$after}}
-        {{end}}
-
-        {{- if $chart.templateafter}}
-        echo "expanding templateafter {{$chart.templateafter}}"
-{{ $render.CallTemplate $chart.templateafter $render }}
-        echo "========= done {{$chart.templateafter}} ==========="
-        {{- end}}
-
-        echo "========= done {{$chart.name}} ==========="
-
-      else
-        echo "skipping {{$chart.name}}.  It is already installed"
-      fi
-
-    {{else}}
-      echo "No charts included in helm/charts to install"
-    {{end}}
-
-  else
-
-    echo "I was not the leader, skipping helm install"
-
-  fi
-
-else
-
-  echo "I am a worker - no helm actions"
-
+# check if it's installed without using helm
+INSTALLED=false
+if [[ ! -z $(kubectl --all-namespaces=true -n heritage=Tiller -o name get all | grep {{$chart.name}}) ]] ; then
+  INSTALLED=true
 fi
 
+if [[ $MASTER_INDEX != notme ]] ; then
+  if [[ $MASTER_INDEX == 0 ]] ; then
+    if [[ "$INSTALLED" == false ]] ; then
+      echo "I am the elected leader - I can run helm for the cluster"
+
+      echo "Making sure Tiller is running"
+      if [[ -z $(kubectl -n kube-system rollout status deploy/tiller-deploy -w=0 | grep success) ]] ; then
+        xiterr 1 "Tiller NOT running - something went wrong with helm init"
+      fi
+
+      mkdir -p .helm
+      export HELM_HOME=$(cd .helm && pwd)
+
+      echo "Helm initialize"
+      helm init -c --service-account tiller
+      helm repo update
+
+      echo "Installing {{$chart.name}} (from {{$chart.chart}})..."
+
+      {{ range $name, $template := $chart.templates -}}
+      echo "expanding template {{$template}} as {{$name}}.yaml"
+      cat > {{$name}}.yaml << EOF
+{{ $render.CallTemplate $template $render }}
+EOF
+    {{ end -}}
+
+    fi
+    {{ range $index, $tmpl := $chart.templatesbefore -}}{{ if eq ($tmpl.nodes) "leader" -}}
+    if [[ "$INSTALLED" == false ]] || [[ "$INSTALLED" == {{if not $tmpl.runIfInstalled}}false{{else}}{{$tmpl.runIfInstalled}}{{end}} ]] ; then
+      echo "expanding {{$chart.name}} templatebefore {{$tmpl.name}}"
+{{ $render.CallTemplate $tmpl.name $render }}
+      echo "========= done {{$chart.name}} templatebefore {{$tmpl}} ==========="
+    fi
+    {{- end }}{{ end }}
+  fi
+  {{ range $index, $tmpl := $chart.templatesbefore -}}{{ if eq ($tmpl.nodes) "masters" -}}
+  if [[ "$INSTALLED" == false ]] || [[ "$INSTALLED" == {{if not $tmpl.runIfInstalled}}false{{else}}{{$tmpl.runIfInstalled}}{{end}} ]] ; then
+    echo "expanding {{$chart.name}} templatebefore {{$tmpl.name}}"
+{{ $render.CallTemplate $tmpl.name $render }}
+    echo "========= done {{$chart.name}} templatebefore {{$tmpl}} ==========="
+  fi
+  {{- end }}{{ end }}
+fi
+
+{{ range $index, $tmpl := $chart.templatesbefore -}}{{ if eq ($tmpl.nodes) "all" -}}
+if [[ "$INSTALLED" == false ]] || [[ "$INSTALLED" == {{if not $tmpl.runIfInstalled}}false{{else}}{{$tmpl.runIfInstalled}}{{end}} ]] ; then
+  echo "expanding {{$chart.name}} templatebefore {{$tmpl.name}}"
+{{ $render.CallTemplate $tmpl.name $render }}
+  echo "========= done {{$chart.name}} templatebefore {{$tmpl}} ==========="
+fi
+{{- end }}{{ end }}
+
+if [[ $MASTER_INDEX != notme ]] ; then
+  if [[ $MASTER_INDEX == 0 ]] ; then
+    if [[ "$INSTALLED" == false ]] ; then
+      {{ range $index, $before := $chart.kubectlbefore -}}
+      echo "running kubectl {{$before}} ({{$index}})"
+      kubectl {{$before}}
+      {{ end -}}
+
+      {{ if $chart.targz }}
+      echo "retrieving chart from {{$chart.targz}}"
+      curl -gL "{{$chart.targz}}" | tar xz
+      {{ end -}}
+
+      {{ if $chart.repos }}
+      {{ range $name, $url := $chart.repos -}}
+      echo "adding chart repo {{$name}}"
+      helm repo add {{$name}} {{$url}}
+      {{ end -}}
+      helm repo update
+      {{ end -}}
+
+      helm install {{$chart.chart}} --name {{$chart.name}}{{ if $chart.namespace }} --namespace {{$chart.namespace}}{{ end }} \
+        {{ range $param, $value := $chart.params }} --{{$param}} {{$value}}{{ end }}
+
+      {{ if $chart.sleep }}
+      echo "sleep {{$chart.sleep}}"
+      sleep {{$chart.sleep}}
+      {{ else -}}
+      sleep 10s
+      {{ end -}}
+
+      {{ if $chart.wait }}
+      set +e
+      ESCAPE=0
+      while [[ $ESCAPE -lt 30 && -z $(helm list {{$chart.name}} | grep DEPLOYED) ]] ; do
+        echo "helm list {{$chart.name}} is not deployed. $ESCAPE"
+        {{ if $chart.sleep -}}
+        sleep {{$chart.sleep}}
+        {{ else -}}
+        sleep 10
+        {{ end -}}
+        ((ESCAPE=ESCAPE+1))
+      done
+      set -e
+      {{ else -}}
+      echo "let's go! I'm not waiting for chart to be ready"
+      {{ end -}}
+
+      {{ if and $chart.wait $chart.namespace }}
+      set +e
+      ESCAPE=0
+      while [[ $ESCAPE -lt 30 && ! -z $(kubectl get pods --namespace={{$chart.namespace}} | grep ContainerCreating) ]] ; do
+        echo "kubectl get pods --namespace={{$chart.namespace}} is still creating containers. $ESCAPE"
+        {{ if $chart.sleep -}}
+        sleep {{$chart.sleep}}
+        {{ else -}}
+        sleep 10
+        {{ end -}}
+        ((ESCAPE=ESCAPE+1))
+      done
+      set -e
+      {{ end -}}
+
+      {{ range $index, $after := $chart.kubectlafter }}
+      echo "running kubectl {{$after}} ({{$index}})"
+      kubectl {{$after}}
+      {{ end -}}
+
+    fi
+
+    {{ range $index, $tmpl := $chart.templatesafter }}{{ if eq ($tmpl.nodes) "leader" -}}
+    if [[ "$INSTALLED" == false ]] || [[ "$INSTALLED" == {{if not $tmpl.runIfInstalled}}false{{else}}{{$tmpl.runIfInstalled}}{{end}} ]] ; then
+      echo "expanding {{$chart.name}} templateafter {{$tmpl.name}}"
+{{ $render.CallTemplate $tmpl.name $render }}
+      echo "========= done {{$chart.name}} templateafter {{$tmpl}} ==========="
+    fi
+    {{- end }}{{ end }}
+  else
+    echo "I was not the leader, skipping helm install"
+  fi
+
+  {{ range $index, $tmpl := $chart.templatesafter }}{{ if eq ($tmpl.nodes) "masters" -}}
+  if [[ "$INSTALLED" == false ]] || [[ "$INSTALLED" == {{if not $tmpl.runIfInstalled}}false{{else}}{{$tmpl.runIfInstalled}}{{end}} ]] ; then
+    echo "expanding {{$chart.name}} templateafter {{$tmpl.name}}"
+{{ $render.CallTemplate $tmpl.name $render }}
+    echo "========= done {{$chart.name}} templateafter {{$tmpl}} ==========="
+  fi
+  {{- end }}{{ end }}
+else
+  echo "I am a worker - no helm actions"
+fi
+
+{{ range $index, $tmpl := $chart.templatesafter }}{{ if eq ($tmpl.nodes) "all" -}}
+if [[ "$INSTALLED" == false ]] || [[ "$INSTALLED" == {{if not $tmpl.runIfInstalled}}false{{else}}{{$tmpl.runIfInstalled}}{{end}} ]] ; then
+  echo "expanding {{$chart.name}} templateafter {{$tmpl.name}}"
+{{ $render.CallTemplate $tmpl.name $render }}
+  echo "========= done {{$chart.name}} templateafter {{$tmpl}} ==========="
+fi
+{{- end }}{{ end }}
+echo "========= done {{$chart.name}} ==========="
+{{ else -}}
+echo "No charts included in helm/charts to install"
+{{ end -}}
 echo "Finished successfully"
 exit 0
-

--- a/krib/templates/krib-ingress-nginx.sh.tmpl
+++ b/krib/templates/krib-ingress-nginx.sh.tmpl
@@ -11,8 +11,7 @@ echo "Run helm install on the master (skip for minions)..."
 CLUSTER_PROFILE={{.Param "krib/cluster-profile"}}
 PROFILE_TOKEN={{.GenerateProfileToken (.Param "krib/cluster-profile") 7200}}
 {{else -}}
-echo "Missing krib/cluster-profile on the machine!"
-exit 1
+xiterr 1 "Missing krib/cluster-profile on the machine!"
 {{end -}}
 
 {{template "krib-lib.sh.tmpl" .}}
@@ -25,9 +24,8 @@ if [[ $MASTER_INDEX != notme ]] ; then
     export KUBECONFIG=/etc/kubernetes/admin.conf
 
     echo "Making sure Tiller is running"
-    if [[ -z $(kubectl get pods --namespace kube-system --field-selector=status.phase==Running | grep tiller) ]] ; then
-      echo "Tiller NOT running - something went wrong with helm init"
-      exit 1
+    if [[ -z $(kubectl -n kube-system rollout status deploy/tiller-deploy -w=0 | grep success) ]] ; then
+      xiterr 1 "Tiller NOT running - something went wrong with helm init"
     fi
 
     echo "Helm initialize"

--- a/krib/templates/krib-keepalived.sh.tmpl
+++ b/krib/templates/krib-keepalived.sh.tmpl
@@ -10,8 +10,7 @@ set -e
 CLUSTER_PROFILE={{.Param "krib/cluster-profile"}}
 PROFILE_TOKEN={{.GenerateProfileToken (.Param "krib/cluster-profile") 7200}}
 {{else -}}
-echo "Missing etcd/cluster-profile on the machine!"
-exit 1
+xiterr 1 "Missing etcd/cluster-profile on the machine!"
 {{end -}}
 
 {{template "krib-lib.sh.tmpl" .}}

--- a/krib/templates/krib-lib.sh.tmpl
+++ b/krib/templates/krib-lib.sh.tmpl
@@ -7,7 +7,7 @@
 #   - get_param
 # which assumes that RS_UUID and RS_KEY or RS_TOKEN are set.
 #
-function xiterr() { [[ $1 =~ ^[0-9]+$ ]] && { XIT=$1; shift; } || XIT=1; echo "FATAL: $*"; exit $XIT; }
+function xiterr() { [[ $1 =~ ^[0-9]+$ ]] && { XIT=$1; shift; } || XIT=1; echo "FATAL: $*"; exit_stop; }
 
 [[ -z "$PROFILE_TOKEN" ]] && xiterr 1 "required PROFILE_TOKEN not set"
 [[ -z "$CLUSTER_PROFILE" ]] && xiterr 1 "required CLUSTER_PROFILE not set"

--- a/krib/templates/krib-longhorn.sh.tmpl
+++ b/krib/templates/krib-longhorn.sh.tmpl
@@ -11,8 +11,7 @@ echo "Run helm install on the master (skip for minions)..."
 CLUSTER_PROFILE={{.Param "krib/cluster-profile"}}
 PROFILE_TOKEN={{.GenerateProfileToken (.Param "krib/cluster-profile") 7200}}
 {{else -}}
-echo "Missing krib/cluster-profile on the machine!"
-exit 1
+xiterr 1 "Missing krib/cluster-profile on the machine!"
 {{end -}}
 
 {{template "krib-lib.sh.tmpl" .}}

--- a/krib/templates/krib-metallb.sh.tmpl
+++ b/krib/templates/krib-metallb.sh.tmpl
@@ -11,8 +11,7 @@ set -x
 CLUSTER_PROFILE={{.Param "krib/cluster-profile"}}
 PROFILE_TOKEN={{.GenerateProfileToken (.Param "krib/cluster-profile") 7200}}
 {{else -}}
-echo "Missing etcd/cluster-profile on the machine!"
-exit 1
+xiterr 1 "Missing etcd/cluster-profile on the machine!"
 {{end -}}
 
 {{template "krib-lib.sh.tmpl" .}}

--- a/krib/templates/krib-settings.sh.tmpl
+++ b/krib/templates/krib-settings.sh.tmpl
@@ -10,8 +10,7 @@ set -x
 CLUSTER_PROFILE={{.Param "krib/cluster-profile"}}
 PROFILE_TOKEN={{.GenerateProfileToken (.Param "krib/cluster-profile") 7200}}
 {{else -}}
-echo "Missing krib/cluster-profile on the machine!"
-exit 1
+xiterr 1 "Missing krib/cluster-profile on the machine!"
 {{end -}}
 
 {{template "krib-lib.sh.tmpl" .}}

--- a/krib/templates/krib-sonobuoy.sh.tmpl
+++ b/krib/templates/krib-sonobuoy.sh.tmpl
@@ -11,8 +11,7 @@ echo "Configure Sonobuoy on the master (skip for minions)..."
 CLUSTER_PROFILE={{.Param "krib/cluster-profile"}}
 PROFILE_TOKEN={{.GenerateProfileToken (.Param "krib/cluster-profile") 7200}}
 {{else -}}
-echo "Missing krib/cluster-profile on the machine!"
-exit 1
+xiterr 1 "Missing krib/cluster-profile on the machine!"
 {{end -}}
 
 {{template "krib-lib.sh.tmpl" .}}


### PR DESCRIPTION
chart templatebefores and templateafters can now be run if the chart is already installed. (This is needed when adding nodes to a cluster that need required packages or configuration to support pods that could be scheduled to them).
replaced exit 1 with xiterr 1.
go template formatting tweaks.
switched to better tiller check method.
added split helm-init and helm-charts tasks and stages.