### PR TITLE
add dns search domains and servers

### DIFF
--- a/content/params/dns-search-domains.yaml
+++ b/content/params/dns-search-domains.yaml
@@ -1,0 +1,16 @@
+---
+Name: "dns-search-domains"
+Description: "Defines the set of DNS Search Domains to apply to the system."
+Documentation: |
+  This is an array of strings where each string a domain to apply to the DNS
+  search order list.
+
+Schema:
+  type: "array"
+  items:
+    type: "string"
+
+Meta:
+  icon: "time"
+  color: "blue"
+  title: "Digital Rebar Community Content"

--- a/content/params/dns-servers.yaml
+++ b/content/params/dns-servers.yaml
@@ -1,0 +1,16 @@
+---
+Name: "dns-servers"
+Description: "Defines the set of DNS servers to apply to the system."
+Documentation: |
+  This is an array of strings where each string an IP address of a DNS
+  server.
+
+Schema:
+  type: "array"
+  items:
+    type: "string"
+
+Meta:
+  icon: "time"
+  color: "blue"
+  title: "Digital Rebar Community Content"


### PR DESCRIPTION
- add params `dns-servers` and `dns-search-domains`
- currently only used in the ESXi content
- useful for all bootenv content types