### PR TITLE
Increase random sleep from 5 to 25 sec

### DIFF
--- a/krib/tasks/krib-dev-reset.yaml
+++ b/krib/tasks/krib-dev-reset.yaml
@@ -14,8 +14,8 @@ Templates:
     #!/bin/bash
     # Reset CA params
     set -e
-    # we need a random backoff for races
-    SLEEP=$[ ( $RANDOM % 5 ) ]
+    # we need a random backoff to avoid races.
+    SLEEP=$[ ( $RANDOM % 25 ) ]
     sleep $SLEEP
     declare -a WIPE_PARAMS=('etcd/client-ca-name' 'etcd/client-ca-pw' 'etcd/peer-ca-name' 'etcd/peer-ca-pw' 'etcd/server-ca-name' 'etcd/server-ca-pw')
     {{if .ParamExists "etcd/cluster-profile" -}}

--- a/krib/templates/krib-config.sh.tmpl
+++ b/krib/templates/krib-config.sh.tmpl
@@ -62,6 +62,10 @@ KRIB_IP={{ .Param "krib/ip" }}
 KRIB_IP={{ .Machine.Address }}
 {{ end -}}
 
+# we need a random backoff to avoid races.
+SLEEP=$[ ( $RANDOM % 25 ) ]
+sleep $SLEEP
+
 # Making sure I use the right cluster InternalIP
 echo "KUBELET_EXTRA_ARGS=--node-ip=${KRIB_IP}" > /etc/default/kubelet
 


### PR DESCRIPTION
Hi guys,

Here's a mini-PR.. I've found myself still consistently hitting races when resetting the cluster, even at `$RANDOM % 20`. So I bumped the RANDOM range to 25, and so far, so good. I also added the random sleep to `krib-config.sh.tmpl`, since I saw races there too (_I have a workflow for "soft" reinstalling a cluster, without an OS rebuild, which I'll be PRing soon - the race is more evident there_)

Cheers!
D