### PR TITLE
remove deprecated RunnerWait from Stages

### DIFF
--- a/content/stages/aws-discover.yaml
+++ b/content/stages/aws-discover.yaml
@@ -3,7 +3,6 @@ Name: "aws-discover"
 Description: "Stage to dynamically determine if machine is in AWS and record metadata"
 Documentation: |
   Collect information about AWS cloud
-RunnerWait: true
 Tasks:
   - "aws-discover"
 Meta:

--- a/content/stages/centos-7.6.1810.yml
+++ b/content/stages/centos-7.6.1810.yml
@@ -2,7 +2,6 @@
 Name: "centos-7.6.1810-install"
 Description: "CentOS 7.6.1810 install stage."
 BootEnv: "centos-7.6.1810-install"
-RunnerWait: true
 Tasks:
   - "set-hostname"
   - "centos-drp-only-repos"

--- a/content/stages/centos-7.yml
+++ b/content/stages/centos-7.yml
@@ -2,7 +2,6 @@
 Name: "centos-7-install"
 Description: "CentOS 7 install stages.  References the latest CentOS 7 release"
 BootEnv: "centos-7-install"
-RunnerWait: true
 Tasks:
   - "set-hostname"
   - "centos-drp-only-repos"

--- a/content/stages/complete-nowait.yaml
+++ b/content/stages/complete-nowait.yaml
@@ -5,7 +5,6 @@ Documentation: |
   This is deprectated and leaves the runner running, but will exit install bootenvs correctly.
   The use of this was to exit install workflows.  This will continue to work for that, but
   should be replaced by finish-install.
-RunnerWait: false
 BootEnv: "local"
 Meta:
   icon: "checkmark"

--- a/content/stages/complete.yml
+++ b/content/stages/complete.yml
@@ -2,7 +2,6 @@
 Name: "complete"
 Description: "Stage that represents workflow completion to local disk boot but leaves the runner running."
 BootEnv: "local"
-RunnerWait: true
 Meta:
   icon: "check circle outline"
   color: "green"

--- a/content/stages/debian-8.yml
+++ b/content/stages/debian-8.yml
@@ -2,7 +2,6 @@
 Name: "debian-8-install"
 Description: "Debian 8 install stage.  References latest debian 8 install image."
 BootEnv: "debian-8-install"
-RunnerWait: true
 Tasks:
   - "ubuntu-drp-only-repos"
   - "ssh-access"

--- a/content/stages/debian-9.yml
+++ b/content/stages/debian-9.yml
@@ -2,7 +2,6 @@
 Name: "debian-9-install"
 Description: "Debian 9 install stage.  References the latest Debian 9 image"
 BootEnv: "debian-9-install"
-RunnerWait: true
 Tasks:
   - "ubuntu-drp-only-repos"
   - "ssh-access"

--- a/content/stages/discover-no-gohai.yaml
+++ b/content/stages/discover-no-gohai.yaml
@@ -6,7 +6,6 @@ Documentation: |
 
   Pre gohai/skip Parameter, used to run discovery without gohai action.
 BootEnv: "sledgehammer"
-RunnerWait: true
 Tasks:
   - "ssh-access"
 Meta:

--- a/content/stages/discover.yaml
+++ b/content/stages/discover.yaml
@@ -2,7 +2,6 @@
 Name: "discover"
 Description: "Discovery stage used to inventory and baseline new machines"
 BootEnv: "sledgehammer"
-RunnerWait: true
 Tasks:
   - "gohai"
   - "ssh-access"

--- a/content/stages/erase-hard-disk-set.yaml
+++ b/content/stages/erase-hard-disk-set.yaml
@@ -3,7 +3,6 @@ Name: "erase-hard-disk-set"
 Description: |
   Erases a set of disks.
 BootEnv: "sledgehammer"
-RunnerWait: true
 Tasks:
   - "erase-hard-disk-set"
 Meta:

