### PR TITLE
add missing kernel-options and OptionalParams

### DIFF
--- a/content/bootenvs/centos-7.6.1810.yml
+++ b/content/bootenvs/centos-7.6.1810.yml
@@ -49,6 +49,7 @@ OptionalParams:
   - "operating-system-disk"
   - "provisioner-default-password-hash"
   - "kernel-console"
+  - "kernel-options"
   - "proxy-servers"
   - "select-kickseed"
 Templates:

--- a/content/bootenvs/centos-7.yml
+++ b/content/bootenvs/centos-7.yml
@@ -49,6 +49,7 @@ OptionalParams:
   - "operating-system-disk"
   - "provisioner-default-password-hash"
   - "kernel-console"
+  - "kernel-options"
   - "proxy-servers"
   - "select-kickseed"
 Templates:

--- a/content/bootenvs/debian-8.yml
+++ b/content/bootenvs/debian-8.yml
@@ -50,6 +50,7 @@ OptionalParams:
   - "provisioner-default-uid"
   - "provisioner-default-password-hash"
   - "kernel-console"
+  - "kernel-options"
   - "proxy-servers"
   - "dns-domain"
   - "local-repo"

--- a/content/bootenvs/debian-9.yml
+++ b/content/bootenvs/debian-9.yml
@@ -49,6 +49,7 @@ OptionalParams:
   - "provisioner-default-uid"
   - "provisioner-default-password-hash"
   - "kernel-console"
+  - "kernel-options"
   - "proxy-servers"
   - "dns-domain"
   - "local-repo"

--- a/content/bootenvs/discovery.yml
+++ b/content/bootenvs/discovery.yml
@@ -61,6 +61,7 @@ OS:
         {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
 OptionalParams:
   - "kernel-console"
+  - "kernel-options"
 Templates:
   - Name: "pxelinux"
     Path: "pxelinux.cfg/default"

--- a/content/bootenvs/sledgehammer.yml
+++ b/content/bootenvs/sledgehammer.yml
@@ -37,6 +37,7 @@ OS:
         rd_NO_DM
         provisioner.web={{.ProvisionerURL}}
         rs.uuid={{.Machine.UUID}}
+        {{if .ParamExists "kernel-options"}}{{.Param "kernel-options"}}{{end}}
         --
         {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
     arm64:
@@ -57,10 +58,12 @@ OS:
         rd_NO_DM
         provisioner.web={{.ProvisionerURL}}
         rs.uuid={{.Machine.UUID}}
+        {{if .ParamExists "kernel-options"}}{{.Param "kernel-options"}}{{end}}
         --
         {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
 OptionalParams:
   - "kernel-console"
+  - "kernel-options"
 Templates:
   - Name: "kexec"
     ID: "kexec.tmpl"

--- a/content/bootenvs/ubuntu-16.04.yml
+++ b/content/bootenvs/ubuntu-16.04.yml
@@ -43,6 +43,7 @@ OptionalParams:
   - "provisioner-default-uid"
   - "provisioner-default-password-hash"
   - "kernel-console"
+  - "kernel-options"
   - "proxy-servers"
   - "dns-domain"
   - "local-repo"

--- a/content/bootenvs/ubuntu-18.04-arm64-hwe.yml
+++ b/content/bootenvs/ubuntu-18.04-arm64-hwe.yml
@@ -49,6 +49,7 @@ OptionalParams:
   - provisioner-default-uid
   - provisioner-default-password-hash
   - kernel-console
+  - kernel-options
   - proxy-servers
   - dns-domain
   - local-repo

--- a/content/bootenvs/ubuntu-18.04.yml
+++ b/content/bootenvs/ubuntu-18.04.yml
@@ -73,6 +73,7 @@ OptionalParams:
   - provisioner-default-uid
   - provisioner-default-password-hash
   - kernel-console
+  - kernel-options
   - proxy-servers
   - dns-domain
   - local-repo


### PR DESCRIPTION
- missing `kernel-options` in sledgehammer bootenv
- added `OptionalParams` references for `kernel-options`