### PR TITLE
check if /etc/fstab exists before remove swap entry from it

### DIFF
--- a/krib/templates/krib-config.sh.tmpl
+++ b/krib/templates/krib-config.sh.tmpl
@@ -20,7 +20,9 @@ xiterr 1 "Missing krib/cluster-profile on the machine!"
 echo "MAKE SURE SWAP IS OFF!- kubeadm requirement"
 if free | grep -q Swap ; then
   swapoff -a
-  sed -i /swap/d /etc/fstab
+  if [ -f /etc/fstab ]; then
+    sed -i /swap/d /etc/fstab
+  fi
 fi
 
 echo "MAKE SURE bridge-nf-call-iptables CONTAINS 1 - kubeadm requirement"


### PR DESCRIPTION
When installing Kubernetes on CoreOS it fails due to missing `/etc/fstab`. Problem described in issue #223.