### PR TITLE
Add metallb l3

### DIFF
--- a/krib/params/metallb-l3-ip-range.yaml
+++ b/krib/params/metallb-l3-ip-range.yaml
@@ -1,0 +1,13 @@
+---
+Name: "metallb/l3-ip-range"
+Description: "IP range for MetalLB L3 config"
+Documentation: |
+  This should be set to match the CIDR route 
+  you have allocated to L3 MetalLB
+  ex: 192.168.1.0/24 (currently only a single route supported)
+Schema:
+  type: "string"
+Meta:
+  color: "blue"
+  icon: "setting"
+  title: "Community Content"

--- a/krib/params/metallb-l3-peer-address.yaml
+++ b/krib/params/metallb-l3-peer-address.yaml
@@ -1,0 +1,13 @@
+---
+Name: "metallb/l3-peer-address"
+Description: "IP range for MetalLB L3 peer address"
+Documentation: |
+  This should be set to match the IP of the
+  BGP-enabled router you want MetalLB to peer with
+  ex: 192.168.1.1 (currently only a single peer supported)
+Schema:
+  type: "string"
+Meta:
+  color: "blue"
+  icon: "setting"
+  title: "Community Content"

--- a/krib/stages/krib-metallb.yaml
+++ b/krib/stages/krib-metallb.yaml
@@ -4,7 +4,7 @@ Description: "KRIB installs and configures MetalLB on the cluster"
 Documentation: |
   Installs and runs MetalLB kubectl install
 
-  see: https://metallb.netlify.com/tutorial/layer2/
+  see: https://metallb.netlify.com/tutorial/
 RunnerWait: true
 Tasks:
   - "krib-metallb"

--- a/krib/tasks/krib-metallb.yaml
+++ b/krib/tasks/krib-metallb.yaml
@@ -7,12 +7,14 @@ Templates:
     Path: ""
 RequiredParams:
   - krib/cluster-profile
-  - metallb/l2-ip-range  
 OptionalParams:
   - krib/metallb-config
   - metallb/monitoring-port
   - metallb/limits-cpu 
   - metallb/limits-memory
+  - metallb/l2-ip-range 
+  - metallb/l3-ip-range
+  - metallb/l3-peer-address
 Meta:
   icon: "sitemap"
   color: "blue"

--- a/krib/templates/krib-metallb.sh.tmpl
+++ b/krib/templates/krib-metallb.sh.tmpl
@@ -63,8 +63,61 @@ else
   echo "I was not the leader, skipping metallb install"
 fi
 
-echo "Finished successfully"
+echo "Finished MetalLB L2 deployment successfully"
+{{ else if eq (.ParamExists "metallb/l3-ip-range") true -}}
+
+MASTER_INDEX=$(find_me $KRIB_MASTERS_PARAM "Uuid" $RS_UUID)
+
+if [[ $MASTER_INDEX == 0 ]] ; then
+  export KUBECONFIG=/etc/kubernetes/admin.conf
+  if ! which wget ; then
+    install wget
+  fi
+  
+  wget -O /tmp/metallb.yaml {{ .Param "krib/metallb-config" }}
+{{$port := .Param "metallb/monitoring-port"}}
+  sed -i 's/prometheus.io\/port: "7472"/prometheus.io\/port: "{{$port}}"/' /tmp/metallb.yaml
+  sed -i 's/- --port=7472/- --port={{$port}}/' /tmp/metallb.yaml
+  sed -i 's/containerPort: 7472/containerPort: {{$port}}/' /tmp/metallb.yaml
+{{$cpu := .Param "metallb/limits-cpu"}}  
+  sed -i 's/cpu: 100m/cpu: {{$cpu}}/' /tmp/metallb.yaml
+{{$memory := .Param "metallb/limits-memory"}}  
+  sed -i 's/memory: 100Mi/memory: {{$memory}}/' /tmp/metallb.yaml
+
+  if [[ -n $(kubectl get namespaces | grep -w metallb-system) ]] ; then
+    echo "Purging existing metallb install"
+    kubectl delete -f /tmp/metallb.yaml
+  fi
+
+{{$l3_ip_range := .Param "metallb/l3-ip-range"}} 
+{{$l3_peer_address := .Param "metallb/l3-peer-address"}} 
+
+  cat >/tmp/metallb-config.yaml <<EOFCONFIG
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    peers:
+    - peer-address: {{$l3_peer_address}}  
+      peer-asn: 64501
+      my-asn: 64500
+    address-pools:
+    - name: default
+      protocol: bgp
+      addresses:
+      - {{$l3_ip_range}} 
+EOFCONFIG
+
+  kubectl apply -f /tmp/metallb.yaml
+  kubectl apply -f /tmp/metallb-config.yaml
+else
+  echo "I was not the leader, skipping metallb install"
+fi
 {{else -}}
-echo "No metallb/l2-ip-range, skipping install"
+echo "No metallb/l2-ip-range or metallb/l3-ip-range, skipping install"
 {{end -}}
 exit 0


### PR DESCRIPTION
Hey guys,

Here's a PR to add optional metallb layer 3 configuration to KRIB. It's built on the existing code to deploy L2, and is working insofar as metallb deploys corrects and stands up BGP its peer (I haven't tested with any services yet)

```
root@cn1:~# kubectl --kubeconfig admin.conf get pods -n metallb-system -o wide
NAME                          READY   STATUS    RESTARTS   AGE     IP               NODE                                  NOMINATED NODE   READINESS GATES
controller-7cd4fb6bff-l27f8   1/1     Running   1          7h40m   10.121.210.194   mn2.kube-cluster.funkypenguin.co.nz   <none>           <none>
speaker-2hjnb                 1/1     Running   1          7h40m   192.168.33.12    mn2.kube-cluster.funkypenguin.co.nz   <none>           <none>
speaker-5l5k2                 1/1     Running   1          7h40m   192.168.33.24    wn4.kube-cluster.funkypenguin.co.nz   <none>           <none>
speaker-c25g2                 1/1     Running   1          7h40m   192.168.33.22    wn2.kube-cluster.funkypenguin.co.nz   <none>           <none>
speaker-fc6j6                 1/1     Running   1          7h40m   192.168.33.13    mn3.kube-cluster.funkypenguin.co.nz   <none>           <none>
speaker-qlm99                 1/1     Running   1          7h39m   192.168.33.21    wn1.kube-cluster.funkypenguin.co.nz   <none>           <none>
speaker-qr42z                 1/1     Running   1          7h40m   192.168.33.11    mn1.kube-cluster.funkypenguin.co.nz   <none>           <none>
speaker-w2v8k                 1/1     Running   1          7h39m   192.168.33.23    wn3.kube-cluster.funkypenguin.co.nz   <none>           <none>
root@cn1:~#
```

Cheers!
D