### PR TITLE
Make rancheros operating disk configurable + rancheros v1.5.3

### DIFF
--- a/rancheros/bootenvs/rancheros-disk.yaml
+++ b/rancheros/bootenvs/rancheros-disk.yaml
@@ -4,13 +4,13 @@ Description: "Run RancherOS latest disk"
 OS:
   Name: "rancheros-latest"
   Family: "rancheros"
-  IsoFile: "rancheros-latest.iso"
-  IsoSha256: "4ebb4d7ae2732482dade8131b1b6425ff1bc4a9122a318d97cdc831bd64b400c"
-  IsoUrl: "https://releases.rancher.com/os/v1.5.0/rancheros.iso"
-  Version: "v1.5.0"
+  IsoFile: "rancheros-v1.5.3.iso"
+  IsoSha256: "ea14623a2dc36cdec944d10f10c453f70e16b294713a1fe8f96449d61c70c02a"
+  IsoUrl: "https://releases.rancher.com/os/v1.5.3/rancheros.iso"
+  Version: "v1.5.3"
 Initrds:
-  - "boot/initrd-v1.5.0"
-Kernel: "boot/vmlinuz-4.14.85-rancher"
+  - "boot/initrd-v1.5.3"
+Kernel: "boot/vmlinuz-4.14.128-rancher"
 BootParams: >-
   rancher.password=rancher
   rancher.cloud_init.datasources=[url:{{.Machine.Url}}/rancheros-cloud-init]
@@ -19,6 +19,7 @@ BootParams: >-
 RequiredParams:
 OptionalParams:
   - "kernel-console"
+  - "operating-system-disk"
 Templates:
   - Name: "kexec"
     ID: "kexec.tmpl"

--- a/rancheros/bootenvs/rancheros-latest.yaml
+++ b/rancheros/bootenvs/rancheros-latest.yaml
@@ -4,23 +4,24 @@ Description: "Run RancherOS latest"
 OS:
   Name: "rancheros-latest"
   Family: "rancheros"
-  IsoFile: "rancheros-latest.iso"
-  IsoSha256: "4ebb4d7ae2732482dade8131b1b6425ff1bc4a9122a318d97cdc831bd64b400c"
-  IsoUrl: "https://releases.rancher.com/os/v1.5.0/rancheros.iso"
-  Version: "v1.5.0"
+  IsoFile: "rancheros-v1.5.3.iso"
+  IsoSha256: "ea14623a2dc36cdec944d10f10c453f70e16b294713a1fe8f96449d61c70c02a"
+  IsoUrl: "https://releases.rancher.com/os/v1.5.3/rancheros.iso"
+  Version: "v1.5.3"
 Initrds:
-  - "boot/initrd-v1.5.0"
-Kernel: "boot/vmlinuz-4.14.85-rancher"
+  - "boot/initrd-v1.5.3"
+Kernel: "boot/vmlinuz-4.14.128-rancher"
 BootParams: >-
   rancher.password=rancher
   rancher.state.dev=LABEL=RANCHER_STATE
