### PR TITLE
Add fluent-bit GELF logging

### DIFF
--- a/krib/params/krib-log-target-gelf.yaml
+++ b/krib/params/krib-log-target-gelf.yaml
@@ -1,0 +1,13 @@
+---
+Name: "krib/log-target-gelf"
+Description: "The target for GELF (Graylog) logs if running the krib-logging stage"
+Documentation: |
+  An IP outside the cluster designated configured to receive GELF (GrayLog) "The target for GELF (Graylog) "The target for GELF (Graylog) logs
+  on UDP 2201
+  
+Schema:
+  type: "string"
+Meta:
+  color: "blue"
+  icon: "book"
+  title: "Community Content"

--- a/krib/params/krib-log-target-syslog.yaml
+++ b/krib/params/krib-log-target-syslog.yaml
@@ -1,0 +1,13 @@
+---
+Name: "krib/log-target-syslog"
+Description: "The target for remote syslog logs if running the krib-logging stage"
+Documentation: |
+  An IP outside the cluster designated configured to receive remote syslog logs
+  on UDP 514
+  
+Schema:
+  type: "string"
+Meta:
+  color: "blue"
+  icon: "book"
+  title: "Community Content"

--- a/krib/stages/krib-logging.yaml
+++ b/krib/stages/krib-logging.yaml
@@ -1,0 +1,13 @@
+---
+Name: "krib-logging"
+Description: "KRIB install fluent-bit on the cluster for logging"
+Documentation: |
+  Installs and runs fluent-bit to aggregate container logs to a graylog server
+  via GELF UDP input
+RunnerWait: true
+Tasks:
+  - "krib-logging"
+Meta:
+  icon: "ship"
+  color: "blue"
+  title: "Community Content"

--- a/krib/tasks/krib-logging-fluent-bit.yaml
+++ b/krib/tasks/krib-logging-fluent-bit.yaml
@@ -8,7 +8,7 @@ Documentation: |
   The install checks to see if tiller is running and may skip initialization.
 RequiredParams:
   - krib/cluster-profile
-  - krib/controller-ip  
+  - krib/log-target-gelf
 Templates:
   - ID: "logging-fluent-bit.yaml.tmpl"
     Name: "YAML manifents for fluent-bit"

--- a/krib/tasks/krib-logging-fluent-bit.yaml
+++ b/krib/tasks/krib-logging-fluent-bit.yaml
@@ -1,0 +1,23 @@
+---
+Description: "A task to install logging"
+Name: "krib-logging"
+Documentation: |
+  Installs fluent-bit for aggregation of cluster logging to a graylog server
+  This uses the Digital Rebar Cluster pattern so krib/cluster-profile must be set.
+
+  The install checks to see if tiller is running and may skip initialization.
+RequiredParams:
+  - krib/cluster-profile
+  - krib/controller-ip  
+Templates:
+  - ID: "logging-fluent-bit.yaml.tmpl"
+    Name: "YAML manifents for fluent-bit"
+    Path: "/tmp/logging-fluent-bit.yaml"
+  - ID: "logging-fluent-bit.sh.tmpl"
+    Name: "Apply the YAML manifests"
+    Path: ""
+Meta:
+  icon: "ship"
+  color: "blue"
+  title: "Community Content"
+  feature-flags: "sane-exit-codes"

--- a/krib/templates/krib-ingress-nginx-tillerless.sh.tmpl
+++ b/krib/templates/krib-ingress-nginx-tillerless.sh.tmpl
@@ -84,15 +84,15 @@ if [[ $MASTER_INDEX == 0 ]] ; then
   wget -O /tmp/certmanager-manifests.yaml {{ .Param "certmanager/manifests" }}
 
   echo "Preparing namespace and disabling validation.."
