### PR TITLE
Move validate nic counts to validation

### DIFF
--- a/validation/._Documentation.meta
+++ b/validation/._Documentation.meta
@@ -50,3 +50,16 @@ name is *add_validation_error* call with a single string parameter.  This can be
 called multiple times.  A validation task should include both the *setup.tmpl*
 and the *validation-lib.tmpl*.
 
+Namespace Definitions
+=====================
+
+Validation system stages, control params, and other content parts will utilize the
+name space of ``validation>``.  Individual Tasks, Params, etc. that
+implement functional use of the Validation system components will utilize the
+common name space of ``validate`.
+
+For example, the Start Stage for the Validation system is ``validation-start``, while
+the NIC Count and UP link state checking uses a task namespaced as ``validate-nic-counts`.
+
+Standard Stage/Task and Param semantics still apply (eg ``validate/nic-required-up`` is the
+Param namespace name).

--- a/validation/params/validate-nic-counts.yaml
+++ b/validation/params/validate-nic-counts.yaml
@@ -1,0 +1,12 @@
+---
+Name: "validate/nic-counts"
+Description: "Validate the minimum number of NICs that a system must have."
+Documentation: |
+  Defines the minimum number of NICs that the Validation system should
+  check for.
+Schema:
+  type: number
+  minimum: 1
+  maximum: 99
+  default: 2
+Secure: false

--- a/validation/params/validate-nic-required-up.yaml
+++ b/validation/params/validate-nic-required-up.yaml
@@ -1,0 +1,14 @@
+---
+Name: "validate/nic-required-up"
+Description: "Validate the required number of NICs that must support an 'UP' link state."
+Documentation: |
+  Validates the number of NICs that can support an ``UP`` link state.  This
+  process does not try to configure any network stack on the interface, just
+  verifies that the port link state can be brought ``UP`` successfully (eg
+  there is cable and connection to upstream switch device).
+Schema:
+  type: number
+  minimum: 1
+  maximum: 99
+  default: 2
+Secure: false

--- a/validation/tasks/validate-nic-counts.yaml
+++ b/validation/tasks/validate-nic-counts.yaml
@@ -1,6 +1,15 @@
 ---
 Name: "validate-nic-counts"
 Description: "Validate the NIC Counts and NIC UP checks"
+Documentation: |
+  This task implements the Validation library function to verify that
+  a given system has a minimum number of NICs in the system, and that
+  a minimum number of those NICs can be brought to a "link UP" state.
+
+  The link up state refers only to the systems ability to brint the link
+  UP, but does not attempt to configure any IP or network stack details
+  on the link.  This verifies cable connectivity and remote switch end
+  is able to establish "UP" state.
 Meta:
   icon: "plug"
   color: "blue"

--- a/validation/tasks/validate-nic-counts.yaml
+++ b/validation/tasks/validate-nic-counts.yaml
@@ -1,0 +1,18 @@
+---
+Name: "validate-nic-counts"
+Description: "Validate the NIC Counts and NIC UP checks"
+Meta:
+  icon: "plug"
+  color: "blue"
+  title: "RackN Content"
+Templates:
+  - Name: "validate-nic-counts.sh"
+    Contents: |
+      #!/usr/bin/env bash
+      {{ template "setup.tmpl" . }}
+      {{ template "validation-lib.tmpl" . }}
+
+      NICS={{ .Param "validate/nic-counts" }}
+      UPS={{ .Param "validate/nic-required-up" }}
+
+      validate_nic_counts $NICS $UPS


### PR DESCRIPTION
Move the validate nic count/up pieces to the Validation content pack.

Adds two params to control the NIC Count and the UP link check count.
- validate/nic-counts
- validate/nic-required-up

Default values if not specified are 2 and 2.