### PR TITLE
Add containerd alternative (and fix a bug)

### DIFF
--- a/krib/params/krib-cluster-cri-socket.yaml
+++ b/krib/params/krib-cluster-cri-socket.yaml
@@ -4,7 +4,9 @@ Description: "Specify the CRI Socket for Kubernetes."
 Documentation: |
   This Param defines which Socket to use for the Container Runtime
   Interface.  By default KRIB content uses Docker as the CRI, however
-  our goal is to support multiple container CRI formats. 
+  our goal is to support multiple container CRI formats. A viable 
+  alternative is /run/containerd/containerd.sock, assuming krib/container-runtime 
+  is set to "containerd"
 Schema:
   type: "string"
   default: "/var/run/dockershim.sock"

--- a/krib/params/krib-container-runtime.yaml
+++ b/krib/params/krib-container-runtime.yaml
@@ -1,0 +1,17 @@
+---
+Name: "krib/container-runtime"
+Description: "Container runtime employed in KRIB cluster"
+Documentation: |
+  The container runtime to be used for the KRIB cluster. This can be
+  either docker (the default) or containerd.
+
+Schema:
+  type: string
+  enum:
+    - docker
+    - containerd
+  default: docker
+Meta:
+  color: "blue"
+  icon: "ship"
+  title: "Community Content"

--- a/krib/params/krib-repo.yaml
+++ b/krib/params/krib-repo.yaml
@@ -1,0 +1,14 @@
+---
+Name: "krib/repo"
+Description: "URL path to a pre-prepared collection of necessary KRIB install files"
+Documentation: |
+  Allows operators to pre-prepare a URL (i.e., a local repository) of the installation packages necessary for KRIB. 
+  If this value is set, then tasks like containerd-install and etcd-config will source their installation files
+  from this repository, rather than attempting to download them from the internet (which may take longer, given
+  the amount of machines to be installed plus the capacity of the internet service)
+Schema:
+  type: "string"
+Meta:
+  color: "blue"
+  icon: "book"
+  title: "Community Content"

--- a/krib/stages/krib-runtime-install.yaml
+++ b/krib/stages/krib-runtime-install.yaml
@@ -1,0 +1,24 @@
+---
+Available: true
+BootEnv: ""
+Bundle: Unspecified
+Description: Install a container runtime from Internet Repos
+Documentation: ""
+Endpoint: ""
+Errors: []
+Meta:
+  color: yellow
+  icon: docker
+  title: Community Content
+Name: krib-runtime-install
+OptionalParams: []
+Params: {}
+Profiles: []
+ReadOnly: true
+Reboot: false
+RequiredParams: []
+RunnerWait: true
+Tasks:
+- krib-runtime-install
+Templates: []
+Validated: true

--- a/krib/stages/krib-runtime-install.yaml
+++ b/krib/stages/krib-runtime-install.yaml
@@ -1,24 +1,13 @@
 ---
-Available: true
-BootEnv: ""
-Bundle: Unspecified
 Description: Install a container runtime from Internet Repos
-Documentation: ""
-Endpoint: ""
-Errors: []
+Documentation: |
+  This stage allows for the installation of multiple container runtimes. The single task (krib-runtime-install)
+  which it executes, will launch further tasks based on the value of krib/container-runtime. Currently docker
+  and containerd are supported, although the design is extensible. 
 Meta:
   color: yellow
   icon: docker
   title: Community Content
 Name: krib-runtime-install
-OptionalParams: []
-Params: {}
-Profiles: []
-ReadOnly: true
-Reboot: false
-RequiredParams: []
-RunnerWait: true
 Tasks:
 - krib-runtime-install
-Templates: []
-Validated: true

--- a/krib/tasks/containerd-install.yaml
+++ b/krib/tasks/containerd-install.yaml
@@ -1,0 +1,18 @@
+
+---
+Description: "A task to install containerd"
+Name: "containerd-install"
+Documentation: |
+  Installs containerd using O/S packages
+OptionalParams:
+  - docker/working-dir
+  - kubectl/working-dir
+Templates:
+  - ID: "containerd-install.sh.tmpl"
+    Name: "Install containerd from internet repo"
+    Path: ""
+Meta:
+  icon: "docker"
+  color: "blue"
+  title: "Community Content"
+  feature-flags: "sane-exit-codes"