-  rancher.state.autoformat=[/dev/sda]
+  rancher.state.autoformat=[/dev/{{if .ParamExists "operating-system-disk"}}{{.Param "operating-system-disk"}}{{else}}sda{{end}}]
   rancher.cloud_init.datasources=[url:{{.Machine.Url}}/rancheros-cloud-init]
   loglevel=8
   {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
 RequiredParams:
 OptionalParams:
   - "kernel-console"
+  - "operating-system-disk"
 Templates:
   - Name: "kexec"
     ID: "kexec.tmpl"

--- a/rancheros/tasks/rancher-install.yaml
+++ b/rancheros/tasks/rancher-install.yaml
@@ -16,6 +16,14 @@ Templates:
 
     set -e
 
+    echo "Wait for docker daemon to start"
+    for ((i=0; i<120; i++)); do
+        if docker ps >/dev/null; then
+            break
+        fi
+        sleep 1
+    done
+
     echo "Start Rancher Server"
     mkdir -p /host/rancher
     docker run -d --restart=unless-stopped -p 80:80 -p 443:443 -v /host/rancher:/var/lib/rancher rancher/rancher:latest

--- a/rancheros/tasks/rancher-join-cluster.yaml
+++ b/rancheros/tasks/rancher-join-cluster.yaml
@@ -28,10 +28,10 @@ Templates:
 
     for image in $curlimage $jqimage; do
       until docker inspect $image > /dev/null 2>&1; do
-      docker pull $image
-          sleep 2
+        docker pull $image
+        sleep 2
       done
-      done
+    done
 
     while true; do
       docker run --rm $curlimage -sLk "https://$rancher_server_ip/ping" && break

--- a/rancheros/tasks/rancheros-install.yaml
+++ b/rancheros/tasks/rancheros-install.yaml
@@ -8,6 +8,8 @@ Meta:
   icon: unlinkify
   title: RackN Content
 Name: rancheros-install
+OptionalParams:
+  - "operating-system-disk"
 Templates:
 - Contents: |-
     #!/bin/bash
@@ -16,7 +18,9 @@ Templates:
     set -e
 
     echo "Install RancherOS to disk"
-    ros install --debug -c "{{.ProvisionerURL}}/machines/{{.Machine.Uuid}}/rancheros-cloud-init" -d /dev/sda -t gptsyslinux --no-reboot
+    ros install --debug -c "{{.ProvisionerURL}}/machines/{{.Machine.Uuid}}/rancheros-cloud-init" \
+                        -d /dev/{{if .ParamExists "operating-system-disk"}}{{.Param "operating-system-disk"}}{{else}}sda{{end}} \
+                        -t gptsyslinux --no-reboot
 
     echo "Finished successfully"
     exit 0

--- a/rancheros/tasks/rancheros-wipe-disks.yaml
+++ b/rancheros/tasks/rancheros-wipe-disks.yaml
@@ -1,3 +1,4 @@
+BootEnv: sledgehammer
 Description: Wipe Disks for RancherOS
 Documentation: |
   Wipe Disks for RancherOS

--- a/rancheros/tasks/rancheros-wipe-disks.yaml
+++ b/rancheros/tasks/rancheros-wipe-disks.yaml
@@ -8,6 +8,8 @@ Meta:
   icon: unlinkify
   title: RackN Content
 Name: rancheros-wipe-disks
+OptionalParams:
+  - "operating-system-disk"
 Templates:
 - Contents: |-
     #!/bin/bash
@@ -15,8 +17,8 @@ Templates:
 
     set -e
 
-    echo "Force wipe and format /dev/sda"
-    mkfs.ext4 -F -L RANCHER_STATE /dev/sda
+    echo "Force wipe and format disk"
+    mkfs.ext4 -F -L RANCHER_STATE /dev/{{if .ParamExists "operating-system-disk"}}{{.Param "operating-system-disk"}}{{else}}sda{{end}}
     echo "Finished successfully"
     exit 0
   Name: rancheros-wipe-disks

--- a/rancheros/templates/rancheros-cloud-init.tmpl
+++ b/rancheros/templates/rancheros-cloud-init.tmpl
@@ -47,6 +47,6 @@ rancher:
     fstype: auto
     dev: LABEL=RANCHER_STATE
     autoformat:
-    - /dev/sda
+    - /dev/{{if .ParamExists "operating-system-disk"}}{{.Param "operating-system-disk"}}{{else}}sda{{end}}
 {{end}}
 {{end -}}

--- a/rancheros/templates/rancheros-example-state.tmpl
+++ b/rancheros/templates/rancheros-example-state.tmpl
@@ -3,4 +3,4 @@
     fstype: auto
     dev: LABEL=RANCHER_STATE
     autoformat:
-    - /dev/sda
+    - /dev/{{if .ParamExists "operating-system-disk"}}{{.Param "operating-system-disk"}}{{else}}sda{{end}}

--- a/rancheros/workflows/rancher-server-live.yaml
+++ b/rancheros/workflows/rancher-server-live.yaml
@@ -7,6 +7,7 @@ Meta:
 Name: "rancher-server-live"
 ReadOnly: false
 Stages:
+  - "erase-hard-disk-set"
   - "rancheros-wipe-disks"
   - "rancheros-live"
   - "rancher-install"

--- a/rancheros/workflows/rancher-worker-node-live.yaml
+++ b/rancheros/workflows/rancher-worker-node-live.yaml
@@ -5,6 +5,7 @@ Meta:
   title: "Build and Join a Live RancherOS node to a Rancher Cluster"
 Name: "rancher-worker-node-live"
 Stages:
+  - "erase-hard-disk-set"
   - "rancheros-wipe-disks"
   - "rancheros-live"
   - "rancher-join-cluster"


### PR DESCRIPTION
As of now it is hardcoded for sda.
Using the parameter operating-system-disk if available.

Also updating to v1.5.3.