### PR TITLE
remove extra volumes mount of hyperkube

### DIFF
--- a/krib/templates/krib-kubeadm.cfg.tmpl
+++ b/krib/templates/krib-kubeadm.cfg.tmpl
@@ -20,21 +20,7 @@ nodeRegistration:
 ---
 apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
-controllerManager:
-  extraVolumes:
-    - name: hyperkube
-      hostPath: /k8s/hyperkube
-      mountPath: /hyperkube
-scheduler:
-  extraVolumes:
-    - name: hyperkube
-      hostPath: /k8s/hyperkube
-      mountPath: /hyperkube
 apiServer:
-  extraVolumes:
-    - name: hyperkube
-      hostPath: /k8s/hyperkube
-      mountPath: /hyperkube
   extraArgs:
     audit-log-path: /var/log/kubernetes/audit
     audit-log-maxage: "2"


### PR DESCRIPTION
Api server, scheduler and control manager can't start due to extra volume mount to missing `hyperkube` binary. This PR removes these extra volumes and solves problem described in detail in issue #225.