### PR TITLE
KRIB IP Override

### DIFF
--- a/krib/params/etcd-ip.yaml
+++ b/krib/params/etcd-ip.yaml
@@ -1,0 +1,15 @@
+---
+Name: "etcd/ip"
+Description: "IP used by etcd for listen / advertise"
+Documentation: |
+  For configurations where the etcd cluster should communicate
+  over a network other than the one that the machine was booted
+  from.
+
+  If unset, will default to the Machine Address.
+Schema:
+  type: "string"
+Meta:
+  color: "blue"
+  icon: "book"
+  title: "Community Content"

--- a/krib/params/krib-ip.yaml
+++ b/krib/params/krib-ip.yaml
@@ -1,0 +1,14 @@
+---
+Name: "krib/ip"
+Description: "InternalIP (--node-ip param to kubelet) used by Kubernetes hosts"
+Documentation: |
+  For configurations where kubelet does not correctly detect the IP
+  over which nodes should communicate.
+
+  If unset, will default to the Machine Address.
+Schema:
+  type: "string"
+Meta:
+  color: "blue"
+  icon: "ship"
+  title: "Community Content"

--- a/krib/params/provider-flannel-config.yaml
+++ b/krib/params/provider-flannel-config.yaml
@@ -7,7 +7,7 @@ Documentation: |
   Param will have no effect on the cluster.
 Schema:
   type: "string"
-  default: "https://raw.githubusercontent.com/coreos/flannel/v0.10.0/Documentation/  kube-flannel.yml"
+  default: "https://raw.githubusercontent.com/coreos/flannel/v0.10.0/Documentation/kube-flannel.yml"
 Meta:
   color: "blue"
   icon: "ship"

