### PR TITLE
Update versions + cleanup

### DIFF
--- a/krib/params/docker-version.yaml
+++ b/krib/params/docker-version.yaml
@@ -5,7 +5,7 @@ Documentation: |
   "Docker Version to use for Kubernetes"
 Schema:
   type: "string"
-  default: "18.09"
+  default: "19.03"
 Meta:
   color: "blue"
   icon: "boxes"

--- a/krib/params/etcd-version.yaml
+++ b/krib/params/etcd-version.yaml
@@ -6,7 +6,7 @@ Documentation: |
   Note: Changes should be coordinate with KRIB Kubernetes version
 Schema:
   type: "string"
-  default: "3.3.13"
+  default: "3.4.1"
 Meta:
   color: "blue"
   icon: "book"

--- a/krib/params/krib-cluster-cni-version.yaml
+++ b/krib/params/krib-cluster-cni-version.yaml
@@ -7,7 +7,7 @@ Documentation: |
 
 Schema:
   type: "string"
-  default: "v0.7.1"
+  default: "v0.8.2"
 Meta:
   color: "blue"
   icon: "book"

--- a/krib/params/krib-cluster-cni-version.yaml
+++ b/krib/params/krib-cluster-cni-version.yaml
@@ -7,7 +7,7 @@ Documentation: |
 
 Schema:
   type: "string"
-  default: "v0.8.0"
+  default: "v0.7.1"
 Meta:
   color: "blue"
   icon: "book"

--- a/krib/params/krib-cluster-crictl-version.yaml
+++ b/krib/params/krib-cluster-crictl-version.yaml
@@ -7,7 +7,7 @@ Documentation: |
 
 Schema:
   type: "string"
-  default: "v1.15.0"
+  default: "v1.16.0"
 Meta:
   color: "blue"
   icon: "book"

--- a/krib/params/krib-cluster-kubernetes-version.yaml
+++ b/krib/params/krib-cluster-kubernetes-version.yaml
@@ -7,7 +7,7 @@ Documentation: |
 
 Schema:
   type: "string"
-  default: "v1.16.0"
+  default: "v1.15.4"
 Meta:
   color: "blue"
   icon: "book"

--- a/krib/params/krib-cluster-kubernetes-version.yaml
+++ b/krib/params/krib-cluster-kubernetes-version.yaml
@@ -7,7 +7,7 @@ Documentation: |
 
 Schema:
   type: "string"
-  default: "v1.15.2"
+  default: "v1.16.0"
 Meta:
   color: "blue"
   icon: "book"

--- a/krib/params/provider-calico-config.yaml
+++ b/krib/params/provider-calico-config.yaml
@@ -7,7 +7,7 @@ Documentation: |
   Param will have no effect on the cluster.
 Schema:
   type: "string"
-  default: "https://docs.projectcalico.org/v3.8/manifests/calico.yaml"
+  default: "https://docs.projectcalico.org/v3.9/manifests/calico.yaml"
 Meta:
   color: "blue"
   icon: "ship"

--- a/krib/templates/docker-install.sh.tmpl
+++ b/krib/templates/docker-install.sh.tmpl
@@ -3,16 +3,10 @@
 set -e
 
 # Get access and who we are.
-{{template "setup.tmpl" .}}
+{{ template "setup.tmpl" .}}
 
-{{ if .ParamExists "krib/cluster-profile" -}}
-CLUSTER_PROFILE={{ .Param "krib/cluster-profile" }}
-PROFILE_TOKEN={{ .GenerateProfileToken (.Param "krib/cluster-profile") 7200 }}
-{{ else -}}
-xiterr 1 "Missing krib/cluster-profile on the machine!"
-{{ end -}}
+{{ template "download-tools.tmpl" .}}
 
-{{ template "krib-lib.sh.tmpl" .}}
 [[ $RS_UUID ]] && export RS_UUID="{{.Machine.UUID}}"
 
 {{if .ParamExists "docker/working-dir" -}}

--- a/krib/templates/krib-dashboard.sh.tmpl
+++ b/krib/templates/krib-dashboard.sh.tmpl
@@ -53,7 +53,7 @@ metadata:
   namespace: kubernetes-dashboard
 EOFSA
 
-  cat >/root/setup/dashboard/dashboard-admin.yaml <<EOFDA
+  cat > /root/setup/dashboard/dashboard-admin.yaml << EOFDA
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:

