### PR TITLE
load kernel module br_netfilter if already not loaded

### DIFF
--- a/krib/templates/krib-config.sh.tmpl
+++ b/krib/templates/krib-config.sh.tmpl
@@ -23,6 +23,12 @@ if free | grep -q Swap ; then
   sed -i /swap/d /etc/fstab
 fi
 
+echo "MAKE SURE kernel module br_netfilter is loaded - kubeadm requirement"
+if ! lsmod | grep ^br_netfilter > /dev/null ; then
+    modprobe br_netfilter
+    echo "br_netfilter" > /etc/modules-load.d/br_netfilter.conf
+fi
+
 echo "MAKE SURE bridge-nf-call-iptables CONTAINS 1 - kubeadm requirement"
 if [ ! -f /etc/sysctl.d/99-net.bridge.bridge-nf-call-iptables ]; then
   cat <<EOF >/etc/sysctl.d/99-net.bridge.bridge-nf-call-iptables


### PR DESCRIPTION
When installing Kubernetes on CoreOS live bootenv the kernel module br_netfilter isn't loaded. This solves the problem described in issue #224.