--- a/krib/tasks/krib-runtime-install.yaml
+++ b/krib/tasks/krib-runtime-install.yaml
@@ -1,0 +1,11 @@
+---
+Description: "Installs container runtime"
+Name: "krib-runtime-install"
+Documentation: |
+  Installs a container runtime
+RequiredParams:
+  - krib/container-runtime
+Templates:
+  - ID: "krib-runtime-install.sh.tmpl"
+    Name: "Install a container runtime on a KRIB built Kubernetes node"
+    Path: ""  

--- a/krib/templates/containerd-install.sh.tmpl
+++ b/krib/templates/containerd-install.sh.tmpl
@@ -22,7 +22,7 @@ fi
 KRIB_REPO={{.Param "krib/package-repository"}}
 {{end -}}
 
-if [[ -e $KRIB_REPO ]] ; then
+if [[ ! -z "$KRIB_REPO" ]] ; then
   curl -L ${KRIB_REPO}/cri-containerd-{{.Param "containerd/version"}}.linux-amd64.tar.gz | tar xvz -C /
 else
   curl -L https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{.Param "containerd/version"}}.linux-amd64.tar.gz | tar xvz -C /

--- a/krib/templates/containerd-install.sh.tmpl
+++ b/krib/templates/containerd-install.sh.tmpl
@@ -23,7 +23,7 @@ KRIB_REPO={{.Param "krib/package-repository"}}
 {{end -}}
 
 if [[ -e $KRIB_REPO ]] ; then
-  curl -L ${{KRIB_REPO}/cri-containerd-{{.Param "containerd/version"}}.linux-amd64.tar.gz | tar xvz -C /
+  curl -L ${KRIB_REPO}/cri-containerd-{{.Param "containerd/version"}}.linux-amd64.tar.gz | tar xvz -C /
 else
   curl -L https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{.Param "containerd/version"}}.linux-amd64.tar.gz | tar xvz -C /
 fi

--- a/krib/templates/containerd-install.sh.tmpl
+++ b/krib/templates/containerd-install.sh.tmpl
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Kubernetes Rebar Integrated Boot (KRIB) Docker Install
+set -e
+
+# Get access and who we are.
+{{template "setup.tmpl" .}}
+[[ $RS_UUID ]] && export RS_UUID="{{.Machine.UUID}}"
+
+ETCD_CONTROLLER_IP={{.Param "etcd/controller-ip"}}
+
+{{if .ParamExists "kubectl/working-dir" -}}
+# Only do this if it exists.
+# if it isn't setup, don't use it.
+if [[ -e {{.Param "kubectl/working-dir"}} ]] ; then
+  echo "Linking the kubectl working directory into place."
+  ln -s {{.Param "kubectl/working-dir"}} /var/lib/kubectl
+fi
+{{end -}}
+
+
+curl -L http://${ETCD_CONTROLLER_IP}/cri-containerd-{{.Param "containerd/version"}}.linux-amd64.tar.gz | tar xvz -C /
+
+# Configure containerd
+
+{{if .ParamExists "containerd/config" -}}
+echo "Creating /etc/containerd/config.toml file from Param containerd/config"
+cat <<EOF >/etc/containerd/config.toml
+{{.Param "containerd/config"}}
+EOF
+cat /etc/containerd/config.toml
+{{else -}}
+echo "Skipping custom etc/containerd/config.toml: No containerd/config defined"
+{{end -}}
+
+# start containerd
+systemctl start containerd
+
+echo "Containerd installed successfully"
+exit 0

--- a/krib/templates/containerd-install.sh.tmpl
+++ b/krib/templates/containerd-install.sh.tmpl
@@ -17,9 +17,16 @@ if [[ -e {{.Param "kubectl/working-dir"}} ]] ; then
 fi
 {{end -}}
 
+# Allow for a local repository for installation files
+{{if .ParamExists "krib/package-repository" -}}
+KRIB_REPO={{.Param "krib/package-repository"}}
+{{end -}}
 
