### PR TITLE
workaround: dont enforce full object spec during migration

### DIFF
--- a/task-library/params/cluster-machines.yaml
+++ b/task-library/params/cluster-machines.yaml
@@ -5,13 +5,6 @@ Schema:
   type: "array"
   items:
     type: "object"
-    properties:
-      Address:
-        type: string
-      Name:
-        type: string
-      Uuid:
-        type: string
   default: []
 Meta:
   color: "blue"


### PR DESCRIPTION
workaround for issue #407 until we update the code to use the more complete object data