### PR TITLE
Make sure docker config dir exists before trying to create daemon.json

### DIFF
--- a/krib/templates/docker-install.sh.tmpl
+++ b/krib/templates/docker-install.sh.tmpl
@@ -31,6 +31,7 @@ fi
 
 {{if .ParamExists "docker/daemon"}}
 echo "Creating /etc/docker/daemon.json file from Param docker/daemon"
+mkdir -p /etc/docker
 cat <<EOF >/etc/docker/daemon.json
 {{.ParamAsJSON "docker/daemon"}}
 EOF


### PR DESCRIPTION
Seems like docker packages on C7 at least are not creating `/etc/docker` on install anymore - so the creation of `/etc/docker/daemon.json` if specifying `docker/daemon` fails as the directory doesn't exist.
