### PR TITLE
Add optional local repo to speed up re-installations

### DIFF
--- a/krib/params/krib-cluster-cri-socket.yaml
+++ b/krib/params/krib-cluster-cri-socket.yaml
@@ -4,7 +4,9 @@ Description: "Specify the CRI Socket for Kubernetes."
 Documentation: |
   This Param defines which Socket to use for the Container Runtime
   Interface.  By default KRIB content uses Docker as the CRI, however
-  our goal is to support multiple container CRI formats. 
+  our goal is to support multiple container CRI formats. A viable 
+  alternative is /run/containerd/containerd.sock, assuming krib/container-runtime 
+  is set to "containerd"
 Schema:
   type: "string"
   default: "/var/run/dockershim.sock"

--- a/krib/params/krib-container-runtime.yaml
+++ b/krib/params/krib-container-runtime.yaml
@@ -1,0 +1,17 @@
+---
+Name: "krib/container-runtime"
+Description: "Container runtime employed in KRIB cluster"
+Documentation: |
+  The container runtime to be used for the KRIB cluster. This can be
+  either docker (the default) or containerd.
+
+Schema:
+  type: string
+  enum:
+    - docker
+    - containerd
+  default: docker
+Meta:
+  color: "blue"
+  icon: "ship"
+  title: "Community Content"

--- a/krib/params/krib-repo.yaml
+++ b/krib/params/krib-repo.yaml
@@ -1,0 +1,14 @@
+---
+Name: "krib/repo"
+Description: "URL path to a pre-prepared collection of necessary KRIB install files"
+Documentation: |
+  Allows operators to pre-prepare a URL (i.e., a local repository) of the installation packages necessary for KRIB. 
+  If this value is set, then tasks like containerd-install and etcd-config will source their installation files
+  from this repository, rather than attempting to download them from the internet (which may take longer, given
+  the amount of machines to be installed plus the capacity of the internet service)
+Schema:
+  type: "string"
+Meta:
+  color: "blue"
+  icon: "book"
+  title: "Community Content"

--- a/krib/stages/krib-runtime-install.yaml
+++ b/krib/stages/krib-runtime-install.yaml
@@ -1,0 +1,24 @@
+---
+Available: true
+BootEnv: ""
+Bundle: Unspecified
+Description: Install a container runtime from Internet Repos
+Documentation: ""
+Endpoint: ""
+Errors: []
+Meta:
+  color: yellow
+  icon: docker
+  title: Community Content
+Name: krib-runtime-install
+OptionalParams: []
+Params: {}
+Profiles: []
+ReadOnly: true
+Reboot: false
+RequiredParams: []
+RunnerWait: true
+Tasks:
+- krib-runtime-install
+Templates: []
+Validated: true

--- a/krib/tasks/containerd-install.yaml
+++ b/krib/tasks/containerd-install.yaml
@@ -1,0 +1,18 @@
+
+---
+Description: "A task to install containerd"
+Name: "containerd-install"
+Documentation: |
+  Installs containerd using O/S packages
+OptionalParams:
+  - docker/working-dir
+  - kubectl/working-dir
+Templates:
+  - ID: "containerd-install.sh.tmpl"
+    Name: "Install containerd from internet repo"
+    Path: ""
+Meta:
+  icon: "docker"
+  color: "blue"
+  title: "Community Content"
+  feature-flags: "sane-exit-codes"

--- a/krib/tasks/krib-runtime-install.yaml
+++ b/krib/tasks/krib-runtime-install.yaml
@@ -1,0 +1,11 @@
+---
+Description: "Installs container runtime"
+Name: "krib-runtime-install"
+Documentation: |
+  Installs a container runtime
+RequiredParams:
+  - krib/container-runtime
+Templates:
+  - ID: "krib-runtime-install.sh.tmpl"
+    Name: "Install a container runtime on a KRIB built Kubernetes node"
+    Path: ""  

--- a/krib/templates/containerd-install.sh.tmpl
+++ b/krib/templates/containerd-install.sh.tmpl
@@ -22,7 +22,7 @@ fi
 KRIB_REPO={{.Param "krib/package-repository"}}
 {{end -}}
 
-if [[ -e $KRIB_REPO ]] ; then
+if [[ ! -z "$KRIB_REPO" ]] ; then
   curl -L ${KRIB_REPO}/cri-containerd-{{.Param "containerd/version"}}.linux-amd64.tar.gz | tar xvz -C /
 else
   curl -L https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{.Param "containerd/version"}}.linux-amd64.tar.gz | tar xvz -C /

--- a/krib/templates/containerd-install.sh.tmpl
+++ b/krib/templates/containerd-install.sh.tmpl
@@ -23,7 +23,7 @@ KRIB_REPO={{.Param "krib/package-repository"}}
 {{end -}}
 
 if [[ -e $KRIB_REPO ]] ; then
