### PR TITLE
Avoid buggy ips by default in metallb

### DIFF
--- a/krib/templates/krib-metallb.sh.tmpl
+++ b/krib/templates/krib-metallb.sh.tmpl
@@ -108,6 +108,7 @@ data:
     address-pools:
     - name: default
       protocol: bgp
+      avoid-buggy-ips: true
       addresses:
       - {{$l3_ip_range}} 
 EOFCONFIG


### PR DESCRIPTION
Hey guys,

Felt like this would be a good default, for safety reasons. Basically, prevent metallb from using the first or last IP in a block (10.0.0.0/32, or 10.0.0.255/32, for example)

Cheers!
D