### PR TITLE
add ability to ignore preflight errors, streamline docs

### DIFF
--- a/krib/._Documentation.meta
+++ b/krib/._Documentation.meta
@@ -77,11 +77,9 @@ CLI Install
 KRIB uses the Certs plugin to build TLS, you can install that from the RackN library
 
   ::
+    # install required content and create the certs plugin
+    drpcli plugin_providers upload certs from catalog:certs-tip
 
-    # download cert plugin provider (installs the plugin autmatically)
-    curl -o certs https://s3-us-west-2.amazonaws.com/rebar-catalog/certs/v2.4.0-0-02301d35f9f664d6c81d904c92a9c81d3fd41d2c/amd64/linux/certs
-    # install plugin provider
-    drpcli plugin_providers upload certs from certs
     # verify it worked - should return true
     drpcli plugins show certs | jq .Available
 
@@ -90,14 +88,7 @@ Using the Command Line (`drpcli`) utility configured to your endpoint, use this 
   ::
 
     # Get code
-    git clone https://github.com/digitalrebar/provision-content
-    cd krib
-
-    # KRIB content install
-    drpcli contents bundle krib.yaml
-    drpcli contents upload krib.yaml
-
-If KRIB is already installed, you should replace the upload with `drpcli contents update krib krib.yaml`
+    drpcli contents upload catalog:krib-tip
 
 UX Install
 ==========
@@ -126,11 +117,6 @@ The basic outline for configuring KRIB follows the below steps:
 
 There are many configuration options available, review the ``krib/*`` and ``etcd/*`` parameters to learn more.
 
-Configure with Terraform
-========================
-
-Please review the ``intergrations/krib`` for example Terraform plans.
-
 Configure with the CLI
 ======================
 
@@ -151,6 +137,8 @@ You must writeable create a *Profile* from YAML (or JSON if you prefer) with the
       color: "purple"
       icon: "ship"
       title: "My Installed Kubernetes Cluster"
+      render: "krib"
+      reset-keeps": "krib/cluster-profile,etcd/cluster-profile"
     ' > /tmp/krib-config.yaml
 
     drpcli profiles create - < /tmp/krib-config.yaml

--- a/krib/params/krib-ignore-preflight-errors.yaml
+++ b/krib/params/krib-ignore-preflight-errors.yaml
@@ -1,0 +1,18 @@
+---
+Name: "krib/ignore-preflight-errors"
+Description: "Options for kubeadm init --ignore-preflight-errors"
+Documentation: |
+  Helpful for debug and test clusters.  This flag allows operators to select none, all or some
+  preflight error checks to ignore during the kubeadm init.
+
+  Use "all" to ignore all errors
+  Use "none" to include all errors [default]
+
+  More Info, see https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-init/
+Schema:
+  type: "string"
+  default: "none"
+Meta:
+  color: "black"
+  icon: "bug"
+  title: "Community Content"

--- a/krib/templates/krib-config.sh.tmpl
+++ b/krib/templates/krib-config.sh.tmpl
@@ -104,7 +104,7 @@ if [[ $MASTER_INDEX != notme ]] ; then
     cat $T >> /tmp/kubeadm.cfg && rm -f $T
     {{ end -}}
 
-    kubeadm init --config=/tmp/kubeadm.cfg 2>&1 | tee -a /tmp/kubeadm.init.log
+    kubeadm init --config=/tmp/kubeadm.cfg --ignore-preflight-errors {{ .Param "krib/ignore-preflight-errors" }} 2>&1 | tee -a /tmp/kubeadm.init.log
 
     echo "Building certificate file."
     tar -zcvf /tmp/cert.tgz /etc/kubernetes/pki/ca.crt /etc/kubernetes/pki/ca.key /etc/kubernetes/pki/sa.key /etc/kubernetes/pki/sa.pub
@@ -141,7 +141,7 @@ if [[ $MASTER_INDEX != notme ]] ; then
     get_param $KRIB_MASTER_CERTS_PARAM | jq -r . | base64 -d - | tar -zxvf -
     cd -
 
-    kubeadm init --config=/tmp/kubeadm.cfg 2>&1 > /tmp/kubeadm.init.log
+    kubeadm init --config=/tmp/kubeadm.cfg --ignore-preflight-errors {{ .Param "krib/ignore-preflight-errors" }} 2>&1 > /tmp/kubeadm.init.log
 
   fi
 


### PR DESCRIPTION
This allows you to do testing that is blocked by the preflight checks.

also, updates the docs