-curl -L http://${ETCD_CONTROLLER_IP}/cri-containerd-{{.Param "containerd/version"}}.linux-amd64.tar.gz | tar xvz -C /
-
+if [[ -e $KRIB_REPO ]] ; then
+  curl -L ${{KRIB_REPO}/cri-containerd-{{.Param "containerd/version"}}.linux-amd64.tar.gz | tar xvz -C /
+else
+  curl -L https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{.Param "containerd/version"}}.linux-amd64.tar.gz | tar xvz -C /
+fi
 # Configure containerd
 
 {{if .ParamExists "containerd/config" -}}

--- a/krib/templates/krib-kubeadm.cfg.tmpl
+++ b/krib/templates/krib-kubeadm.cfg.tmpl
@@ -51,12 +51,12 @@ etcd:
     certFile: /etc/kubernetes/pki/etcd/client.pem
     keyFile: /etc/kubernetes/pki/etcd/client-key.pem
     endpoints:
-{{if and .ParamExists "krib/cluster-master-vip" .ParamExists "etcd/cluster-client-vip-port" }}
-      https://{{ .Param "krib/cluster-master-vip" }}:{{ .Param "etcd/cluster-client-vip-port" }}
+{{if and (.ParamExists "krib/cluster-master-vip") (.ParamExists "etcd/cluster-client-vip-port") }}
+      - https://{{ .Param "krib/cluster-master-vip" }}:{{ .Param "etcd/cluster-client-vip-port" }}
 {{else}}
   {{ $port := .Param "etcd/client-port" -}}
   {{- range $elem := .Param "etcd/servers"}}
-    - https://{{ $elem.Address }}:{{ $port }}
+      - https://{{ $elem.Address }}:{{ $port }}
   {{ end -}}    
 {{ end -}}
 useHyperKubeImage: true

--- a/krib/templates/krib-runtime-install.sh.tmpl
+++ b/krib/templates/krib-runtime-install.sh.tmpl
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+{{template "setup.tmpl" .}}
+
+cr={{.Param "krib/container-runtime"}}
+case $cr in
+  docker) tasks="docker-install mount-docker";;
+  containerd) tasks="containerd-install";;
+  *) echo "No idea what to do with $cr"; exit 1;;
+esac
+
+drpcli machines tasks add {{.Machine.UUID}} at 0 $tasks

--- a/krib/templates/krib-runtime-install.sh.tmpl
+++ b/krib/templates/krib-runtime-install.sh.tmpl
@@ -4,7 +4,7 @@
 
 cr={{.Param "krib/container-runtime"}}
 case $cr in
-  docker) tasks="docker-install mount-docker";;
+  docker) tasks="docker-install";;
   containerd) tasks="containerd-install";;
   *) echo "No idea what to do with $cr"; exit 1;;
 esac

--- a/krib/workflows/krib-soft-install-cluster.yaml
+++ b/krib/workflows/krib-soft-install-cluster.yaml
@@ -1,17 +1,14 @@
 # Workflow
 ---
-Name: "krib-install-cluster"
-Description: "KRIB built kubernetes install-to-disk demo cluster"
+Name: "krib-soft-install-cluster"
+Description: "Install KRIB cluster on existing machine OS (post-reset)"
 Errors: []
 Meta:
   color: "yellow"
   icon: "ship"
-  title: "kubernetes install-to-disk demo cluster"
+  title: "kubernetes install on existing machine OS"
 ReadOnly: false
 Stages:
-  - "centos-7-install"
-  - "runner-service"
-  - "finish-install"
   - "krib-runtime-install"
   - "kubernetes-install"
   - "etcd-config"


### PR DESCRIPTION
Hey guys,

Here's a PR to implement an alternative container runtime in KRIB (thanks @galthaus for the idea).

I also added (because it was necessary to test):

1. A workflow to "soft-reinstall" a cluster (without an OS rebuild)
2. The beginning of a feature (in an upcoming PR), which introduces the `krib/repo` param, allowing an operator to maintain a local copy of source files, avoiding annoying delays while rebuilding.
3. A fix to the ETC HA PR from a few days ago, because my "if" statement with multiple conditions was invalid (it's now valid)

I've tested this against both containerd and docker, on a full re-install and a "soft" reinstall.

Cheers!
D
