### PR TITLE
Optional publish ip for nginx ingress

### DIFF
--- a/krib/params/krib-ingress-nginx-mandatory.yaml
+++ b/krib/params/krib-ingress-nginx-mandatory.yaml
@@ -1,12 +1,13 @@
 ---
-Name: "krib/ingress-nginx-mandatory"
-Description: "Specifies the YAML config file url to use for nginx ingress install."
+Name: "krib/ingress-nginx-publish-ip"
+Description: "Optionally specifies a publish IP to the nginx external ingress"
 Documentation: |
-  Set this string to an HTTP or HTTPS reference for a YAML configuration to
-  use for nginx install.  
+  If running an nginx ingress behind a NATing firewall, it may be required to explicitly specify
+  the public IP assigned to ingresses, for example to make something like external-dns work
+  If this value is set, then either the nginx ingress, or (if enabled) the _external_ nginx ingress
+  will have the "--publish-status-address" argument set to this value.
 Schema:
   type: "string"
-  default: "https://github.com/kubernetes/ingress-nginx/raw/nginx-0.24.1/deploy/mandatory.yaml"
 Meta:
   color: "blue"
   icon: "ship"

--- a/krib/params/krib-ingress-nginx-publish-ip.yaml
+++ b/krib/params/krib-ingress-nginx-publish-ip.yaml
@@ -1,0 +1,13 @@
+---
+Name: "krib/ingress-nginx-mandatory"
+Description: "Specifies the YAML config file url to use for nginx ingress install."
+Documentation: |
+  Set this string to an HTTP or HTTPS reference for a YAML configuration to
+  use for nginx install.  
+Schema:
+  type: "string"
+  default: "https://github.com/kubernetes/ingress-nginx/raw/nginx-0.24.1/deploy/mandatory.yaml"
+Meta:
+  color: "blue"
+  icon: "ship"
+  title: "Community Content"

--- a/krib/params/provider-calico-config.yaml
+++ b/krib/params/provider-calico-config.yaml
@@ -7,7 +7,7 @@ Documentation: |
   Param will have no effect on the cluster.
 Schema:
   type: "string"
-  default: "https://docs.projectcalico.org/v3.6/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.7/calico.yaml"
+  default: "https://docs.projectcalico.org/v3.8/manifests/calico.yaml"
 Meta:
   color: "blue"
   icon: "ship"

--- a/krib/templates/krib-config.sh.tmpl
+++ b/krib/templates/krib-config.sh.tmpl
@@ -135,7 +135,7 @@ if [[ $MASTER_INDEX != notme ]] ; then
       calico)
         echo "Starting calico networking..."
         # Disable NetworkManager interference per https://docs.projectcalico.org/v3.8/maintenance/troubleshooting#configure-networkmanager
-        if [ -d "/etc/NetworkManager/conf.d" ]"; then
+        if [ -d "/etc/NetworkManager/conf.d" ]; then
           echo -e "[keyfile]\nunmanaged-devices=interface-name:cali*;interface-name:tunl*" > /etc/NetworkManager/conf.d/calico.conf
         fi
 
@@ -143,7 +143,7 @@ if [[ $MASTER_INDEX != notme ]] ; then
         # This next line assures that in the event of multiple NICs in the node, the NIC able to reach 1.1.1.1 will be chosen
         # This can optionally be changed to a regex or even an explicit NIC name
         sed -i "/autodetect\"/a\            - name: IP_AUTODETECTION_METHOD\n              value: \"can-reach=1.1.1.1\"" /tmp/calico.yaml
-        sed "s#value: \"192.168.0.0/16\"#value: \"{{ .Param "krib/cluster-pod-subnet" }}\"#g" /tmp/calico.yaml
+        sed -i "s#value: \"192.168.0.0/16\"#value: \"{{ .Param "krib/cluster-pod-subnet" }}\"#g" /tmp/calico.yaml
         kubectl apply -f /tmp/calico.yaml
         mkdir -p /tmp/cleanup
         mv /tmp/calico.yaml /tmp/cleanup/

--- a/krib/templates/krib-config.sh.tmpl
+++ b/krib/templates/krib-config.sh.tmpl
@@ -134,7 +134,20 @@ if [[ $MASTER_INDEX != notme ]] ; then
     case $NET_TYPE in
       calico)
         echo "Starting calico networking..."
