### PR TITLE
WIP: Adding CentOS 8 Content

### DIFF
--- a/content/bootenvs/centos-8.0.1905.yml
+++ b/content/bootenvs/centos-8.0.1905.yml
@@ -1,0 +1,79 @@
+---
+Name: "centos-8.0.1905-install"
+Description: "CentOS-8.0.1905 installer that points to the latest CentOS 8.0.1905 release."
+Documentation: |
+  This BootEnv installs the CentOS 8.0.1905 Minimal operating system.  Both x86_64
+  and aarch64 architectures are supported.
+Meta:
+  feature-flags: "change-stage-v2"
+  icon: "linux"
+  color: "blue"
+  title: "Digital Rebar Community Content"
+OS:
+  Family: "redhat"
+  Name: "centos-8.0.1905"
+  SupportedArchitectures:
+    x86_64:
+      IsoFile: "CentOS-8-x86_64-1905-boot.iso"
+      IsoUrl: "http://sjc.edge.kernel.org/centos/8.0.1905/isos/x86_64/CentOS-8-x86_64-1905-boot.iso"
+      Sha256: "a7993a0d4b7fef2433e0d4f53530b63c715d3aadbe91f152ee5c3621139a2cbc"
+      Kernel: "images/pxeboot/vmlinuz"
+      Initrds:
+        - "images/pxeboot/initrd.img"
+      BootParams: >-
+        ksdevice=bootif
+        ks={{.Machine.Url}}/compute.ks
+        method={{.Env.InstallUrl}}
+        inst.geoloc=0
+        {{if .ParamExists "kernel-options"}}{{.Param "kernel-options"}}{{end}}
+        --
+        {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
+    aarch64:
+      Loader: "grubarm64.efi"
+      IsoFile: "CentOS-8-aarch64-1905-boot.iso"
+      IsoUrl: "http://mirrors.sonic.net/centos/8.0.1905/isos/aarch64/CentOS-8-aarch64-1905-boot.iso"
+      Sha256: "18a211a826bd3dd4d034ddc529303bc2b5dc6e1b63ea311644d7698e7b67fb3e"
+      Kernel: "images/pxeboot/vmlinuz"
+      Initrds:
+        - "images/pxeboot/initrd.img"
+      BootParams: >-
+        ksdevice=bootif
+        ks={{.Machine.Url}}/compute.ks
+        method={{.Env.InstallUrl}}
+        inst.geoloc=0
+        {{if .ParamExists "kernel-options"}}{{.Param "kernel-options"}}{{end}}
+        --
+        {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
+RequiredParams:
+OptionalParams:
+  - "operating-system-disk"
+  - "provisioner-default-password-hash"
+  - "kernel-console"
+  - "kernel-options"
+  - "proxy-servers"
+  - "select-kickseed"
+Templates:
+  - Name: "kexec"
+    ID: "kexec.tmpl"
+    Path: "{{.Machine.Path}}/kexec"
+  - ID: "default-pxelinux.tmpl"
+    Name: "pxelinux"
+    Path: "pxelinux.cfg/{{.Machine.HexAddress}}"
+  - ID: "default-ipxe.tmpl"
+    Name: "ipxe"
+    Path: "{{.Machine.Address}}.ipxe"
+  - ID: "default-pxelinux.tmpl"
+    Name: "pxelinux-mac"
+    Path: 'pxelinux.cfg/{{.Machine.MacAddr "pxelinux"}}'
+  - ID: "default-ipxe.tmpl"
+    Name: "ipxe-mac"
+    Path: '{{.Machine.MacAddr "ipxe"}}.ipxe'
+  - ID: "default-grub.tmpl"
+    Name: "grub"
+    Path: "grub/{{.Machine.Address}}.cfg"
+  - ID: "default-grub.tmpl"
+    Name: "grub-mac"
+    Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'
+  - ID: "select-kickseed.tmpl"
+    Name: "compute.ks"
+    Path: "{{.Machine.Path}}/compute.ks"

--- a/content/bootenvs/centos-8.0.1905.yml
+++ b/content/bootenvs/centos-8.0.1905.yml
@@ -14,9 +14,9 @@ OS:
   Name: "centos-8.0.1905"
   SupportedArchitectures:
     x86_64:
-      IsoFile: "CentOS-8-x86_64-1905-boot.iso"
-      IsoUrl: "http://sjc.edge.kernel.org/centos/8.0.1905/isos/x86_64/CentOS-8-x86_64-1905-boot.iso"
-      Sha256: "a7993a0d4b7fef2433e0d4f53530b63c715d3aadbe91f152ee5c3621139a2cbc"
+      IsoFile: "CentOS-8-x86_64-1905-dvd1.iso"
+      IsoUrl: "http://sjc.edge.kernel.org/centos/8.0.1905/isos/x86_64/CentOS-8-x86_64-1905-dvd1.iso"
+      Sha256: "ea17ef71e0df3f6bf1d4bf1fc25bec1a76d1f211c115d39618fe688be34503e8"
       Kernel: "images/pxeboot/vmlinuz"
       Initrds:
         - "images/pxeboot/initrd.img"
@@ -30,9 +30,9 @@ OS:
         {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
     aarch64:
       Loader: "grubarm64.efi"
-      IsoFile: "CentOS-8-aarch64-1905-boot.iso"
-      IsoUrl: "http://mirrors.sonic.net/centos/8.0.1905/isos/aarch64/CentOS-8-aarch64-1905-boot.iso"
-      Sha256: "18a211a826bd3dd4d034ddc529303bc2b5dc6e1b63ea311644d7698e7b67fb3e"
+      IsoFile: "CentOS-8-aarch64-1905-dvd1.iso"
+      IsoUrl: "http://mirrors.sonic.net/centos/8.0.1905/isos/aarch64/CentOS-8-aarch64-1905-dvd1.iso"
+      Sha256: "c950cf7599a2317e081506a3e0684f665ef9c8fe66963bf7492595d7c6ccc230"
       Kernel: "images/pxeboot/vmlinuz"
       Initrds:
         - "images/pxeboot/initrd.img"

--- a/content/bootenvs/centos-8.1.1911.yml
+++ b/content/bootenvs/centos-8.1.1911.yml
@@ -1,8 +1,8 @@
 ---
-Name: "centos-8-install"
-Description: "CentOS-8 installer that points to the latest CentOS 8 release."
+Name: "centos-8.1.1911-install"
+Description: "CentOS-8.1.1911 installer that points to the latest CentOS 8.1.1911 release."
 Documentation: |
-  This BootEnv installs the CentOS 8 Minimal operating system.  Both x86_64
+  This BootEnv installs the CentOS 8.1.1911 Minimal operating system.  Both x86_64
   and aarch64 architectures are supported.
 Meta:
   feature-flags: "change-stage-v2"
@@ -11,7 +11,7 @@ Meta:
   title: "Digital Rebar Community Content"
 OS:
   Family: "redhat"
-  Name: "centos-8"
+  Name: "centos-8.1.1911"
   SupportedArchitectures:
     x86_64:
       IsoFile: "CentOS-8.1.1911-x86_64-dvd1.iso"
@@ -22,7 +22,8 @@ OS:
         - "images/pxeboot/initrd.img"
       BootParams: >-
         ksdevice=bootif
-        inst.ks={{.Machine.Url}}/compute.ks
+        ks={{.Machine.Url}}/compute.ks
+        method={{.Env.InstallUrl}}
         inst.geoloc=0
         {{if .ParamExists "kernel-options"}}{{.Param "kernel-options"}}{{end}}
         --
@@ -37,7 +38,8 @@ OS:
         - "images/pxeboot/initrd.img"
       BootParams: >-
         ksdevice=bootif
-        inst.ks={{.Machine.Url}}/compute.ks
+        ks={{.Machine.Url}}/compute.ks
+        method={{.Env.InstallUrl}}
         inst.geoloc=0
         {{if .ParamExists "kernel-options"}}{{.Param "kernel-options"}}{{end}}
         --

--- a/content/bootenvs/centos-8.yml
+++ b/content/bootenvs/centos-8.yml
@@ -1,0 +1,79 @@
+---
+Name: "centos-8-install"
+Description: "CentOS-8 installer that points to the latest CentOS 8 release."
+Documentation: |
+  This BootEnv installs the CentOS 8 Minimal operating system.  Both x86_64
+  and aarch64 architectures are supported.
+Meta:
+  feature-flags: "change-stage-v2"
+  icon: "linux"
+  color: "blue"
+  title: "Digital Rebar Community Content"
+OS:
+  Family: "redhat"
+  Name: "centos-8"
+  SupportedArchitectures:
+    x86_64:
+      IsoFile: "CentOS-8-x86_64-1905-boot.iso"
+      IsoUrl: "http://sjc.edge.kernel.org/centos/8.0.1905/isos/x86_64/CentOS-8-x86_64-1905-boot.iso"
+      Sha256: "a7993a0d4b7fef2433e0d4f53530b63c715d3aadbe91f152ee5c3621139a2cbc"
+      Kernel: "images/pxeboot/vmlinuz"
+      Initrds:
+        - "images/pxeboot/initrd.img"
+      BootParams: >-
+        ksdevice=bootif
+        ks={{.Machine.Url}}/compute.ks
+        method={{.Env.InstallUrl}}
+        inst.geoloc=0
+        {{if .ParamExists "kernel-options"}}{{.Param "kernel-options"}}{{end}}
+        --
+        {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
+    aarch64:
+      Loader: "grubarm64.efi"
+      IsoFile: "CentOS-8-aarch64-1905-boot.iso"
+      IsoUrl: "http://mirrors.sonic.net/centos/8.0.1905/isos/aarch64/CentOS-8-aarch64-1905-boot.iso"
+      Sha256: "18a211a826bd3dd4d034ddc529303bc2b5dc6e1b63ea311644d7698e7b67fb3e"
+      Kernel: "images/pxeboot/vmlinuz"
+      Initrds:
+        - "images/pxeboot/initrd.img"
+      BootParams: >-
+        ksdevice=bootif
+        ks={{.Machine.Url}}/compute.ks
+        method={{.Env.InstallUrl}}
+        inst.geoloc=0
+        {{if .ParamExists "kernel-options"}}{{.Param "kernel-options"}}{{end}}
+        --
+        {{if .ParamExists "kernel-console"}}{{.Param "kernel-console"}}{{end}}
+RequiredParams:
+OptionalParams:
+  - "operating-system-disk"
+  - "provisioner-default-password-hash"
+  - "kernel-console"
+  - "kernel-options"
+  - "proxy-servers"
+  - "select-kickseed"
+Templates:
+  - Name: "kexec"
+    ID: "kexec.tmpl"
+    Path: "{{.Machine.Path}}/kexec"
+  - ID: "default-pxelinux.tmpl"
+    Name: "pxelinux"
+    Path: "pxelinux.cfg/{{.Machine.HexAddress}}"
+  - ID: "default-ipxe.tmpl"
+    Name: "ipxe"
+    Path: "{{.Machine.Address}}.ipxe"
+  - ID: "default-pxelinux.tmpl"
+    Name: "pxelinux-mac"
+    Path: 'pxelinux.cfg/{{.Machine.MacAddr "pxelinux"}}'
+  - ID: "default-ipxe.tmpl"
+    Name: "ipxe-mac"
+    Path: '{{.Machine.MacAddr "ipxe"}}.ipxe'
+  - ID: "default-grub.tmpl"
+    Name: "grub"
+    Path: "grub/{{.Machine.Address}}.cfg"
+  - ID: "default-grub.tmpl"
+    Name: "grub-mac"
+    Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'
+  - ID: "select-kickseed.tmpl"
+    Name: "compute.ks"
+    Path: "{{.Machine.Path}}/compute.ks"

--- a/content/params/package-repositories.yaml
+++ b/content/params/package-repositories.yaml
@@ -115,10 +115,29 @@ Schema:
       arch: x86_64
       url: https://mirrors.edge.kernel.org/centos/8.0.1905/BaseOS/x86_64/os/
       installSource: true
+    - tag: centos-8.1.1911
+      os:
+        - centos-8.1.1911
+      arch: x86_64
+      url: https://mirrors.edge.kernel.org/centos/8.1.1911/BaseOS/x86_64/os/
+      installSource: true
+    - tag: centos-8.0.1905
+      os:
+        - centos-8.0.1905
+      arch: aarch64
+      url: https://mirrors.edge.kernel.org/centos/8.0.1905/BaseOS/aarch64/os/
+      installSource: true
+    - tag: centos-8.1.1911
+      os:
+        - centos-8.1.1911
+      arch: aarch64
+      url: https://mirrors.edge.kernel.org/centos/8.1.1911/BaseOS/aarch64/os/
+      installSource: true
     - tag: centos-8-everything
       os:
         - centos-8
         - centos-8.0.1905
+        - centos-8.1.1911
       arch: x86_64
       url: https://mirrors.edge.kernel.org/centos/8/
       distribution: "8"
@@ -133,6 +152,7 @@ Schema:
       os:
         - centos-8
         - centos-8.0.1905
+        - centos-8.1.1911
       arch: aarch64
       url: http://mirrors.sonic.net/centos/8/
       distribution: "8"
@@ -147,6 +167,7 @@ Schema:
       os:
         - centos-8
         - centos-8.0.1905
+        - centos-8.1.1911
       arch: any
       url: http://mirrors.kernel.org/fedora-epel/8/Everything/$basearch
       distribution: "8"

--- a/content/params/package-repositories.yaml
+++ b/content/params/package-repositories.yaml
@@ -97,6 +97,59 @@ Documentation: |
         - non-free
 Schema:
   default:
+    - tag: centos-8
+      os:
+        - centos-8
+      arch: x86_64
+      url: https://mirrors.edge.kernel.org/centos/8/BaseOS/x86_64/os/
+      installSource: true
+    - tag: centos-8
+      os:
+        - centos-8
+      arch: aarch64
+      url: http://mirrors.sonic.net/centos/8/BaseOS/aarch64/os/
+      installSource: true
+    - tag: centos-8.0.1905
+      os:
+        - centos-8.0.1905
+      arch: x86_64
+      url: https://mirrors.edge.kernel.org/centos/8.0.1905/BaseOS/x86_64/os/
+      installSource: true
+    - tag: centos-8-everything
+      os:
+        - centos-8
+        - centos-8.0.1905
+      arch: x86_64
+      url: https://mirrors.edge.kernel.org/centos/8/
+      distribution: "8"
+      components:
+        - AppStream
+        - centosplus
+        - extras
+        - fasttrack
+        - BaseOS
+        - PowerTools
+    - tag: centos-8-everything
+      os:
+        - centos-8
+        - centos-8.0.1905
+      arch: aarch64
+      url: http://mirrors.sonic.net/centos/8/
+      distribution: "8"
+      components:
+        - AppStream
+        - centosplus
+        - extras
+        - fasttrack
+        - BaseOS
+        - PowerTools
+    - tag: epel-8
+      os:
+        - centos-8
+        - centos-8.0.1905
+      arch: any
+      url: http://mirrors.kernel.org/fedora-epel/8/Everything/$basearch
+      distribution: "8"
     - tag: centos-7
       os:
         - centos-7
@@ -122,6 +175,7 @@ Schema:
         - centos-7.4.1708
         - centos-7.5.1804
         - centos-7.6.1810
+        - centos-7.7.1908
       arch: x86_64
       url: "http://mirrors.edge.kernel.org/centos"
       distribution: "7"
@@ -142,6 +196,7 @@ Schema:
         - centos-7.4.1708
         - centos-7.5.1804
         - centos-7.6.1810
+        - centos-7.7.1908
       arch: aarch64
       url: "http://mirror.centos.org/altarch"
       distribution: "7"
@@ -159,6 +214,7 @@ Schema:
         - centos-7.4.1708
         - centos-7.5.1804
         - centos-7.6.1810
+        - centos-7.7.1908
       arch: any
       url: http://mirrors.kernel.org/fedora-epel/7/$basearch
       distribution: "7"

--- a/content/stages/centos-8.0.1905.yml
+++ b/content/stages/centos-8.0.1905.yml
@@ -4,7 +4,6 @@ Description: "CentOS 8.0.1905 install stage."
 BootEnv: "centos-8.0.1905-install"
 Tasks:
   - "set-hostname"
-  - "centos-drp-only-repos"
   - "ssh-access"
   - "configure-network"
 Meta:

--- a/content/stages/centos-8.0.1905.yml
+++ b/content/stages/centos-8.0.1905.yml
@@ -1,0 +1,13 @@
+---
+Name: "centos-8.0.1905-install"
+Description: "CentOS 8.0.1905 install stage."
+BootEnv: "centos-8.0.1905-install"
+Tasks:
+  - "set-hostname"
+  - "centos-drp-only-repos"
+  - "ssh-access"
+  - "configure-network"
+Meta:
+  icon: "download"
+  color: "yellow"
+  title: "Digital Rebar Community Content"

--- a/content/stages/centos-8.1.1911.yml
+++ b/content/stages/centos-8.1.1911.yml
@@ -1,7 +1,7 @@
 ---
-Name: "centos-8-install"
-Description: "CentOS 8 install stages.  References the latest CentOS 8 release"
-BootEnv: "centos-8-install"
+Name: "centos-8.1.1911-install"
+Description: "CentOS 8.1.1911 install stage."
+BootEnv: "centos-8.1.1911-install"
 Tasks:
   - "set-hostname"
   - "ssh-access"

--- a/content/stages/centos-8.yml
+++ b/content/stages/centos-8.yml
@@ -1,0 +1,13 @@
+---
+Name: "centos-8-install"
+Description: "CentOS 8 install stages.  References the latest CentOS 8 release"
+BootEnv: "centos-8-install"
+Tasks:
+  - "set-hostname"
+  - "centos-drp-only-repos"
+  - "ssh-access"
+  - "configure-network"
+Meta:
+  icon: "download"
+  color: "yellow"
+  title: "Digital Rebar Community Content"

--- a/content/templates/centos-7.ks.tmpl
+++ b/content/templates/centos-7.ks.tmpl
@@ -1,8 +1,9 @@
 # DigitalRebar Provision Centos-7 (and related distros) kickstart
 
-{{range .InstallRepos}}
-{{ .Install }}
-{{end}}
+url --url {{.ProvisionerURL}}/centos-8/install
+repo --name="BaseOS" --baseurl={{.ProvisionerURL}}/centos-8/install/BaseOS
+repo --name="AppStream" --baseurl={{.ProvisionerURL}}/centos-8/install/AppStream
+
 # key --skip
 # Disable geolocation for language and timezone
 # Currently broken by https://bugzilla.redhat.com/show_bug.cgi?id=1111717


### PR DESCRIPTION
`centos-8` and `centos-8.0.1905`
- adds BootEnvs for CentOS 8
- adds Stages
- updates `package-repositories`
- BONUS: added `package-repositories` tags for `centos-7.7.1908` that I missed previously

NOTE:  This is currently broken.  It appears that Redhat/CentOS repos for C8 have been restructured some - and the `package-repositories` logic is going to need to be updated (hopefully JUST my Param definition). 

I am staging this for now to pick up again later.