### PR TITLE
add sipcalc to sledgehammer

### DIFF
--- a/sledgehammer-builder/tasks/sledgehammer-stage-bits.yaml
+++ b/sledgehammer-builder/tasks/sledgehammer-stage-bits.yaml
@@ -412,6 +412,16 @@ Templates:
       var/cache/yum/*
       usr/local/bin/*
       usr/share/doc
+  - Name: install-sipcalc
+    Contents: |
+      #!/bin/bash
+      # 'arch' is built for "x86_64", "aarch64, "armv7hl"
+      # for ARM arch types - not tested yet
+      # orig source location: https://koji.fedoraproject.org/koji/packageinfo?packageID=8762
+      arch=$(uname -p)
+      wget https://s3-us-west-2.amazonaws.com/rackn-sledgehammer/sipcalc-1.1.6-15.fc30.$arch.rpm -O /root/sipcalc.rpm
+      yum install -y /root/sipcalc.rpm
+      rm -rf /root/sipcalc.rpm
   - Name: update-systemd
     Contents: |
       #!/bin/bash


### PR DESCRIPTION
- adds sipcalc 1.1.6-15 from Fedora Core 30 build packages
- staged on rackn S3 bucket for retrieval
- original source location: https://koji.fedoraproject.org/koji/packageinfo?packageID=8762
- tested successfully for x86_64 build sledgehammer
- `aarch64`, `armv7hl`, and `i686` packages exist, but those builds have not been tested
  * relies on `uname -p` to return a match to above values
  * if ARM versions don't match, some `case` mangling may need to be added to get the right package version

