### PR TITLE
Optional selective mastership

### DIFF
--- a/krib/params/etcd-cluster-client-vip-port.yaml
+++ b/krib/params/etcd-cluster-client-vip-port.yaml
@@ -1,0 +1,17 @@
+---
+Name: "etcd/cluster-client-vip-port"
+Description: "VIP etcd client port for multi-master etcd clusters (default 8379)"
+Documentation: |
+  The VIP client port to use for multi-master etcd clusters. Each
+  etcd instance will bind to 'etcd/client-port' (2379 by default),
+  but HA services will be serviced by this port number.
+
+  Defaults to '8379'.
+
+Schema:
+  type: "number"
+  default: 8379
+Meta:
+  color: "blue"
+  icon: "ship"
+  title: "Community Content"

--- a/krib/params/krib-cluster-i-am-master.yaml
+++ b/krib/params/krib-cluster-i-am-master.yaml
@@ -1,0 +1,19 @@
+---
+Name: "krib/i-am-master"
+Description: "Cause member nodes to assume a GKC master role"
+Documentation: |
+  When this param is set to true AND the krib/selective-mastership param is set to true,
+  then this node will participate in mastership election. On the other hard, if this param
+  is set to false (the default), but krib/selective-mastership param is set to true, then
+  this node will never become a master. This option is useful to prevent dedicated workers from
+  assuming mastership.
+
+  Defaults to 'false'.
+
+Schema:
+  type: "boolean"
+  default: false
+Meta:
+  color: "blue"
+  icon: "ship"
+  title: "Community Content"

--- a/krib/params/krib-cluster-selective-mastership.yaml
+++ b/krib/params/krib-cluster-selective-mastership.yaml
@@ -1,0 +1,17 @@
+---
+Name: "krib/selective-mastership"
+Description: "Require an additional param (krib/i-am-master) to permit a machine to self-elect to master"
+Documentation: |
+  When this param is set to true, then in order for a machine to self-elect to a mastetr,
+  the, krib/i-am-master param must be set for that machine. This option is useful to prevent 
+  dedicated workers from assuming mastership.
+
+  Defaults to 'false'.
+
+Schema:
+  type: "boolean"
+  default: false
+Meta:
+  color: "blue"
+  icon: "ship"
+  title: "Community Content"

--- a/krib/tasks/etcd-config.yaml
+++ b/krib/tasks/etcd-config.yaml
@@ -10,7 +10,8 @@ RequredParams:
 OptionalParams:
   - etcd/client-ca-name
   - etcd/client-ca-pw
-  - etcd/client-port
+  - etcd/client-ca-name  
+  - etcd/cluster-client-vip-port
   - etcd/name
   - etcd/peer-ca-name
   - etcd/peer-ca-pw

--- a/krib/templates/etcd-config.sh.tmpl
+++ b/krib/templates/etcd-config.sh.tmpl
@@ -4,6 +4,10 @@ set -e
 
 # Get access and who we are.
 {{template "setup.tmpl" .}}
+
+# Skip the remainder of this template if this host is not a master in a selective-master deployment
+{{template "krib-skip-if-not-master.tmpl" .}}
+
 export RS_UUID="{{.Machine.UUID}}"
 export RS_IP="{{.Machine.Address}}"
 

