### PR TITLE
Stop marking machines as not runnable on shutdown.

### DIFF
--- a/coreos/templates/basic-ign.tmpl
+++ b/coreos/templates/basic-ign.tmpl
@@ -62,7 +62,7 @@
         "name": "drpcli.service"
       },
       {
-        "contents": "[Unit]\nDescription=DigitalRebar Provision Client Runner Initial Runnable\nDocumentation=http://provision.readthedocs.io/en/latest/\nWants=network-online.target network.target\nAfter=network-online.target network.target\n\n[Service]\nType=simple\nEnvironmentFile=/etc/drpcli\nExecStartPre=-/bin/curl -g -o /opt/bin/drpcli \"{{.ProvisionerURL}}/files/drpcli.amd64.linux\"\nExecStartPre=-/bin/chmod +x /opt/bin/drpcli\nExecStart=/opt/bin/drpcli machines update \"$RS_UUID\" '{ \"Runnable\": true }'\nExecStop=/opt/drpcli machines update \"$RS_UUID\" '{ \"CurrentTask\": -1, \"Runnable\": false }'\nRemainAfterExit=true\nRestart=on-failure\nRestartSec=5s\nStandardOutput=journal\n\n[Install]\nWantedBy=multi-user.target\n",
+        "contents": "[Unit]\nDescription=DigitalRebar Provision Client Runner Initial Runnable\nDocumentation=http://provision.readthedocs.io/en/latest/\nWants=network-online.target network.target\nAfter=network-online.target network.target\n\n[Service]\nType=simple\nEnvironmentFile=/etc/drpcli\nExecStartPre=-/bin/curl -g -o /opt/bin/drpcli \"{{.ProvisionerURL}}/files/drpcli.amd64.linux\"\nExecStartPre=-/bin/chmod +x /opt/bin/drpcli\nExecStart=/opt/bin/drpcli machines update \"$RS_UUID\" '{ \"Runnable\": true }'\nRemainAfterExit=true\nRestart=on-failure\nRestartSec=5s\nStandardOutput=journal\n\n[Install]\nWantedBy=multi-user.target\n",
         "enabled": true,
         "name": "drpcli-init.service"
       }

--- a/task-library/templates/drpcli-init.service.tmpl
+++ b/task-library/templates/drpcli-init.service.tmpl
@@ -10,7 +10,6 @@ EnvironmentFile=/etc/drpcli
 ExecStartPre=-/bin/curl -g -o /usr/local/bin/drpcli "{{.ProvisionerURL}}/files/drpcli.amd64.linux"
 ExecStartPre=-/bin/chmod +x /usr/local/bin/drpcli
 ExecStart=/usr/local/bin/drpcli machines update "$RS_UUID" '{ "Runnable": true }'
-ExecStop=/usr/local/bin/drpcli machines update "$RS_UUID" '{ "Runnable": false }'
 RemainAfterExit=true
 Restart=on-failure
 RestartSec=5s

--- a/task-library/templates/drpcli-init.sysv.tmpl
+++ b/task-library/templates/drpcli-init.sysv.tmpl
@@ -10,9 +10,6 @@ case $1 in
     start)
         /usr/local/bin/drpcli machines update "$RS_UUID" '{ "Runnable": true }' &>>/var/log/drpcl-init.log </dev/zero
         ;;
-    stop)
-        /usr/local/bin/drpcli machines update "$RS_UUID" '{ "Runnable": false }' &>>/var/log/drpcl-init.log </dev/zero
-        ;;
     status)
         true;;
     enable)


### PR DESCRIPTION
Instead, the runner will do it when asked to reset or ppowercycle the box.
This change is needed because Runnable applies across all contexts,
and we don't want to interfere with a context that may be managing
power on the real system.