### PR TITLE
Add a task and stage and parameters that can be used to

### DIFF
--- a/content/params/sledgehamer-enforce.yaml
+++ b/content/params/sledgehamer-enforce.yaml
@@ -1,0 +1,12 @@
+---
+Name: "sledgehammer/enforce"
+Description: "Should the system enforce being in sledgehammer"
+Documentation: |
+  Boolean parameter indicating if the enforce-sledgehammer task should ensure that the system is running in sledgehammer.
+Schema:
+  type: "boolean"
+  default: false
+Meta:
+  icon: "search minus"
+  color: "blue"
+  title: "Digital Rebar Community Content"

--- a/content/params/sledgehamer-reboot-if-not-in-sledgehammer.yaml
+++ b/content/params/sledgehamer-reboot-if-not-in-sledgehammer.yaml
@@ -1,0 +1,12 @@
+---
+Name: "sledgehammer/reboot-if-not-in-sledgehammer"
+Description: "Should the system reboot if not in sledgehammer"
+Documentation: |
+  Boolean parameter indicating if the enforce-sledgehammer task should reboot the system if not in sledgehammer.
+Schema:
+  type: "boolean"
+  default: false
+Meta:
+  icon: "search minus"
+  color: "blue"
+  title: "Digital Rebar Community Content"

--- a/content/stages/discover.yaml
+++ b/content/stages/discover.yaml
@@ -3,6 +3,7 @@ Name: "discover"
 Description: "Discovery stage used to inventory and baseline new machines"
 BootEnv: "sledgehammer"
 Tasks:
+  - "enforce-sledgehammer"
   - "gohai"
   - "ssh-access"
 Meta:

--- a/content/stages/enforce-sledgehammer.yaml
+++ b/content/stages/enforce-sledgehammer.yaml
@@ -1,0 +1,9 @@
+---
+Name: "enforce-sledgehammer"
+Description: "Ensure that the system is in sledgehammer"
+Tasks:
+  - "enforce-sledgehammer"
+Meta:
+  icon: "spinner"
+  color: "purple"
+  title: "Digital Rebar Community Content"

--- a/content/tasks/enforce-sledgehammer.yaml
+++ b/content/tasks/enforce-sledgehammer.yaml
@@ -1,0 +1,43 @@
+---
+Name: "enforce-sledgehammer"
+Description: "Make sure the system is in sledgehammer"
+Documentation: |
+  Sets Param: gohai-inventory
+
+  Collect inventory from machines using drpcli gohai command
+  and store the result in the gohai-inventory Param on the machine.
+
+  If you want to disable this behavior, set the gohai/skip Param to true.
+
+  Hint: this can be A LOT of data added to the machine param!  You may
+  want to use ?slim in the API to skip returning it on list requests.
+OptionalParams:
+  - sledgehammer/enforce
+  - sledgehammer/reboot-if-not-in-sledgehammer
+Templates:
+  - Name: "enforce-sledgehammer"
+    Contents: |
+      #!/usr/bin/env bash
+      . helper
+      __sane_exit
+
+      {{if .Param "sledgehammer/enforce" -}}
+        if ! grep -q 'sledgehammer\.iso' /proc/cmdline; then
+          {{if .Param "sledgehammer/reboot-if-not-in-sledgehammer" -}}
+            echo "System not in Sledgehammer, rebooting"
+            exit_reboot
+          {{else -}}
+            echo "System not in Sledgehammer, failing"
+            exit 1
+          {{end -}}
+        fi
+        echo "System in Sledgehammer, exiting"
+      {{else -}}
+        echo "Skipping sledgehammer enforcement"
+      {{end -}}
+      exit 0
+Meta:
+  icon: "search"
+  color: "blue"
+  title: "Digital Rebar Community Content"
+  feature-flags: "sane-exit-codes"


### PR DESCRIPTION
Add a task and stage and parameters that can be used to
enforce that a system is sledgehammer.  While hard to do,
there are times that the system can get out of sync with
itself and the admin wants to enforce that the system is
in sledgehammer.  The primary way this happens is that a
Next-Boot-Pxe call failed and the system ended up back
in the original local booted operating system.

The default discovery stage will allow for enforcing this
or a new stage can be added to an existing workflow,
enforce-sledgehammer.

Whether the new task should enforce or not is controlled
by the parameter 'sledgehamer/enforce'.  This defaults to
false, but when set to true, the task will fail if not
in sledgehammer.  Additionally, the parameter,
'sledgehammer/reboot-if-not-in-sledgehammer`, when set
to true (not the default), will reboot the system instead
of failing.