### PR TITLE
Add a runner-tmpdir param.

### DIFF
--- a/content/params/runner-tmpdir.yaml
+++ b/content/params/runner-tmpdir.yaml
@@ -8,7 +8,7 @@ Documentation: |
   override that default location on a machine-by-machine basis.  On
   Unix systems, it does this by setting the TMPDIR environment
   variable to the value if this parameter when the agent start up.  On
-  Windows.  it dues so by setting the TMP environment variable
+  Windows, it does so by setting the TMP environment variable
   instead.  If this parameter is left unset, then the machine agent
   will use whatever the default values for the system are.
 Schema:

--- a/content/params/runner-tmpdir.yaml
+++ b/content/params/runner-tmpdir.yaml
@@ -1,0 +1,20 @@
+---
+Name: runner-tmpdir
+Description: The temp directory the runner should keep scratch data in
+Documentation: |
+  Normally, when the machine agent runs tasks, it uses a hierarchy of
+  scratch directories underneath /tmp to hold temporary running data,
+  such as job logs, generated scripts, etc.  This param allows you to
+  override that default location on a machine-by-machine basis.  On
+  Unix systems, it does this by setting the TMPDIR environment
+  variable to the value if this parameter when the agent start up.  On
+  Windows.  it dues so by setting the TMP environment variable
+  instead.  If this parameter is left unset, then the machine agent
+  will use whatever the default values for the system are.
+Schema:
+  type: string
+  default: ''
+Meta:
+  icon: "folder"
+  color: "blue"
+  title: "Digital Rebar Community Content"


### PR DESCRIPTION
This lets the location that the runner will use to store the
scratch files it uses in the case that we cannot rely on the continual
availability of the system default location.