-  kubectl create namespace cert-manager
-  kubectl label namespace cert-manager certmanager.k8s.io/disable-validation="true"
+  kubectl create namespace cert-manager || echo "Failed to create namespace, it probably already exists. Proceeding..."
+  kubectl label namespace cert-manager certmanager.k8s.io/disable-validation="true" || echo "Failed to disable validation on namespace, it's probably already done. Proceeding..."
 
   # a fresh cluster struggles with races if this happens too fast.
   sleep 1m
   kubectl apply -f /tmp/certmanager-manifests.yaml
 
   # It seems to take about 2m until the pods are createde, and the webhook admission controller is ready for validating the CRDs which come next
-  sleep 1m
+  sleep 2m
 {{if .ParamExists "certmanager/acme-challenge-dns01-provider"}}
   if [[ -n $(kubectl -n kube-system get secrets | grep -w certmanager-provider) ]] ; then
     echo "Removing existing certmanager-provider Secret"

--- a/krib/templates/krib-metallb.sh.tmpl
+++ b/krib/templates/krib-metallb.sh.tmpl
@@ -108,6 +108,7 @@ data:
     address-pools:
     - name: default
       protocol: bgp
+      avoid-buggy-ips: true
       addresses:
       - {{$l3_ip_range}} 
 EOFCONFIG

--- a/krib/templates/logging-fluent-bit.sh.tmpl
+++ b/krib/templates/logging-fluent-bit.sh.tmpl
@@ -30,6 +30,8 @@ if [[ $MASTER_INDEX != notme ]] ; then
 
     echo "Applying fluent-bit manifests"
     kubectl apply -f /tmp/logging-fluent-bit.yaml
+    mkdir -p /tmp/cleanup
+    mv /tmp/logging-fluent-bit.yaml /tmp/cleanup
 
   else
 

--- a/krib/templates/logging-fluent-bit.sh.tmpl
+++ b/krib/templates/logging-fluent-bit.sh.tmpl
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Kubernetes Rebar Integrated Boot (KRIB) Kubeadm Installer
+set -e
+
+# Get access and who we are.
+{{template "setup.tmpl" .}}
+
+echo "Configure fluent-bit logging the master (skip for minions)..."
+
+{{if .ParamExists "krib/cluster-profile" -}}
+CLUSTER_PROFILE={{.Param "krib/cluster-profile"}}
+PROFILE_TOKEN={{.GenerateProfileToken (.Param "krib/cluster-profile") 7200}}
+{{else -}}
+xiterr 1 "Missing krib/cluster-profile on the machine!"
+{{end -}}
+
+{{template "krib-lib.sh.tmpl" .}}
+
+MASTER_INDEX=$(find_me $KRIB_MASTERS_PARAM "Uuid" $RS_UUID)
+echo "My Master index is $MASTER_INDEX"
+if [[ $MASTER_INDEX != notme ]] ; then
+
+  if [[ $MASTER_INDEX == 0 ]] ; then
+
+    echo "I am the elected leader - install fluent-bit and helm init"
+
+    # needed to apply manifests
+    export KUBECONFIG="/etc/kubernetes/admin.conf"
+
+
+    echo "Applying fluent-bit manifests"
+    kubectl apply -f /tmp/logging-fluent-bit.yaml
+
+  else
+
+    echo "I was not the leader, skipping fluent-bit init"
+
+  fi
+
+else
+
+  echo "I am a worker - no fluent-bit actions"
+
+fi
+
+echo "Finished successfully"
+exit 0

--- a/krib/templates/logging-fluent-bit.yaml.tmpl
+++ b/krib/templates/logging-fluent-bit.yaml.tmpl
@@ -92,7 +92,7 @@ data:
     [OUTPUT]
         Name          gelf
         Match         *
-        Host          {{ .Param "krib/controller-ip" }}
+        Host          {{ .Param "krib/log-target-gelf" }}
         Port          12201
         Mode          udp
         Gelf_Short_Message_Key log

