### PR TITLE
Adding fedora 31 bootenv

### DIFF
--- a/content/bootenvs/fedora-31.yml
+++ b/content/bootenvs/fedora-31.yml
@@ -1,0 +1,63 @@
+---
+Name: "fedora-31-install"
+Description: "Fedora Server 31"
+Documentation: |
+  This BootEnv installs the Fedora 31 Minimal server operating system. x86_64
+  is supported.
+Meta:
+  feature-flags: "change-stage-v2"
+  icon: "linux"
+  color: "blue"
+  title: "Digital Rebar Community Content"
+OS:
+  Family: "fedora"
+  Name: "fedora-31"
+  SupportedArchitectures:
+    x86_64:
+      IsoFile: "Fedora-Server-dvd-x86_64-31-1.9.iso"
+      IsoUrl: "http://mirror.rackspace.com/fedora/releases/31/Server/x86_64/iso/Fedora-Server-dvd-x86_64-31-1.9.iso"
+      Sha256: "225ebc160e40bb43c5de28bad9680e3a78a9db40c9e3f4f42f3ee3f10f95dbeb"
+      Kernel: "images/pxeboot/vmlinuz"
+      Initrds:
+        - "images/pxeboot/initrd.img"
+      BootParams: >-
+        ksdevice=bootif
+        ks={{.Machine.Url}}/compute.ks
+        method={{.Env.InstallUrl}}
+        inst.geoloc=0
+        {{.Param "kernel-options"}}
+        --
+        {{.Param "kernel-console"}}
+RequiredParams:
+OptionalParams:
+  - "operating-system-disk"
+  - "provisioner-default-password-hash"
+  - "kernel-console"
+  - "kernel-options"
+  - "proxy-servers"
+  - "select-kickseed"
+Templates:
+  - Name: "kexec"
+    ID: "kexec.tmpl"
+    Path: "{{.Machine.Path}}/kexec"
+  - ID: "default-pxelinux.tmpl"
+    Name: "pxelinux"
+    Path: "pxelinux.cfg/{{.Machine.HexAddress}}"
+  - ID: "default-ipxe.tmpl"
+    Name: "ipxe"
+    Path: "{{.Machine.Address}}.ipxe"
+  - ID: "default-pxelinux.tmpl"
+    Name: "pxelinux-mac"
+    Path: 'pxelinux.cfg/{{.Machine.MacAddr "pxelinux"}}'
+  - ID: "default-ipxe.tmpl"
+    Name: "ipxe-mac"
+    Path: '{{.Machine.MacAddr "ipxe"}}.ipxe'
+  - ID: "default-grub.tmpl"
+    Name: "grub"
+    Path: "grub/{{.Machine.Address}}.cfg"
+  - ID: "default-grub.tmpl"
+    Name: "grub-mac"
+    Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'
+  - ID: "select-kickseed.tmpl"
+    Name: "compute.ks"
+    Path: "{{.Machine.Path}}/compute.ks"

--- a/content/params/kickstart-base-packages.yaml
+++ b/content/params/kickstart-base-packages.yaml
@@ -1,0 +1,50 @@
+---
+Name: kickstart-base-packages
+Description: A map containing the distro, and the list of base packages to be installed
+Documentation: |
+  This provides a list of packages to be installed during a CentOS, RHEL, Fedora, and compatible package based kickstar install.
+  Here is an example of how to override the default packages used for CentOS
+
+    ::
+
+      {"centos": ["@core", "openssh"]}
+
+
+Schema:
+  type: object
+  default:
+    unknown:
+      - "@core"
+      - trousers
+      - fipscheck
+      - device-mapper-multipath
+      - openssh
+      - curl
+      - efibootmgr
+      - tar
+    redhat:
+      - "@core"
+      - trousers
+      - fipscheck
+      - device-mapper-multipath
+      - openssh
+      - curl
+      - efibootmgr
+      - tar
+    centos:
+      - "@core"
+      - trousers
+      - fipscheck
+      - device-mapper-multipath
+      - openssh
+      - curl
+      - efibootmgr
+      - tar
+    fedora:
+      - "@core"
+      - fipscheck
+      - device-mapper-multipath
+      - openssh
+      - curl
+      - efibootmgr
+      - tar

--- a/content/stages/fedora-31.yml
+++ b/content/stages/fedora-31.yml
@@ -1,0 +1,13 @@
+---
+Name: "fedora-31-install"
+Description: "Fedora 31 Install Stage"
+BootEnv: "fedora-31-install"
+Tasks:
+  - "set-hostname"
+  - "centos-drp-only-repos"
+  - "ssh-access"
+  - "configure-network"
+Meta:
+  icon: "download"
+  color: "yellow"
+  title: "Digital Rebar Community Content"

--- a/content/templates/centos-7.ks.tmpl
+++ b/content/templates/centos-7.ks.tmpl
@@ -30,14 +30,16 @@ text
 reboot {{if .Param "kexec-ok" }}--kexec{{end}}
 
 %packages
-@core
-trousers
-fipscheck
-device-mapper-multipath
-openssh
-curl
-efibootmgr
-tar
+{{ $packages := index (.Param "kickstart-base-packages") .Env.OS.Name -}}
+{{ if not $packages -}}
+{{ $packages = index (.Param "kickstart-base-packages") .Env.OS.Family -}}
+{{ end -}}
+{{ if not $packages -}}
+{{ $packages = index (.Param "kickstart-base-packages") "unknown" -}}
+{{ end -}}
+{{ range $index, $element := $packages -}}
+{{$element}}
+{{ end -}}
 {{if .ParamExists "extra-packages" -}}
 {{ range $index, $element := (.Param "extra-packages") -}}
 {{$element}}

--- a/content/templates/select-kickseed.tmpl
+++ b/content/templates/select-kickseed.tmpl
@@ -29,6 +29,7 @@
 {{else -}}
   {{if (eq "redhat" .Env.OS.Family) -}} {{template "centos-7.ks.tmpl" .}} {{end -}}
   {{if (eq "centos" .Env.OS.Family) -}} {{template "centos-7.ks.tmpl" .}} {{end -}}
+  {{if (eq "fedora" .Env.OS.Family) -}} {{template "centos-7.ks.tmpl" .}} {{end -}}
   {{if (eq "debian" .Env.OS.Family) -}} {{template "net-seed.tmpl" .}} {{end -}}
   {{if (eq "ubuntu" .Env.OS.Family) -}} {{template "net-seed.tmpl" .}} {{end -}}
 {{end -}}

--- a/task-library/workflows/fedora-base.yaml
+++ b/task-library/workflows/fedora-base.yaml
@@ -1,0 +1,19 @@
+Name: "fedora-base"
+Description: "Basic Fedora Install Workflow + Runner"
+Documentation: |
+  This workflow includes the DRP Runner in Fedora provisioning process for DRP.
+
+  After the install completes, the workflow installs the runner
+  in a waiting state so that DRP will automatically detect and start a
+  new workflow if the Machine.Workflow is updated.
+
+  NOTE: To enable, upload the Fedora ISO as per the fedora-31 BootEnv
+Stages:
+  - fedora-31-install
+  - runner-service
+  - finish-install
+  - complete
+Meta:
+  color: green
+  icon: download
+  title: RackN Content


### PR DESCRIPTION
This chgange adds support for Fedora 31 x86_64

This change also introduces a new param called kickstart-base-packages

Fixes: rackn/provision-server#182

Signed-off-by: Michael Rice <michael@michaelrice.org>