-  curl -L ${{KRIB_REPO}/cri-containerd-{{.Param "containerd/version"}}.linux-amd64.tar.gz | tar xvz -C /
+  curl -L ${KRIB_REPO}/cri-containerd-{{.Param "containerd/version"}}.linux-amd64.tar.gz | tar xvz -C /
 else
   curl -L https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{.Param "containerd/version"}}.linux-amd64.tar.gz | tar xvz -C /
 fi

--- a/krib/templates/containerd-install.sh.tmpl
+++ b/krib/templates/containerd-install.sh.tmpl
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Kubernetes Rebar Integrated Boot (KRIB) Docker Install
+set -e
+
+# Get access and who we are.
+{{template "setup.tmpl" .}}
+[[ $RS_UUID ]] && export RS_UUID="{{.Machine.UUID}}"
+
+ETCD_CONTROLLER_IP={{.Param "etcd/controller-ip"}}
+
+{{if .ParamExists "kubectl/working-dir" -}}
+# Only do this if it exists.
+# if it isn't setup, don't use it.
+if [[ -e {{.Param "kubectl/working-dir"}} ]] ; then
+  echo "Linking the kubectl working directory into place."
+  ln -s {{.Param "kubectl/working-dir"}} /var/lib/kubectl
+fi
+{{end -}}
+
+
+curl -L http://${ETCD_CONTROLLER_IP}/cri-containerd-{{.Param "containerd/version"}}.linux-amd64.tar.gz | tar xvz -C /
+
+# Configure containerd
+
+{{if .ParamExists "containerd/config" -}}
+echo "Creating /etc/containerd/config.toml file from Param containerd/config"
+cat <<EOF >/etc/containerd/config.toml
+{{.Param "containerd/config"}}
+EOF
+cat /etc/containerd/config.toml
+{{else -}}
+echo "Skipping custom etc/containerd/config.toml: No containerd/config defined"
+{{end -}}
+
+# start containerd
+systemctl start containerd
+
+echo "Containerd installed successfully"
+exit 0

--- a/krib/templates/containerd-install.sh.tmpl
+++ b/krib/templates/containerd-install.sh.tmpl
@@ -17,9 +17,16 @@ if [[ -e {{.Param "kubectl/working-dir"}} ]] ; then
 fi
 {{end -}}
 
+# Allow for a local repository for installation files
+{{if .ParamExists "krib/package-repository" -}}
+KRIB_REPO={{.Param "krib/package-repository"}}
+{{end -}}
 
-curl -L http://${ETCD_CONTROLLER_IP}/cri-containerd-{{.Param "containerd/version"}}.linux-amd64.tar.gz | tar xvz -C /
-
+if [[ -e $KRIB_REPO ]] ; then
+  curl -L ${{KRIB_REPO}/cri-containerd-{{.Param "containerd/version"}}.linux-amd64.tar.gz | tar xvz -C /
+else
+  curl -L https://storage.googleapis.com/cri-containerd-release/cri-containerd-{{.Param "containerd/version"}}.linux-amd64.tar.gz | tar xvz -C /
+fi
 # Configure containerd
 
 {{if .ParamExists "containerd/config" -}}

--- a/krib/templates/etcd-config.sh.tmpl
+++ b/krib/templates/etcd-config.sh.tmpl
@@ -209,7 +209,17 @@ fi
 mkdir -p ${TMP_DIR}
 
 echo "Download etcd version: v${ETCD_VERSION}"
-download -L https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz -o ${TMP_DIR}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz
+# Allow for a local repository for installation files
+{{if .ParamExists "krib/package-repository" -}}
+KRIB_REPO={{.Param "krib/package-repository"}}
+{{end -}}
+
+if [[ ! -z "$KRIB_REPO" ]] ; then
+  download -L ${KRIB_REPO}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz -o ${TMP_DIR}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz
+else
+  download -L https://github.com/coreos/etcd/releases/download/v${ETCD_VERSION}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz -o ${TMP_DIR}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz
+fi
+
 echo "Install etcd version: ${ETCD_VERSION}"
 tar -C ${INSTALL_DIR} -xzf ${TMP_DIR}/etcd-v${ETCD_VERSION}-linux-amd64.tar.gz --strip-components=1
 

--- a/krib/templates/krib-kubeadm.cfg.tmpl
+++ b/krib/templates/krib-kubeadm.cfg.tmpl
@@ -51,12 +51,12 @@ etcd:
     certFile: /etc/kubernetes/pki/etcd/client.pem
     keyFile: /etc/kubernetes/pki/etcd/client-key.pem
     endpoints:
-{{if and .ParamExists "krib/cluster-master-vip" .ParamExists "etcd/cluster-client-vip-port" }}
-      https://{{ .Param "krib/cluster-master-vip" }}:{{ .Param "etcd/cluster-client-vip-port" }}
+{{if and (.ParamExists "krib/cluster-master-vip") (.ParamExists "etcd/cluster-client-vip-port") }}
+      - https://{{ .Param "krib/cluster-master-vip" }}:{{ .Param "etcd/cluster-client-vip-port" }}
 {{else}}
   {{ $port := .Param "etcd/client-port" -}}
   {{- range $elem := .Param "etcd/servers"}}
-    - https://{{ $elem.Address }}:{{ $port }}
+      - https://{{ $elem.Address }}:{{ $port }}
   {{ end -}}    
 {{ end -}}
 useHyperKubeImage: true

--- a/krib/templates/krib-runtime-install.sh.tmpl
+++ b/krib/templates/krib-runtime-install.sh.tmpl
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+{{template "setup.tmpl" .}}
+
+cr={{.Param "krib/container-runtime"}}
+case $cr in
+  docker) tasks="docker-install mount-docker";;
+  containerd) tasks="containerd-install";;
+  *) echo "No idea what to do with $cr"; exit 1;;
+esac
+
+drpcli machines tasks add {{.Machine.UUID}} at 0 $tasks

