### PR TITLE
bootstrap lock is good practice (share code)

### DIFF
--- a/task-library/tasks/bootstrap-lock.yaml
+++ b/task-library/tasks/bootstrap-lock.yaml
@@ -1,0 +1,29 @@
+---
+Name: "bootstrap-lock"
+Description: "A task to lock the machine at end of a bootstrap stage"
+Documentation: |
+  Useful as the final task in a bootstrap sequence.
+
+  This task will set Machine.Lock = true to prevent accidential
+  operator actions on the DR Server bootstrap machine agent.  This is
+  important because the bootstrap machine agent has administrative
+  power on the DR Server and can cause issues is accidently run.
+Templates:
+  - Name: "lock.sh"
+    Path: ""
+    Contents: |
+      #!/usr/bin/env bash
+
+      {{ template "setup.tmpl" . }}
+
+      echo "Locking Machine"
+      drpcli machines meta set $RS_UUID key icon to "chess queen"
+      drpcli machines meta set $RS_UUID key color to "black"
+      drpcli machines update $RS_UUID '{"Locked":true}'
+
+Meta:
+  icon: "lock"
+  color: "yellow"
+  title: "Community Content"
+  feature-flags: "sane-exit-codes"
+  copyright: "RackN 2020"


### PR DESCRIPTION
position so that edge-lab and multi-site demo can start using shared code

other generic bootstrap tasks will eventually follow.