### PR TITLE
fix(burnin): add cpu reserve to allow for tweaking memory usage in test.

### DIFF
--- a/burnin/params/burnin-cpumem-memory-reserve.yml
+++ b/burnin/params/burnin-cpumem-memory-reserve.yml
@@ -1,0 +1,13 @@
+---
+Name: "burnin-cpumem-memory-reserve"
+Description: "Memory (in MB) to reserve for sledgehammer per Proc"
+Documentation: |
+  Sledgehammer is an in-memory OS and needs some memory to operate.
+  This parameter allows for the tweaking of the reserve as needed.
+Schema:
+  type: "number"
+  default: 256
+Meta:
+  color: "blue"
+  icon: "fire"
+  title: "RackN Content"

--- a/burnin/tasks/cpumem_stress.yml
+++ b/burnin/tasks/cpumem_stress.yml
@@ -25,7 +25,9 @@ Templates:
     DURATION="{{.Param "burnin-cpumem-duration"}}m"
     echo 3 >/proc/sys/vm/drop_caches
     MEM="$(free -m |awk '/Mem/ {print $7}')"
-    MEM=$(( (MEM / NUMPROCS) - 128 ))
+    MEM=$(( (MEM / NUMPROCS) - ${{.Param "burnin-cpumum-memory-reserve"}} ))
+
+    echo "Running stress on $NUMPROCS processors for $DURATION with ${MEM}m locked on each CPU"
 
     stress-ng --cpu 0 --cpu-method=all \
           --vm 0 --vm-method=all --vm-locked --vm-keep --vm-bytes="${MEM}m" \


### PR DESCRIPTION
Sledgehammer is in-memory OS and needs a reserve.  Previous 128M/Proc
was sufficient.  Sledgehammer has grown and needs more.  Add parameter
to allow tweaks in the future.  Update default to 256M.