### PR TITLE
add MegaCli 32bit requirements for RAID plugin

### DIFF
--- a/sledgehammer-builder/bootenvs/build-sledgehammer.yaml
+++ b/sledgehammer-builder/bootenvs/build-sledgehammer.yaml
@@ -102,6 +102,7 @@ Templates:
       fuse-ntfs-3g
       gdisk
       glibc
+      glibc.i686
       gzip
       hostname
       initscripts
@@ -115,6 +116,7 @@ Templates:
       kernel-tools
       kexec-tools
       less
+      libstdc++.i686
       libsysfs
       linux-firmware
       lldpd
@@ -127,6 +129,7 @@ Templates:
       {{end}}
       mktemp
       ncurses
+      ncurses-libs.i686
       nfs-utils
       ntfs-3g
       ntfsprogs


### PR DESCRIPTION
adds 32bit (i686) requirements for RAID module `MegaCli` operation:
- install glibc.i686
- libstdc++.i686
- ncurses-libs.i686