### PR TITLE
Improve calico

### DIFF
--- a/krib/params/provider-calico-config.yaml
+++ b/krib/params/provider-calico-config.yaml
@@ -7,7 +7,7 @@ Documentation: |
   Param will have no effect on the cluster.
 Schema:
   type: "string"
-  default: "https://docs.projectcalico.org/v3.6/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml"
+  default: "https://docs.projectcalico.org/v3.8/manifests/calico.yaml"
 Meta:
   color: "blue"
   icon: "ship"

--- a/krib/templates/krib-config.sh.tmpl
+++ b/krib/templates/krib-config.sh.tmpl
@@ -135,7 +135,7 @@ if [[ $MASTER_INDEX != notme ]] ; then
       calico)
         echo "Starting calico networking..."
         # Disable NetworkManager interference per https://docs.projectcalico.org/v3.8/maintenance/troubleshooting#configure-networkmanager
-        if [ -d "/etc/NetworkManager/conf.d" ]"; then
+        if [ -d "/etc/NetworkManager/conf.d" ]; then
           echo -e "[keyfile]\nunmanaged-devices=interface-name:cali*;interface-name:tunl*" > /etc/NetworkManager/conf.d/calico.conf
         fi
 
@@ -143,7 +143,7 @@ if [[ $MASTER_INDEX != notme ]] ; then
         # This next line assures that in the event of multiple NICs in the node, the NIC able to reach 1.1.1.1 will be chosen
         # This can optionally be changed to a regex or even an explicit NIC name
         sed -i "/autodetect\"/a\            - name: IP_AUTODETECTION_METHOD\n              value: \"can-reach=1.1.1.1\"" /tmp/calico.yaml
-        sed "s#value: \"192.168.0.0/16\"#value: \"{{ .Param "krib/cluster-pod-subnet" }}\"#g" /tmp/calico.yaml
+        sed -i "s#value: \"192.168.0.0/16\"#value: \"{{ .Param "krib/cluster-pod-subnet" }}\"#g" /tmp/calico.yaml
         kubectl apply -f /tmp/calico.yaml
         mkdir -p /tmp/cleanup
         mv /tmp/calico.yaml /tmp/cleanup/

--- a/krib/templates/krib-config.sh.tmpl
+++ b/krib/templates/krib-config.sh.tmpl
@@ -134,7 +134,20 @@ if [[ $MASTER_INDEX != notme ]] ; then
     case $NET_TYPE in
       calico)
         echo "Starting calico networking..."
-        curl -gfsSL {{ .Param "provider/calico-config" }} | sed "s#value: \"192.168.0.0/16\"#value: \"{{ .Param "krib/cluster-pod-subnet" }}\"#g" | kubectl apply -f -
+        # Disable NetworkManager interference per https://docs.projectcalico.org/v3.8/maintenance/troubleshooting#configure-networkmanager
+        if [ -d "/etc/NetworkManager/conf.d" ]"; then
+          echo -e "[keyfile]\nunmanaged-devices=interface-name:cali*;interface-name:tunl*" > /etc/NetworkManager/conf.d/calico.conf
+        fi
+
+        curl -gfsSL {{ .Param "provider/calico-config" }} > /tmp/calico.yaml
+        # This next line assures that in the event of multiple NICs in the node, the NIC able to reach 1.1.1.1 will be chosen
+        # This can optionally be changed to a regex or even an explicit NIC name
+        sed -i "/autodetect\"/a\            - name: IP_AUTODETECTION_METHOD\n              value: \"can-reach=1.1.1.1\"" /tmp/calico.yaml
+        sed "s#value: \"192.168.0.0/16\"#value: \"{{ .Param "krib/cluster-pod-subnet" }}\"#g" /tmp/calico.yaml
+        kubectl apply -f /tmp/calico.yaml
+        mkdir -p /tmp/cleanup
+        mv /tmp/calico.yaml /tmp/cleanup/
+
         ;;
       flannel)
         echo "Starting flannel networking..."


### PR DESCRIPTION
Hey guys,

A quick one - in a multi-NIC kube deployment, calico auto-selects which NIC to use, and occasionally gets it wrong. This PR does the following:

1. Updates Calico from 3.6 to 3.8
2. Adds config to avoid NetworkManager interference (if enabled)
3. Tells Calico to prefer the NIC which can reach 1.1.1.1, rather than the simplistic (numerical, I think) method calico uses by default. Has no effect on a single-NIC deployment.

Cheers!
D