### PR TITLE
Correctly use HA cluster endpoint (WIP - input requested)

### DIFF
--- a/krib/templates/krib-kubeadm.cfg.tmpl
+++ b/krib/templates/krib-kubeadm.cfg.tmpl
@@ -43,7 +43,7 @@ apiServer:
     {{ end }}
 certificatesDir: /etc/kubernetes/pki
 clusterName: {{ .Param "krib/cluster-name" }}
-controlPlaneEndpoint: {{ .Param "krib/cluster-master-vip" }}
+controlPlaneEndpoint: {{ .Param "krib/cluster-master-vip" }}:{{ .Param "krib/cluster-api-vip-port" }}
 imageRepository: {{ .Param "krib/cluster-image-repository" }}
 etcd:
   external:


### PR DESCRIPTION
Hi,

Here's another small issue I stumbled across, and I could use some input. I have a workflow to re-install cluster (without reinstalling OS). The workflow resets the cluster (using `krib-dev-reset`), and then wipes all the relevant data from machine OS. Then I re-install.

Every time I re-installed though, kubeadm would fail to create a cluster, and I found that it was because kubeadm was using the cluster VIP IP, but defaulting to port 6443 (vs 8443, the API VIP port).

The problem was intermittent, because on a small cluster, the host running the template might be the same host which achieved keepalived master status, in which case it _would_ be listening on port 6443 and 8443.

This PR fixes the issue, on both a traditional install and a "soft" install, so I feel as if it's a previously hidden bug. But I'm open to input re how this **should** work, and also re whether there's a more elegant way to specify a custom port number for `controlPlaneEndpoint`! :)

Cheers!
D