### PR TITLE
adding function to umount when the /dev/sda1

### DIFF
--- a/krib/templates/mount-disks.sh.tmpl
+++ b/krib/templates/mount-disks.sh.tmpl
@@ -48,7 +48,7 @@ partprobe
 
 echo "Make filesystem - xfs - docker likes it"
 
-mkfs.xfs /dev/${GETDISK}1
+mkfs.xfs -f /dev/${GETDISK}1
 
 echo "Mount filesystem - put it in place, put not permanently"
 

--- a/krib/templates/mount-disks.sh.tmpl
+++ b/krib/templates/mount-disks.sh.tmpl
@@ -24,6 +24,13 @@ case $BE in
     ;;
 esac
 
+# Umount disk if already mounted
+if mount | grep /mnt/sda1 > /dev/null; then
+    umount /dev/sda1
+else
+    echo "/dev/sda1 is not mounted"
+fi
+
 GETDISK=$(lsblk | grep "disk" | awk '{ print $1 }' | head -1)
 echo "Found /dev/$GETDISK - using ..."
 


### PR DESCRIPTION
i think better is check the /dev/sda1 already mounted or not, if already mounted, better we umount first,  so when we re-running the krib-live-cluster workflow for the 2nd time cause by failed one of the stage after mount-disk, it will work