--- a/content/stages/finish-install.yaml
+++ b/content/stages/finish-install.yaml
@@ -8,9 +8,7 @@ Documentation: |
   Going forward, the STOP action is not required.  The changing of bootenv from something-install to
   local will cause the runner to exit.
 
-  The runner will also continue to run regardless of the RunnerWait flag.
 BootEnv: "local"
-RunnerWait: false
 Meta:
   icon: "checkmark"
   color: "yellow"

--- a/content/stages/gce-discover.yaml
+++ b/content/stages/gce-discover.yaml
@@ -3,7 +3,6 @@ Name: "gce-discover"
 Description: "Stage to dynamically determine if machine is in GCE and record metadata"
 Documentation: |
   Collect information about Google cloud
-RunnerWait: true
 Tasks:
   - "gce-discover"
 Meta:

--- a/content/stages/machine-meta.yaml
+++ b/content/stages/machine-meta.yaml
@@ -5,6 +5,5 @@ Meta:
   icon: "info"
 Name: "machine-meta"
 Reboot: false
-RunnerWait: true
 Tasks:
   - "machine-meta-setter"

--- a/content/stages/prep-install.yaml
+++ b/content/stages/prep-install.yaml
@@ -4,7 +4,6 @@ Description: |
   Prepares system for OS install by zeroing out any data on the disks
   that might confuse the OS install process.
 BootEnv: "sledgehammer"
-RunnerWait: true
 Tasks:
   - "erase-hard-disks-for-os-install"
 Meta:

--- a/content/stages/reorder-uefi-bootorder.yaml
+++ b/content/stages/reorder-uefi-bootorder.yaml
@@ -1,7 +1,6 @@
 ---
 Name: reorder-uefi-bootorder
 Description: Reorder the UEFI bootorder during OS install to make the current boot device the first one.
-RunnerWait: true
 Tasks:
   - always-pxe-in-uefi-first
 Meta:

--- a/content/stages/sledgehammer-wait.yaml
+++ b/content/stages/sledgehammer-wait.yaml
@@ -2,7 +2,6 @@
 Name: "sledgehammer-wait"
 Description: "Wait for more tasks in sledgehammer - useful for debugging"
 BootEnv: "sledgehammer"
-RunnerWait: true
 Meta:
   icon: "hand paper"
   color: "blue"

--- a/content/stages/ssh-access.yaml
+++ b/content/stages/ssh-access.yaml
@@ -1,7 +1,6 @@
 ---
 Name: "ssh-access"
 Description: "Stage that installs SSH keys and configure SSH access policy"
-RunnerWait: true
 Tasks:
   - "ssh-access"
 Meta:

--- a/content/stages/ubuntu-16.04.yml
+++ b/content/stages/ubuntu-16.04.yml
@@ -2,7 +2,6 @@
 Name: "ubuntu-16.04-install"
 Description: "Ubuntu 16.04 installation stage.  References latest release"
 BootEnv: "ubuntu-16.04-install"
-RunnerWait: true
 Tasks:
   - "ubuntu-drp-only-repos"
   - "ssh-access"

--- a/content/stages/ubuntu-18.04-arm64-hwe.yml
+++ b/content/stages/ubuntu-18.04-arm64-hwe.yml
@@ -11,7 +11,6 @@ Profiles: []
 ReadOnly: true
 Reboot: false
 RequiredParams: []
-RunnerWait: true
 Tasks:
 - ubuntu-drp-only-repos
 - ssh-access

--- a/content/stages/ubuntu-18.04.yml
+++ b/content/stages/ubuntu-18.04.yml
@@ -20,7 +20,6 @@ Profiles: []
 ReadOnly: true
 Reboot: false
 RequiredParams: []
-RunnerWait: true
 Tasks:
 - ubuntu-drp-only-repos
 - ssh-access


### PR DESCRIPTION
`RunnerWait` is deprecated and no longer observed.  Removing from all community content stages so as to avoid any confusion.