### PR TITLE
made dns call in validation lib more dynamic

### DIFF
--- a/validation/templates/validation-lib.tmpl
+++ b/validation/templates/validation-lib.tmpl
@@ -15,7 +15,13 @@ add_validation_error() {
 }
 
 validate_machine_name_dns_by_ip() {
-    local my_ip=$(getent hosts {{.Machine.Name}}|awk '{print $1}')
+    local host=""
+    if [[ $# < 1 ]]; then
+        host={{.Machine.Name}}
+    else
+        host=$1
+    fi
+    local my_ip=$(getent hosts ${host}|awk '{print $1}')
 
     if [[ ${my_ip} != $1 ]]; then
         return 1


### PR DESCRIPTION
Now if you call the `validate_machine_name_dns_by_ip`  using an optional param
of a hostname it will use that, otherwise it defaults to using the Machine.Name

Signed-off-by: Michael Rice <michael@michaelrice.org>