### PR TITLE
Filter out content after @ from ip -o link

### DIFF
--- a/task-library/templates/network-lldp-start.sh.tmpl
+++ b/task-library/templates/network-lldp-start.sh.tmpl
@@ -17,7 +17,7 @@ done
 {{if .Param "network/lldp-all-nics" }}
 echo ""
 echo "Setting all links up"
-ip -o link | awk -F: '{ print $2 }' | while read intf
+ip -o link | awk -F: '{ print $2 }' | awk -F@ '{ print $1 }' | while read intf
 do
     ip link set dev $intf up
 done


### PR DESCRIPTION
ip -o link returns a list of all network links, some of which may include a portion with @ followed by the parent interface. This is filtered out to be properly passed to ip link set dev $intf up, otherwise it will err.