--- a/krib/templates/etcd-config.sh.tmpl
+++ b/krib/templates/etcd-config.sh.tmpl
@@ -28,7 +28,7 @@ build_cert() {
 
   echo "Generating certificate for ${profile} with my name ${myname} and my IP ${myip}"
   drpcli machines runaction $RS_UUID getca certs/root $ca_name | jq -r . > /etc/kubernetes/pki/etcd/${profile}-ca.pem
-  drpcli certs csr $ca_name $myname $RS_IP $myip $(hostname) {{ .Param "krib/cluster-master-vip" }} > tmp.csr
+  drpcli certs csr $ca_name $myname $RS_IP $myip $(hostname) {{if .ParamExists "krib/cluster-master-vip" }}{{ .Param "krib/cluster-master-vip" }}{{end}} > tmp.csr
   drpcli machines runaction $RS_UUID signcert certs/root $ca_name certs/root-pw $ca_pw certs/csr "$(jq .CSR tmp.csr)" certs/profile $profile | jq -r . > /etc/kubernetes/pki/etcd/$profile.pem
   jq -r .Key tmp.csr > /etc/kubernetes/pki/etcd/$profile-key.pem
   rm tmp.csr

--- a/krib/templates/etcd-config.sh.tmpl
+++ b/krib/templates/etcd-config.sh.tmpl
@@ -28,7 +28,7 @@ build_cert() {
 
   echo "Generating certificate for ${profile} with my name ${myname} and my IP ${myip}"
   drpcli machines runaction $RS_UUID getca certs/root $ca_name | jq -r . > /etc/kubernetes/pki/etcd/${profile}-ca.pem
-  drpcli certs csr $ca_name $myname $RS_IP $myip $(hostname) > tmp.csr
+  drpcli certs csr $ca_name $myname $RS_IP $myip $(hostname) {{ .Param "krib/cluster-master-vip" }} > tmp.csr
   drpcli machines runaction $RS_UUID signcert certs/root $ca_name certs/root-pw $ca_pw certs/csr "$(jq .CSR tmp.csr)" certs/profile $profile | jq -r . > /etc/kubernetes/pki/etcd/$profile.pem
   jq -r .Key tmp.csr > /etc/kubernetes/pki/etcd/$profile-key.pem
   rm tmp.csr

--- a/krib/templates/etcd-config.sh.tmpl
+++ b/krib/templates/etcd-config.sh.tmpl
@@ -71,6 +71,14 @@ get_member_id() {
 }
 {{ end -}}
 
+## Additional param to explicitly indicate masters
+{{if eq (.ParamExists "krib/selective-mastership") true -}}
+{{if eq (.ParamExists "krib/i-am-master") false -}}
+echo "krib/selective-mastership is true but krib/i-am-master is false. I am denied mastership, so move on"
+exit 0
+{{ end -}}
+{{ end -}}
+
 echo "Configure the etcd cluster"
 
 ETCD_CLUSTER_NAME={{.Param "etcd/name"}}

--- a/krib/templates/krib-get-masters.sh.tmpl
+++ b/krib/templates/krib-get-masters.sh.tmpl
@@ -8,6 +8,23 @@ set -e
 export RS_UUID="{{.Machine.UUID}}"
 export RS_IP="{{.Machine.Address}}"
 
+## Query optionals params which may explicitly indicate masters
+{{if .ParamExists "krib/selective-mastership" -}}SELECTIVE_MASTERSHIP={{.Param "krib/selective-mastership" -}}{{end -}}
+{{if .ParamExists "krib/i-am-master" -}}I_AM_MASTER={{.Param "krib/i-am-master" -}}{{end -}}
+if [[ "$SELECTIVE_MASTERSHIP" == true]]; then
+  if [[ ! "$I_AM_MASTER" == true ]] ; then
+    echo "krib/selective-mastership is true but krib/i-am-master is not. I am denied mastership, so move on"
+    exit 0
+  fi
+fi
+
+{{if .ParamExists "krib/selective-mastership" -}}
+{{if eq (.ParamExists "krib/i-am-master") false -}}
+echo "krib/selective-mastership is true but krib/i-am-master is false. I am denied mastership, so move on"
+exit 0
+{{ end -}}
+{{ end -}}
+
 echo "Elect and wait for the masters"
 
 CLUSTER_NAME={{.Param "krib/cluster-name"}}

--- a/krib/templates/krib-get-masters.sh.tmpl
+++ b/krib/templates/krib-get-masters.sh.tmpl
@@ -5,25 +5,14 @@ set -e
 # Get access and who we are.
 {{template "setup.tmpl" .}}
 
+# Skip the remainder of this template if this host is not a master in a selective-master deployment
+{{template "krib-skip-if-not-master.tmpl" .}}
+
 export RS_UUID="{{.Machine.UUID}}"
 export RS_IP="{{.Machine.Address}}"
 
-## Query optionals params which may explicitly indicate masters
-{{if .ParamExists "krib/selective-mastership" -}}SELECTIVE_MASTERSHIP={{.Param "krib/selective-mastership" -}}{{end -}}
-{{if .ParamExists "krib/i-am-master" -}}I_AM_MASTER={{.Param "krib/i-am-master" -}}{{end -}}
-if [[ "$SELECTIVE_MASTERSHIP" == true]]; then
-  if [[ ! "$I_AM_MASTER" == true ]] ; then
-    echo "krib/selective-mastership is true but krib/i-am-master is not. I am denied mastership, so move on"
-    exit 0
-  fi
-fi
-
-{{if .ParamExists "krib/selective-mastership" -}}
-{{if eq (.ParamExists "krib/i-am-master") false -}}
-echo "krib/selective-mastership is true but krib/i-am-master is false. I am denied mastership, so move on"
-exit 0
-{{ end -}}
-{{ end -}}
+# Skip the remainder of this template if this host is not a master in a selective-master deployment
+{{template "krib-skip-if-not-master.tmpl" .}}
 
 echo "Elect and wait for the masters"
 

--- a/krib/templates/krib-haproxy.cfg.tmpl
+++ b/krib/templates/krib-haproxy.cfg.tmpl
@@ -55,6 +55,15 @@ frontend k8s-api
   tcp-request content accept if { req.ssl_hello_type 1 }
   default_backend k8s-api
 
+frontend etcd-client
+  bind *:{{ .Param "etcd/cluster-client-vip-port" }}
+  mode tcp
+  option tcplog
+  tcp-request inspect-delay 5s
+  #tcp-request content reject if !HTTP
+  tcp-request content accept if { req.ssl_hello_type 1 }
+  default_backend etcd-client
+
 backend k8s-api
   mode tcp
   option tcplog
@@ -64,4 +73,15 @@ backend k8s-api
 {{ $port := .Param "krib/cluster-api-port" -}}
 {{ range $index, $elem := .Param "krib/cluster-masters" }}
   server k8s-api-{{ $index }} {{ $elem.Address }}:{{ $port }} check
+{{ end -}}
+
+backend etcd-client
+  mode tcp
+  option tcplog
+  option tcp-check
+  balance roundrobin
+  default-server inter 10s downinter 5s rise 2 fall 2 slowstart 60s maxconn 250 maxqueue 256 weight 100
+{{ $port := .Param "etcd/client-port" -}}
+{{ range $index, $elem := .Param "krib/cluster-masters" }}
+  server etcd-client-{{ $index }} {{ $elem.Address }}:{{ $port }} check
 {{ end -}}

--- a/krib/templates/krib-kubeadm.cfg.tmpl
+++ b/krib/templates/krib-kubeadm.cfg.tmpl
@@ -51,10 +51,7 @@ etcd:
     certFile: /etc/kubernetes/pki/etcd/client.pem
     keyFile: /etc/kubernetes/pki/etcd/client-key.pem
     endpoints:
-{{ $port := .Param "etcd/client-port" -}}
-{{- range $elem := .Param "etcd/servers"}}
-    - https://{{ $elem.Address }}:{{ $port }}
-{{ end -}}
+      https://{{ .Param "krib/cluster-master-vip" }}:{{ .Param "etcd/cluster-client-vip-port" }}
 useHyperKubeImage: true
 kubernetesVersion: {{ .Param "krib/cluster-kubernetes-version" }}
 networking:

--- a/krib/templates/krib-kubeadm.cfg.tmpl
+++ b/krib/templates/krib-kubeadm.cfg.tmpl
@@ -51,7 +51,14 @@ etcd:
     certFile: /etc/kubernetes/pki/etcd/client.pem
     keyFile: /etc/kubernetes/pki/etcd/client-key.pem
     endpoints:
+{{if and .ParamExists "krib/cluster-master-vip" .ParamExists "etcd/cluster-client-vip-port" }}
       https://{{ .Param "krib/cluster-master-vip" }}:{{ .Param "etcd/cluster-client-vip-port" }}
+{{else}}
+  {{ $port := .Param "etcd/client-port" -}}
+  {{- range $elem := .Param "etcd/servers"}}
+    - https://{{ $elem.Address }}:{{ $port }}
+  {{ end -}}    
+{{ end -}}
 useHyperKubeImage: true
 kubernetesVersion: {{ .Param "krib/cluster-kubernetes-version" }}
 networking:

--- a/krib/templates/krib-skip-if-not-master.tmpl
+++ b/krib/templates/krib-skip-if-not-master.tmpl
@@ -1,0 +1,21 @@
+#### BEGIN krib-skip-if-not-master.tmpl
+# This snippet skips the remainder of the calling template, if 
+# selective mastership is enabled, but the current machine is not
+# selected to be a master. This template is called from etcd-config.sh.tmpl _and_
+# from krib-get-masters.sh.tmpl, so it makes sense to decompose the contents
+# into this single, re-usable template
+
+{{if .ParamExists "krib/selective-mastership" -}}
+SELECTIVE_MASTERSHIP={{.Param "krib/selective-mastership" }}
+{{end -}}
+{{if .ParamExists "krib/i-am-master" -}}
+I_AM_MASTER={{.Param "krib/i-am-master" }}
+{{end -}}
+if [[ "$SELECTIVE_MASTERSHIP" == true ]] ; then
+  if [[ ! "$I_AM_MASTER" == true ]] ; then
+    echo "krib/selective-mastership is true but krib/i-am-master is not. I am denied mastership, so move on"
+    exit 0
+  fi
+fi
+
+#### END krib-skip-if-not-master.tmpl


### PR DESCRIPTION
Hi guys, 

In our environment, we have different hardware for masters vs workers, so we don't necessarily want the workers to self-elect to mastership. However, like all good geeks, we're lazy, and we want to be able to "select all" machines and reinstall the cluster with one click.

To this end, here's a PR which introduces 2 optional parameters for "selective mastership" (disabled by default). If `krib/selective-mastership` is **true** (the default is false), then a machine will skip etc/k8s mastership election unless `krib/i-am-master` is also **true** (again, the default is false).

Cheers!
D