--- a/krib/templates/etcd-config.sh.tmpl
+++ b/krib/templates/etcd-config.sh.tmpl
@@ -22,9 +22,11 @@ build_cert() {
   local ca_name=$2
   local ca_pw=$3
   local myname=$4
+  local myip=$5
 
+  echo "Generating certificate for ${profile} with my name ${myname} and my IP ${myip}"
   drpcli machines runaction $RS_UUID getca certs/root $ca_name | jq -r . > /etc/kubernetes/pki/etcd/${profile}-ca.pem
-  drpcli certs csr $ca_name $myname $RS_IP $(hostname) > tmp.csr
+  drpcli certs csr $ca_name $myname $RS_IP $myip $(hostname) > tmp.csr
   drpcli machines runaction $RS_UUID signcert certs/root $ca_name certs/root-pw $ca_pw certs/csr "$(jq .CSR tmp.csr)" certs/profile $profile | jq -r . > /etc/kubernetes/pki/etcd/$profile.pem
   jq -r .Key tmp.csr > /etc/kubernetes/pki/etcd/$profile-key.pem
   rm tmp.csr
@@ -35,6 +37,11 @@ echo "Configure the etcd cluster"
 ETCD_CLUSTER_NAME={{.Param "etcd/name"}}
 ETCD_PEER_PORT={{.Param "etcd/peer-port"}}
 ETCD_CLIENT_PORT={{.Param "etcd/client-port"}}
+{{ if .ParamExists "etcd/ip" -}}
+ETCD_IP={{ .Param "etcd/ip" }}
+{{ else -}}
+ETCD_IP={{ .Machine.Address }}
+{{ end -}}
 
 # add server management params if missing
 echo "Add initial variables to track members."
@@ -46,7 +53,10 @@ ETCD_SERVER_COUNT={{.Param "etcd/server-count"}}
 echo "Creating $ETCD_SERVER_COUNT servers"
 
 echo "Electing etcd members to cluster profile: $CLUSTER_PROFILE"
-ETCD_INDEX=$(add_me_if_not_count "etcd/servers" $ETCD_SERVER_COUNT)
+ETCD_INDEX=$(add_me_if_not_count "etcd/servers" $ETCD_SERVER_COUNT $ETCD_IP)
+
+echo "Added myself to cluster profile, my index is ${ETCD_INDEX}"
+
 if [[ $ETCD_INDEX == notme ]] ; then
   echo "I am not an ETCD server.  Move on."
   wait_for_count "etcd/servers-done" $ETCD_SERVER_COUNT
@@ -97,12 +107,14 @@ if [[ $ETCD_INDEX == "0" ]] ; then
     fi
   fi
 fi
-
 {{else -}}
 xiterr 1 "STAGE REQUIRES CERT PLUGIN!!  It is freely available, download from RackN SaaS."
 {{end}}
 
+echo "Waiting for ${ETCD_SERVER_COUNT} servers to start"
 wait_for_count "etcd/servers" $ETCD_SERVER_COUNT
+
+echo "${ETCD_SERVER_COUNT} servers started!"
 
 CLIENT_CA_PW=$(wait_for_variable "etcd/client-ca-pw")
 SERVER_CA_PW=$(wait_for_variable "etcd/server-ca-pw")
@@ -113,9 +125,9 @@ mkdir -p /etc/kubernetes/pki/etcd
 
 ETCD_NAME="etcd$ETCD_INDEX"
 
-build_cert "client" $CLIENT_CA $CLIENT_CA_PW $ETCD_NAME
-build_cert "server" $SERVER_CA $SERVER_CA_PW $ETCD_NAME
-build_cert "peer" $PEER_CA $PEER_CA_PW $ETCD_NAME
+build_cert "client" $CLIENT_CA $CLIENT_CA_PW $ETCD_NAME $ETCD_IP
+build_cert "server" $SERVER_CA $SERVER_CA_PW $ETCD_NAME $ETCD_IP
+build_cert "peer" $PEER_CA $PEER_CA_PW $ETCD_NAME $ETCD_IP
 
 ETCD_URLS=""
 INDEX=0
@@ -138,9 +150,13 @@ echo "Installing etcd v{{.Param "etcd/version"}} (set in Param etcd/version)"
 curl -sSL https://github.com/coreos/etcd/releases/download/v{{.Param "etcd/version"}}/etcd-v{{.Param "etcd/version"}}-linux-amd64.tar.gz | tar -xz --strip-components=1 -C ${INSTALL_DIR}
 rm -rf etcd-v{{.Param "etcd/version"}}-linux-amd64*
 
-touch /etc/etcd.env
-echo "PEER_NAME=${ETCD_NAME}" >> /etc/etcd.env
-echo "PRIVATE_IP={{.Machine.Address}}" >> /etc/etcd.env
+cat << EOF > /etc/etcd.env
+PEER_NAME=${ETCD_NAME}
+ADVERTISE_IP=${ETCD_IP}
+CLIENT_PORT=${ETCD_CLIENT_PORT}
+PEER_PORT=${ETCD_PEER_PORT}
+URLS=${ETCD_URLS}
+EOF
 
 cat >/etc/systemd/system/etcd.service <<EOF
 [Unit]
@@ -157,7 +173,19 @@ RestartSec=5s
 LimitNOFILE=40000
 TimeoutStartSec=0
 
-  ExecStart=${INSTALL_DIR}/etcd --name ${ETCD_NAME} --data-dir /docker/etcd --listen-client-urls https://{{.Machine.Address}}:${ETCD_CLIENT_PORT},http://127.0.0.1:${ETCD_CLIENT_PORT} --advertise-client-urls https://{{.Machine.Address}}:${ETCD_CLIENT_PORT} --listen-peer-urls https://{{.Machine.Address}}:${ETCD_PEER_PORT},http://127.0.0.1:${ETCD_PEER_PORT} --initial-advertise-peer-urls https://{{.Machine.Address}}:${ETCD_PEER_PORT} --cert-file=/etc/kubernetes/pki/etcd/server.pem --key-file=/etc/kubernetes/pki/etcd/server-key.pem --client-cert-auth --trusted-ca-file=/etc/kubernetes/pki/etcd/client-ca.pem --peer-cert-file=/etc/kubernetes/pki/etcd/peer.pem --peer-key-file=/etc/kubernetes/pki/etcd/peer-key.pem --peer-client-cert-auth --peer-trusted-ca-file=/etc/kubernetes/pki/etcd/peer-ca.pem --initial-cluster ${ETCD_URLS} --initial-cluster-token my-etcd-token --initial-cluster-state new
+ExecStart=${INSTALL_DIR}/etcd \
+  --name \${PEER_NAME} \
+  --data-dir /docker/etcd \
+  --listen-client-urls https://\${ADVERTISE_IP}:\${CLIENT_PORT},http://127.0.0.1:\${CLIENT_PORT} \
+  --advertise-client-urls https://\${ADVERTISE_IP}:\${CLIENT_PORT} \
+  --listen-peer-urls https://\${ADVERTISE_IP}:\${PEER_PORT},http://127.0.0.1:\${PEER_PORT} \
+  --initial-advertise-peer-urls https://\${ADVERTISE_IP}:\${PEER_PORT} \
+  --cert-file=/etc/kubernetes/pki/etcd/server.pem \
+  --key-file=/etc/kubernetes/pki/etcd/server-key.pem \
+  --client-cert-auth --trusted-ca-file=/etc/kubernetes/pki/etcd/client-ca.pem \
+  --peer-cert-file=/etc/kubernetes/pki/etcd/peer.pem --peer-key-file=/etc/kubernetes/pki/etcd/peer-key.pem \
+  --peer-client-cert-auth --peer-trusted-ca-file=/etc/kubernetes/pki/etcd/peer-ca.pem \
+  --initial-cluster \${URLS} --initial-cluster-token my-etcd-token --initial-cluster-state new
 
 [Install]
 WantedBy=multi-user.target
@@ -168,8 +196,10 @@ systemctl enable etcd
 systemctl start etcd
 systemctl status etcd
 
-add_me_if_not_count "etcd/servers-done" $ETCD_SERVER_COUNT
+echo "Etcd started, lets go!"
+add_me_if_not_count "etcd/servers-done" $ETCD_SERVER_COUNT $ETCD_IP
 
+echo "Waiting for ${ETCD_SERVER_COUNT} servers to complete etcd install"
 wait_for_count "etcd/servers-done" $ETCD_SERVER_COUNT
 
 exit 0

--- a/krib/templates/krib-config.sh.tmpl
+++ b/krib/templates/krib-config.sh.tmpl
@@ -177,8 +177,10 @@ do
   sleep 2
 done
 
-AC=$(wait_for_variable $KRIB_ADMIN_CONF_PARAM)
-# set labels for nodes / runs on all nodes
+# Wait for KRIB config to be updated from bootstrap node
+wait_for_variable $KRIB_ADMIN_CONF_PARAM > label.conf
+
+# Set labels for nodes / runs on all nodes
 drpcli -T $PROFILE_TOKEN profiles get $CLUSTER_PROFILE param $KRIB_ADMIN_CONF_PARAM > label.conf
 # Re-set HOSTNAME to kubernetes node name
 HOSTNAME=$(kubectl --kubeconfig=label.conf get nodes | cut -d" " -f1 | grep -i $(hostname -s))

--- a/krib/templates/krib-config.sh.tmpl
+++ b/krib/templates/krib-config.sh.tmpl
@@ -33,6 +33,15 @@ fi
 VALUE=$(sysctl -n net.bridge.bridge-nf-call-iptables)
 [ $VALUE != 1 ] && sysctl -w net.bridge.bridge-nf-call-iptables=1
 
+{{ if .ParamExists "krib/ip" -}}
+KRIB_IP={{ .Param "krib/ip" }}
+{{ else -}}
+KRIB_IP={{ .Machine.Address }}
+{{ end -}}
+
+# Making sure I use the right cluster InternalIP
+echo "KUBELET_EXTRA_ARGS=--node-ip=${KRIB_IP}" > /etc/default/kubelet
+
 MASTER_INDEX=$(find_me $KRIB_MASTERS_PARAM "Uuid" $RS_UUID)
 echo "My Master index is $MASTER_INDEX"
 if [[ $MASTER_INDEX != notme ]] ; then
@@ -68,7 +77,7 @@ if [[ $MASTER_INDEX != notme ]] ; then
     drpcli -T $PROFILE_TOKEN profiles add $CLUSTER_PROFILE param $KRIB_MASTER_CERTS_PARAM to /tmp/cert.b64
     rm /tmp/cert.tgz /tmp/cert.b64
 
-    JOIN_CMD=$(cat /tmp/kubeadm.init.log | grep "kubeadm join")
+    JOIN_CMD=$(kubeadm token create --print-join-command)
 
     NET_TYPE={{ .Param "krib/networking-provider" }}
 
@@ -143,10 +152,10 @@ if [[ $MASTER_INDEX != notme ]] ; then
     {{end}}
 
     echo "Recording 'kubeadm' bootstrap config ..."
-    drpcli -T $PROFILE_TOKEN profiles add $CLUSTER_PROFILE param $KRIB_CLUSTER_KUBEADM_CFG_PARAM to "$(cat /tmp/kubeadm.cfg)"
+    drpcli -T $PROFILE_TOKEN profiles add $CLUSTER_PROFILE param $KRIB_CLUSTER_KUBEADM_CFG_PARAM to - < /tmp/kubeadm.cfg
 
     echo "Recording cluster admin config ..."
-    drpcli -T $PROFILE_TOKEN profiles add $CLUSTER_PROFILE param $KRIB_ADMIN_CONF_PARAM to "$(cat /etc/kubernetes/admin.conf)"
+    drpcli -T $PROFILE_TOKEN profiles add $CLUSTER_PROFILE param $KRIB_ADMIN_CONF_PARAM to - < /etc/kubernetes/admin.conf
 
     echo "Recording cluster join script ..."
     drpcli -T $PROFILE_TOKEN profiles add $CLUSTER_PROFILE param $KRIB_JOIN_PARAM to "$JOIN_CMD"

--- a/krib/templates/krib-get-masters.sh.tmpl
+++ b/krib/templates/krib-get-masters.sh.tmpl
@@ -23,6 +23,12 @@ xiterr 1 "Missing krib/cluster-profile on the machine!"
 MASTER_ON_ETCDS={{.Param "krib/cluster-masters-on-etcds"}}
 ETCD_COUNT={{.Param "etcd/server-count"}}
 
+{{ if .ParamExists "krib/ip" -}}
+KRIB_IP={{ .Param "krib/ip" }}
+{{ else -}}
+KRIB_IP={{ .Machine.Address }}
+{{ end -}}
+
 # Get the number of servers to create
 KRIB_MASTER_COUNT={{.Param "krib/cluster-master-count"}}
 echo "Creating $KRIB_MASTER_COUNT k8s masters"
@@ -61,7 +67,7 @@ else
 fi
 
 echo "Electing Members to $CLUSTER_PROFILE"
-MASTER_INDEX=$(add_me_if_not_count "$KRIB_MASTERS_PARAM" $KRIB_MASTER_COUNT)
+MASTER_INDEX=$(add_me_if_not_count "$KRIB_MASTERS_PARAM" $KRIB_MASTER_COUNT $KRIB_IP)
 if [[ $MASTER_INDEX == notme ]] ; then
   echo "I am not a master server.  Move on."
 

--- a/krib/templates/krib-kubeadm.cfg.tmpl
+++ b/krib/templates/krib-kubeadm.cfg.tmpl
@@ -17,14 +17,6 @@ apiServerCertSANs:
 {{ end -}}
 apiServerExtraArgs:
   endpoint-reconciler-type: "lease"
-bootstrapTokens:
-- groups:
-  - system:bootstrappers:kubeadm:default-node-token
-  token: {{ .Param "krib/cluster-bootstrap-token" }}
-  ttl: {{ .Param "krib/cluster-bootstrap-ttl" }}
-  usages:
-  - signing
-  - authentication
 certificatesDir: /etc/kubernetes/pki
 clusterName: {{ .Param "krib/cluster-name" }}
 imageRepository: {{ .Param "krib/cluster-image-repository" }}

--- a/krib/templates/krib-lib.sh.tmpl
+++ b/krib/templates/krib-lib.sh.tmpl
@@ -60,9 +60,9 @@ wait_for_count() {
 add_me_if_not_count() {
   local varname=$1
   local count=$2
+  local me_ip=$3
 
   local me_uuid={{.Machine.Uuid}}
-  local me_ip={{.Machine.Address}}
   local me_name={{.Machine.Name}}
 
   local index="notme"


### PR DESCRIPTION
This adds `krib/ip` and `etcd/ip` which, if set, are used instead of `Machine.Address` when building the `etcd` and `krib` clusters. These do not have to be the same as each other, either.

This means a KRIB cluster can be told to run over specific network(s) rather than using the network which the node was discovered over by `provision`. 
