### PR TITLE
Make etcd ha

### DIFF
--- a/krib/params/etcd-cluster-client-vip-port.yaml
+++ b/krib/params/etcd-cluster-client-vip-port.yaml
@@ -1,0 +1,17 @@
+---
+Name: "etcd/cluster-client-vip-port"
+Description: "VIP etcd client port for multi-master etcd clusters (default 8379)"
+Documentation: |
+  The VIP client port to use for multi-master etcd clusters. Each
+  etcd instance will bind to 'etcd/client-port' (2379 by default),
+  but HA services will be serviced by this port number.
+
+  Defaults to '8379'.
+
+Schema:
+  type: "number"
+  default: 8379
+Meta:
+  color: "blue"
+  icon: "ship"
+  title: "Community Content"

--- a/krib/tasks/etcd-config.yaml
+++ b/krib/tasks/etcd-config.yaml
@@ -10,7 +10,8 @@ RequredParams:
 OptionalParams:
   - etcd/client-ca-name
   - etcd/client-ca-pw
-  - etcd/client-port
+  - etcd/client-ca-name  
+  - etcd/cluster-client-vip-port
   - etcd/name
   - etcd/peer-ca-name
   - etcd/peer-ca-pw

--- a/krib/templates/etcd-config.sh.tmpl
+++ b/krib/templates/etcd-config.sh.tmpl
@@ -28,7 +28,7 @@ build_cert() {
 
   echo "Generating certificate for ${profile} with my name ${myname} and my IP ${myip}"
   drpcli machines runaction $RS_UUID getca certs/root $ca_name | jq -r . > /etc/kubernetes/pki/etcd/${profile}-ca.pem
-  drpcli certs csr $ca_name $myname $RS_IP $myip $(hostname) {{ .Param "krib/cluster-master-vip" }} > tmp.csr
+  drpcli certs csr $ca_name $myname $RS_IP $myip $(hostname) {{if .ParamExists "krib/cluster-master-vip" }}{{ .Param "krib/cluster-master-vip" }}{{end}} > tmp.csr
   drpcli machines runaction $RS_UUID signcert certs/root $ca_name certs/root-pw $ca_pw certs/csr "$(jq .CSR tmp.csr)" certs/profile $profile | jq -r . > /etc/kubernetes/pki/etcd/$profile.pem
   jq -r .Key tmp.csr > /etc/kubernetes/pki/etcd/$profile-key.pem
   rm tmp.csr

--- a/krib/templates/etcd-config.sh.tmpl
+++ b/krib/templates/etcd-config.sh.tmpl
@@ -28,7 +28,7 @@ build_cert() {
 
   echo "Generating certificate for ${profile} with my name ${myname} and my IP ${myip}"
   drpcli machines runaction $RS_UUID getca certs/root $ca_name | jq -r . > /etc/kubernetes/pki/etcd/${profile}-ca.pem
-  drpcli certs csr $ca_name $myname $RS_IP $myip $(hostname) > tmp.csr
+  drpcli certs csr $ca_name $myname $RS_IP $myip $(hostname) {{ .Param "krib/cluster-master-vip" }} > tmp.csr
   drpcli machines runaction $RS_UUID signcert certs/root $ca_name certs/root-pw $ca_pw certs/csr "$(jq .CSR tmp.csr)" certs/profile $profile | jq -r . > /etc/kubernetes/pki/etcd/$profile.pem
   jq -r .Key tmp.csr > /etc/kubernetes/pki/etcd/$profile-key.pem
   rm tmp.csr

--- a/krib/templates/krib-haproxy.cfg.tmpl
+++ b/krib/templates/krib-haproxy.cfg.tmpl
@@ -55,6 +55,15 @@ frontend k8s-api
   tcp-request content accept if { req.ssl_hello_type 1 }
   default_backend k8s-api
 
+frontend etcd-client
+  bind *:{{ .Param "etcd/cluster-client-vip-port" }}
+  mode tcp
+  option tcplog
+  tcp-request inspect-delay 5s
+  #tcp-request content reject if !HTTP
+  tcp-request content accept if { req.ssl_hello_type 1 }
+  default_backend etcd-client
+
 backend k8s-api
   mode tcp
   option tcplog
@@ -64,4 +73,15 @@ backend k8s-api
 {{ $port := .Param "krib/cluster-api-port" -}}
 {{ range $index, $elem := .Param "krib/cluster-masters" }}
   server k8s-api-{{ $index }} {{ $elem.Address }}:{{ $port }} check
+{{ end -}}
+
+backend etcd-client
+  mode tcp
+  option tcplog
+  option tcp-check
+  balance roundrobin
+  default-server inter 10s downinter 5s rise 2 fall 2 slowstart 60s maxconn 250 maxqueue 256 weight 100
+{{ $port := .Param "etcd/client-port" -}}
+{{ range $index, $elem := .Param "krib/cluster-masters" }}
+  server etcd-client-{{ $index }} {{ $elem.Address }}:{{ $port }} check
 {{ end -}}

--- a/krib/templates/krib-kubeadm.cfg.tmpl
+++ b/krib/templates/krib-kubeadm.cfg.tmpl
@@ -51,10 +51,7 @@ etcd:
     certFile: /etc/kubernetes/pki/etcd/client.pem
     keyFile: /etc/kubernetes/pki/etcd/client-key.pem
     endpoints:
-{{ $port := .Param "etcd/client-port" -}}
-{{- range $elem := .Param "etcd/servers"}}
-    - https://{{ $elem.Address }}:{{ $port }}
-{{ end -}}
+      https://{{ .Param "krib/cluster-master-vip" }}:{{ .Param "etcd/cluster-client-vip-port" }}
 useHyperKubeImage: true
 kubernetesVersion: {{ .Param "krib/cluster-kubernetes-version" }}
 networking:

--- a/krib/templates/krib-kubeadm.cfg.tmpl
+++ b/krib/templates/krib-kubeadm.cfg.tmpl
@@ -51,7 +51,14 @@ etcd:
     certFile: /etc/kubernetes/pki/etcd/client.pem
     keyFile: /etc/kubernetes/pki/etcd/client-key.pem
     endpoints:
+{{if and .ParamExists "krib/cluster-master-vip" .ParamExists "etcd/cluster-client-vip-port" }}
       https://{{ .Param "krib/cluster-master-vip" }}:{{ .Param "etcd/cluster-client-vip-port" }}
+{{else}}
+  {{ $port := .Param "etcd/client-port" -}}
+  {{- range $elem := .Param "etcd/servers"}}
+    - https://{{ $elem.Address }}:{{ $port }}
+  {{ end -}}    
+{{ end -}}
 useHyperKubeImage: true
 kubernetesVersion: {{ .Param "krib/cluster-kubernetes-version" }}
 networking:


### PR DESCRIPTION
Hey guys,

Here's a small PR to make the etcd cluster as "HA" as the api server. The PR introduces a new optional param `etcd/cluster-client-vip-port` (default 8379), and configures an haproxy frontend/backend to serve etcd on this port. `kubeadm.cfg` is updated to use this HA etcd endpoint, rather than individual etcd servers.

Cheers!
D