--- a/krib/templates/logging-fluent-bit.yaml.tmpl
+++ b/krib/templates/logging-fluent-bit.yaml.tmpl
@@ -1,3 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: logging
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/krib/templates/logging-fluent-bit.yaml.tmpl
+++ b/krib/templates/logging-fluent-bit.yaml.tmpl
@@ -1,0 +1,179 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluent-bit
+  namespace: logging
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: fluent-bit-read
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - pods
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: fluent-bit-read
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fluent-bit-read
+subjects:
+- kind: ServiceAccount
+  name: fluent-bit
+  namespace: logging
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-config
+  namespace: logging
+  labels:
+    k8s-app: fluent-bit
+data:
+  # Configuration files: server, input, filters and output
+  # ======================================================
+  fluent-bit.conf: |
+    [SERVICE]
+        Flush         1
+        Log_Level     info
+        Daemon        off
+        Parsers_File  parsers.conf
+        HTTP_Server   On
+        HTTP_Listen   0.0.0.0
+        HTTP_Port     2020
+
+    @INCLUDE input-kubernetes.conf
+    @INCLUDE filter-kubernetes.conf
+    @INCLUDE output-graylog.conf
+
+  input-kubernetes.conf: |
+    [INPUT]
+        Name              tail
+        Tag               kube.*
+        Path              /var/log/containers/*.log
+        Parser            docker
+        DB                /var/log/flb_kube.db
+        Mem_Buf_Limit     5MB
+        Skip_Long_Lines   On
+        Refresh_Interval  10
+
+  filter-kubernetes.conf: |
+    [FILTER]
+        Name                kubernetes
+        Match               kube.*
+        Kube_URL            https://kubernetes.default.svc.cluster.local:443
+        Merge_Log           On
+        K8S-Logging.Parser  On
+
+    # ${HOSTNAME} returns the host name.
+    # But Fluentbit runs in a container. So, it is not meaningful.
+    # Instead, copy the host name from the Kubernetes object.
+    [FILTER]
+        Name nest
+        Match *
+        Operation lift
+        Nested_under kubernetes
+
+    # Remove offending fields, see: https://github.com/fluent/fluent-bit/issues/1291
+    [FILTER]
+        Name record_modifier
+        Match *
+        Remove_key annotations
+        Remove_key labels
+
+  output-graylog.conf: |
+    [OUTPUT]
+        Name          gelf
+        Match         *
+        Host          {{ .Param "krib/controller-ip" }}
+        Port          12201
+        Mode          udp
+        Gelf_Short_Message_Key log
+
+  parsers.conf: |
+    [PARSER]
+        Name   json
+        Format json
+        Time_Key time
+        Time_Format %d/%b/%Y:%H:%M:%S %z
+
+    [PARSER]
+        Name        docker
+        Format      json
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L
+        # Command      |  Decoder | Field | Optional Action
+        # =============|==================|=================
+        Decode_Field_As   escaped    log
+
+    [PARSER]
+        Name        syslog
+        Format      regex
+        Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+        Time_Key    time
+        Time_Format %b %d %H:%M:%S
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: fluent-bit
+  namespace: logging
+  labels:
+    k8s-app: fluent-bit-logging
+    version: v1
+    kubernetes.io/cluster-service: "true"
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: fluent-bit-logging
+        version: v1
+        kubernetes.io/cluster-service: "true"
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "2020"
+        prometheus.io/path: /api/v1/metrics/prometheus
+    spec:
+      containers:
+      - name: fluent-bit
+        image: fluent/fluent-bit:1.2.1
+        imagePullPolicy: Always
+        ports:
+          - containerPort: 2020
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: fluent-bit-config
+          mountPath: /fluent-bit/etc/
+        - name: mnt
+          mountPath: /mnt
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: fluent-bit-config
+        configMap:
+          name: fluent-bit-config
+      - name: mnt
+        hostPath:
+          path: /mnt
+      serviceAccountName: fluent-bit
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule


### PR DESCRIPTION
Hey guys,

This PR introduces a fluent-bit implementation based on https://vzurczak.wordpress.com/?p=781, which details a simple design to export all Kubernetes logs to a graylog instance (ideally, off-cluster, although it could be within the cluster).

The changes are implemented as a standalone stage, task, templates, etc, and don't impact any existing workflow unless they're explicitly configured. 

The PR has also accidentally attracted 2 minor bugfixes, one to the metallb implementation, and one to the nginx-ingress deployment.

Cheers!
D