-        curl -gfsSL {{ .Param "provider/calico-config" }} | sed "s#value: \"192.168.0.0/16\"#value: \"{{ .Param "krib/cluster-pod-subnet" }}\"#g" | kubectl apply -f -
+        # Disable NetworkManager interference per https://docs.projectcalico.org/v3.8/maintenance/troubleshooting#configure-networkmanager
+        if [ -d "/etc/NetworkManager/conf.d" ]"; then
+          echo -e "[keyfile]\nunmanaged-devices=interface-name:cali*;interface-name:tunl*" > /etc/NetworkManager/conf.d/calico.conf
+        fi
+
+        curl -gfsSL {{ .Param "provider/calico-config" }} > /tmp/calico.yaml
+        # This next line assures that in the event of multiple NICs in the node, the NIC able to reach 1.1.1.1 will be chosen
+        # This can optionally be changed to a regex or even an explicit NIC name
+        sed -i "/autodetect\"/a\            - name: IP_AUTODETECTION_METHOD\n              value: \"can-reach=1.1.1.1\"" /tmp/calico.yaml
+        sed "s#value: \"192.168.0.0/16\"#value: \"{{ .Param "krib/cluster-pod-subnet" }}\"#g" /tmp/calico.yaml
+        kubectl apply -f /tmp/calico.yaml
+        mkdir -p /tmp/cleanup
+        mv /tmp/calico.yaml /tmp/cleanup/
+
         ;;
       flannel)
         echo "Starting flannel networking..."

--- a/krib/templates/krib-ingress-nginx-tillerless.sh.tmpl
+++ b/krib/templates/krib-ingress-nginx-tillerless.sh.tmpl
@@ -35,7 +35,7 @@ if [[ $MASTER_INDEX == 0 ]] ; then
   # If we're only doing one ingress, allow the possibilty to override the publish ip
   {{ if .ParamExists "krib/ingress-nginx-publish-ip" }}
   {{ if eq (.Param "krib/ingress-external-enabled") false -}}
-  sed -i "/--ingress-class=/ a \            - --publish-status-address={{ .Param "krib/ingress-nginx-publish-ip" }} \\" \
+  sed -i "s/publish-service=$(POD_NAMESPACE)/publish-status-address={{ .Param "krib/ingress-nginx-publish-ip" }}/" \
     /tmp/nginx-ingress-mandatory.yaml
   {{ end -}}
   {{ end -}}
@@ -56,12 +56,15 @@ if [[ $MASTER_INDEX == 0 ]] ; then
     /tmp/nginx-ingress-mandatory.yaml > /tmp/nginx-ingress-external-mandatory.yaml
   sed -i "/annotations-prefix=nginx.ingress/ a \            - --election-id=ingress-controller-leader-external \\" \
     /tmp/nginx-ingress-external-mandatory.yaml
-  sed -i "/annotations-prefix=nginx.ingress/ a \            - --publish-service=ingress-nginx-external/ingress-nginx-external \\" \
-    /tmp/nginx-ingress-external-mandatory.yaml
 
-  # If we're doing an _additional_ external ingress, then allow the possibility of overriding the external ingress publish ip only
+
+  # If we're doing an _additional_ external ingress, then allow the possibility of overriding the external ingress publish ip using --publish-status-address
+  # This value is mutually exclusive from --publish-service
   {{- if .ParamExists "krib/ingress-nginx-publish-ip" }}
-  sed -i "/--ingress-class=/ a \            - --publish-status-address={{ .Param "krib/ingress-nginx-publish-ip" }} \\" \
+  sed -i "s/publish-service=$(POD_NAMESPACE)/publish-status-address={{ .Param "krib/ingress-nginx-publish-ip" }}/" \
+    /tmp/nginx-ingress-external-mandatory.yaml
+  {{ else }}
+    sed -i "/annotations-prefix=nginx.ingress/ a \            - --publish-service=ingress-nginx-external/ingress-nginx-external \\" \
     /tmp/nginx-ingress-external-mandatory.yaml
   {{ end -}}
 

--- a/krib/templates/krib-ingress-nginx-tillerless.sh.tmpl
+++ b/krib/templates/krib-ingress-nginx-tillerless.sh.tmpl
@@ -60,7 +60,7 @@ if [[ $MASTER_INDEX == 0 ]] ; then
     /tmp/nginx-ingress-external-mandatory.yaml
 
   # If we're doing an _additional_ external ingress, then allow the possibility of overriding the external ingress publish ip only
