### PR TITLE
Change 'if' to use 'eq ... true' check

### DIFF
--- a/content/tasks/enforce-sledgehammer.yaml
+++ b/content/tasks/enforce-sledgehammer.yaml
@@ -21,7 +21,7 @@ Templates:
       . helper
       __sane_exit
 
-      {{if .Param "sledgehammer/enforce" -}}
+      {{if eq (.Param "sledgehammer/enforce") true -}}
         if ! grep -q 'sledgehammer\.iso' /proc/cmdline; then
           {{if .Param "sledgehammer/reboot-if-not-in-sledgehammer" -}}
             echo "System not in Sledgehammer, rebooting"


### PR DESCRIPTION
Current check of `if .Param "sledgehammer/enforce"` always passed since the Param exists in community content.

Modify the check to use `if eq (.Param "sledgehammer/enforce" true`.