### PR TITLE
Set sane consul log level

### DIFF
--- a/krib/templates/consul-server.json.tmpl
+++ b/krib/templates/consul-server.json.tmpl
@@ -8,7 +8,7 @@
   "advertise_addr": "{{.Machine.Address}}",
   "bootstrap_expect": 3,
   "ui": false,
-  "log_level": "DEBUG",
+  "log_level": "INFO",
   "enable_syslog": true,
   "encrypt": "{{ .Param "consul/encryption-key" }}",  
   "acl_enforce_version_8": false,


### PR DESCRIPTION
Finally, a small PR from me!

I noticed that consul is a little too noisy in the logging department by default, so this PR sets it to a sane level. Debuggers could always manually tweak it on local nodes if the need arose :)

D