--- a/krib/templates/krib-dashboard.sh.tmpl
+++ b/krib/templates/krib-dashboard.sh.tmpl
@@ -43,16 +43,6 @@ if [[ $MASTER_INDEX == 0 ]] ; then
   mkdir -p /root/setup/dashboard
   cp /tmp/kubernetes-dashboard.yaml /root/setup/dashboard/kubernetes-dashboard.yaml
 
-  cat > /root/setup/dashboard/dashboard-serviceaccount.yaml << EOFSA
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-    k8s-app: kubernetes-dashboard
-  name: kubernetes-dashboard
-  namespace: kubernetes-dashboard
-EOFSA
-
   cat > /root/setup/dashboard/dashboard-admin.yaml << EOFDA
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -71,9 +61,7 @@ subjects:
 EOFDA
 
   kubectl apply -f /root/setup/dashboard/kubernetes-dashboard.yaml
-  kubectl delete -f /root/setup/dashboard/dashboard-serviceaccount.yaml
   kubectl delete -f /root/setup/dashboard/dashboard-admin.yaml
-  kubectl apply -f /root/setup/dashboard/dashboard-serviceaccount.yaml
   kubectl apply -f /root/setup/dashboard/dashboard-admin.yaml
   kubectl scale --replicas=$MASTER_COUNT -n kubernetes-dashboard deployment/kubernetes-dashboard
 

--- a/krib/templates/krib-lib.sh.tmpl
+++ b/krib/templates/krib-lib.sh.tmpl
@@ -10,6 +10,8 @@
 [[ -z "$PROFILE_TOKEN" ]] && xiterr 1 "required PROFILE_TOKEN not set"
 [[ -z "$CLUSTER_PROFILE" ]] && xiterr 1 "required CLUSTER_PROFILE not set"
 
+{{ template "download-tools.tmpl" .}}
+
 wait_for_variable() {
   local varname=$1
   local var=$(get_param "$varname" | jq -r .)
@@ -134,39 +136,6 @@ wait_for_ingress() {
   done
   echo $var
   set -e
-}
-
-with_backoff() {
-  local max_attempts=${ATTEMPTS-5}
-  local timeout=${TIMEOUT-1}
-  local attempt=1
-  local exitCode=0
-
-  while (( $attempt < $max_attempts ))
-  do
-    if "$@"
-    then
-      return 0
-    else
-      exitCode=$?
-    fi
-
-    echo "Failure ($@)! Retrying in $timeout.." 1>&2
-    sleep $timeout
-    attempt=$(( attempt + 1 ))
-    timeout=$(( timeout * 2 ))
-  done
-
-  if [[ $exitCode != 0 ]]
-  then
-    echo "Execution failed for: $@" 1>&2
-  fi
-
-  return $exitCode
-}
-
-download() {
-  with_backoff curl --connect-timeout 10 --max-time 360 --retry 1 --retry-delay 1 --retry-max-time 40 -sS "$@"
 }
 
 # Common parameters that are used.

--- a/task-library/templates/download-tools.tmpl
+++ b/task-library/templates/download-tools.tmpl
@@ -1,0 +1,36 @@
+#
+# Library of common download functions
+#
+
+with_backoff() {
+  local max_attempts=${ATTEMPTS-5}
+  local timeout=${TIMEOUT-1}
+  local attempt=1
+  local exitCode=0
+
+  while (( $attempt < $max_attempts ))
+  do
+    if "$@"
+    then
+      return 0
+    else
+      exitCode=$?
+    fi
+
+    echo "Failure ($@)! Retrying in $timeout.." 1>&2
+    sleep $timeout
+    attempt=$(( attempt + 1 ))
+    timeout=$(( timeout * 2 ))
+  done
+
+  if [[ $exitCode != 0 ]]
+  then
+    echo "Execution failed for: $@" 1>&2
+  fi
+
+  return $exitCode
+}
+
+download() {
+  with_backoff curl --connect-timeout 10 --max-time 360 --retry 1 --retry-delay 1 --retry-max-time 40 -sS "$@"
+}


### PR DESCRIPTION
update:
docker 19.03
etcd 3.4.1
cni 0.8.2
crictl 1.16.0
kubernetes 1.15.4
calico 3.9

cleanup:
more reliable docker download
dashboard re-apply of serviceaccount removed (previous dashboard token sourced; required pod restart)