-  {{ if .ParamExists "krib/ingress-nginx-publish-ip" }}
+  {{- if .ParamExists "krib/ingress-nginx-publish-ip" }}
   sed -i "/--ingress-class=/ a \            - --publish-status-address={{ .Param "krib/ingress-nginx-publish-ip" }} \\" \
     /tmp/nginx-ingress-external-mandatory.yaml
   {{ end -}}

--- a/krib/templates/krib-ingress-nginx-tillerless.sh.tmpl
+++ b/krib/templates/krib-ingress-nginx-tillerless.sh.tmpl
@@ -32,6 +32,14 @@ if [[ $MASTER_INDEX == 0 ]] ; then
   #   kubectl delete -f /tmp/nginx-ingress-mandatory.yaml
   # fi
 
+  # If we're only doing one ingress, allow the possibilty to override the publish ip
+  {{ if .ParamExists "krib/ingress-nginx-publish-ip" }}
+  {{ if eq (.Param "krib/ingress-external-enabled") false -}}
+  sed -i "/--ingress-class=/ a \            - --publish-status-address={{ .Param "krib/ingress-nginx-publish-ip" }} \\" \
+    /tmp/nginx-ingress-mandatory.yaml
+  {{ end -}}
+  {{ end -}}
+
   # Create the default "internal" nginx
   kubectl apply -f /tmp/nginx-ingress-mandatory.yaml
   kubectl apply -f /tmp/nginx-ingress-service.yaml
@@ -50,6 +58,12 @@ if [[ $MASTER_INDEX == 0 ]] ; then
     /tmp/nginx-ingress-external-mandatory.yaml
   sed -i "/annotations-prefix=nginx.ingress/ a \            - --publish-service=ingress-nginx-external/ingress-nginx-external \\" \
     /tmp/nginx-ingress-external-mandatory.yaml
+
+  # If we're doing an _additional_ external ingress, then allow the possibility of overriding the external ingress publish ip only
+  {{ if .ParamExists "krib/ingress-nginx-publish-ip" }}
+  sed -i "/--ingress-class=/ a \            - --publish-status-address={{ .Param "krib/ingress-nginx-publish-ip" }} \\" \
+    /tmp/nginx-ingress-external-mandatory.yaml
+  {{ end -}}
 
   # Prepare the mandatory elements
   sed -i "s/name: nginx-ingress-controller/name: external-nginx-ingress-controller/" /tmp/nginx-ingress-external-mandatory.yaml

--- a/krib/templates/krib-ingress-nginx-tillerless.sh.tmpl
+++ b/krib/templates/krib-ingress-nginx-tillerless.sh.tmpl
@@ -61,7 +61,7 @@ if [[ $MASTER_INDEX == 0 ]] ; then
   # If we're doing an _additional_ external ingress, then allow the possibility of overriding the external ingress publish ip using --publish-status-address
   # This value is mutually exclusive from --publish-service
   {{- if .ParamExists "krib/ingress-nginx-publish-ip" }}
-  sed -i "s/publish-service=$(POD_NAMESPACE)/publish-status-address={{ .Param "krib/ingress-nginx-publish-ip" }}/" \
+  sed -i "s/publish-service=.*/publish-status-address={{ .Param "krib/ingress-nginx-publish-ip" }}/" \
     /tmp/nginx-ingress-external-mandatory.yaml
   {{ else }}
     sed -i "/annotations-prefix=nginx.ingress/ a \            - --publish-service=ingress-nginx-external/ingress-nginx-external \\" \


### PR DESCRIPTION
Another optional improvement to nginx-ingress... when if you set the `krib/ingress-nginx-publish-ip` param, then we'll specify `--publish-status-address` to the nginx ingress controller. This is helpful when the IP which the ingress _thinks_ it gets (i.e., from MetalLB) is not the IP the whole world would use.

In my use-case, for example, I assign RFC1918-private IPs via metallb, and perform 1:1 nat on a firewall. However, ExternalDns needs to see my real-world IP as the IP of the ingress, in order to correctly publish external DNS records.

This is an opt-in param, and is also intended to be used with dual nginx ingresses (one called "nginx-external") if the dual-ingress config is opted into as well.

Cheers!
D