--- a/krib/templates/krib-runtime-install.sh.tmpl
+++ b/krib/templates/krib-runtime-install.sh.tmpl
@@ -4,7 +4,7 @@
 
 cr={{.Param "krib/container-runtime"}}
 case $cr in
-  docker) tasks="docker-install mount-docker";;
+  docker) tasks="docker-install";;
   containerd) tasks="containerd-install";;
   *) echo "No idea what to do with $cr"; exit 1;;
 esac

--- a/krib/templates/kubernetes-install.sh.tmpl
+++ b/krib/templates/kubernetes-install.sh.tmpl
@@ -63,19 +63,36 @@ mkdir -p ${TMP_DIR}
 mkdir -p ${INSTALL_DIR}
 mkdir -p /opt/cni/bin
 
+# Allow for a local repository for installation files
+{{if .ParamExists "krib/package-repository" -}}
+KRIB_REPO={{.Param "krib/package-repository"}}
+{{end -}}
+
 echo "Download cni plugin version: ${CNI_VERSION}"
-download -L "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tgz" -o ${TMP_DIR}/cni-plugins-amd64-${CNI_VERSION}.tgz
+if [[ ! -z "$KRIB_REPO" ]] ; then
+  download -L "${KRIB_REPO}/cni-plugins-linux-amd64-${CNI_VERSION}.tgz" -o ${TMP_DIR}/cni-plugins-amd64-${CNI_VERSION}.tgz
+else
+  download -L "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tgz" -o ${TMP_DIR}/cni-plugins-amd64-${CNI_VERSION}.tgz
+fi
 echo "Install cni plugin version: ${CNI_VERSION}"
 tar -C /opt/cni/bin -xzf ${TMP_DIR}/cni-plugins-amd64-${CNI_VERSION}.tgz
 
 echo "Download crictl version: ${CRICTL_VERSION}"
-download -L "https://github.com/kubernetes-incubator/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" -o ${TMP_DIR}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
+if [[ ! -z "$KRIB_REPO" ]] ; then
+  download -L "${KRIB_REPO}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" -o ${TMP_DIR}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
+else
+  download -L "https://github.com/kubernetes-incubator/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" -o ${TMP_DIR}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
+fi
 echo "Install crictl version: ${CRICTL_VERSION}"
 tar -C ${INSTALL_DIR} -xzf ${TMP_DIR}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz
 
 cd ${INSTALL_DIR}
 echo "Download kubelet, kubeadm, and kubectl version: ${RELEASE}"
-download -L --remote-name-all https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/{kubeadm,kubelet,kubectl}
+if [[ ! -z "$KRIB_REPO" ]] ; then
+  download -L --remote-name-all "${KRIB_REPO}/{kubeadm,kubelet,kubectl}"
+else
+  download -L --remote-name-all https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/{kubeadm,kubelet,kubectl}
+fi
 chmod +x {kubeadm,kubelet,kubectl}
 
 echo "Download kubelet systemd service unit file for version: ${RELEASE}"

--- a/krib/workflows/krib-soft-install-cluster.yaml
+++ b/krib/workflows/krib-soft-install-cluster.yaml
@@ -1,17 +1,14 @@
 # Workflow
 ---
-Name: "krib-install-cluster"
-Description: "KRIB built kubernetes install-to-disk demo cluster"
+Name: "krib-soft-install-cluster"
+Description: "Install KRIB cluster on existing machine OS (post-reset)"
 Errors: []
 Meta:
   color: "yellow"
   icon: "ship"
-  title: "kubernetes install-to-disk demo cluster"
+  title: "kubernetes install on existing machine OS"
 ReadOnly: false
 Stages:
-  - "centos-7-install"
-  - "runner-service"
-  - "finish-install"
   - "krib-runtime-install"
   - "kubernetes-install"
   - "etcd-config"


### PR DESCRIPTION
Hey guys, this is a follow-on from my previous PR re adding containerd as a runtime. This PR includes the containerd PR (because there's some crossover in the downloading of source files). Let me know if this is a problem.

Minus the containerd changes (when the earlier PR is merged), this PR simply adds a conditional to test whether the operator has pre-staged a HTTP/HTTPS repo with the necessary install content. In my case, this saves me 1.4GB of downloads (7 x 200MB) every time I re-install my cluster (it's been 20-30 times today)

Cheers! :)
D