### PR TITLE
remove unsafe hack and use ExtraClaims instead. 

### DIFF
--- a/krib/._RequiredFeatures.meta
+++ b/krib/._RequiredFeatures.meta
@@ -1,1 +1,1 @@
-sane-exit-codes, job-exit-states, fsm-runner, workflows, default-workflow, http-range-header, roles, tenants, sprig, log-has-head-method
+sane-exit-codes, job-exit-states, fsm-runner, workflows, default-workflow, http-range-header, roles, tenants, sprig, log-has-head-method, elevated-tasks

--- a/krib/tasks/krib-dev-hard-reset.yaml
+++ b/krib/tasks/krib-dev-hard-reset.yaml
@@ -3,13 +3,15 @@ Description: "DEV: Reset Profile values between Test Runs, ignoring races"
 Name: "krib-dev-hard-reset"
 Documentation: |
   Clears Created Params: krib/*, etcd/*
+ExtraClaims:
+  - scope: "plugins"
+    action: "*"
+    specific: "*"
 RequiredParams:
   - krib/cluster-profile
   - etcd/cluster-profile
 OptionalParams:
   - krib/cluster-is-production
-  - unsafe/rs-username
-  - unsafe/rs-password
 Templates:
 - Contents: |-
     #!/bin/bash
@@ -36,26 +38,11 @@ Templates:
       echo "drpcli plugins runaction certs deleteroot certs/root {{.Param "etcd/name"}}-server-ca"
       echo "drpcli plugins runaction certs deleteroot certs/root {{.Param "etcd/name"}}-peer-ca"     
       echo "==========================================================================="
-      echo "Try to add unsafe/rs-username with value: <your-non-default-username>, and unsafe/rs-password with value: <your-non-default-password>, on your profile and re-run the krib-hard-reset-cluster workflow"
       
       sleep 1
-      {{if .ParamExists "unsafe/rs-username"}}
-        USERNAME="{{.Param "unsafe/rs-username"}}"
-      {{else}}
-        USERNAME="rocketskates"
-      {{end}}          
-      {{if .ParamExists "unsafe/rs-password"}}
-        PASSWORD="{{.Param "unsafe/rs-password"}}"
-      {{else}}
-        PASSWORD="r0cketsk8ts"
-      {{end}}
-
-      HOLD_TOKEN=$RS_TOKEN
-      unset RS_TOKEN
-      drpcli -U "$USERNAME" -P "$PASSWORD" plugins runaction certs deleteroot certs/root {{.Param "etcd/name"}}-client-ca
-      drpcli -U "$USERNAME" -P "$PASSWORD" plugins runaction certs deleteroot certs/root {{.Param "etcd/name"}}-server-ca
-      drpcli -U "$USERNAME" -P "$PASSWORD" plugins runaction certs deleteroot certs/root {{.Param "etcd/name"}}-peer-ca
-      export RS_TOKEN=$HOLD_TOKEN
+      drpcli plugins runaction certs deleteroot certs/root {{.Param "etcd/name"}}-client-ca
+      drpcli plugins runaction certs deleteroot certs/root {{.Param "etcd/name"}}-server-ca
+      drpcli plugins runaction certs deleteroot certs/root {{.Param "etcd/name"}}-peer-ca
     else
       echo "  No CA root detected - no reset required"
     fi
@@ -103,24 +90,9 @@ Templates:
       echo "==========================================================================="
       echo "drpcli plugins runaction certs deleteroot certs/root {{.Param "consul/name"}}-ca"            
       echo "==========================================================================="
-      echo "Try to add unsafe/rs-username with value: <your-non-default-username>, and unsafe/rs-password with value: <your-non-default-password>, on your profile and re-run the krib-hard-reset-cluster workflow"
       
       sleep 1
-      {{if .ParamExists "unsafe/rs-username"}}
-        USERNAME="{{.Param "unsafe/rs-username"}}"
-      {{else}}
-        USERNAME="rocketskates"
-      {{end}}          
-      {{if .ParamExists "unsafe/rs-password"}}
-        PASSWORD="{{.Param "unsafe/rs-password"}}"
-      {{else}}
-        PASSWORD="r0cketsk8ts"
-      {{end}}
-
-      HOLD_TOKEN=$RS_TOKEN
-      unset RS_TOKEN
-      drpcli -U "$USERNAME" -P "$PASSWORD" plugins runaction certs deleteroot certs/root {{.Param "consul/name"}}-ca            
-      export RS_TOKEN=$HOLD_TOKEN
+      drpcli plugins runaction certs deleteroot certs/root {{.Param "consul/name"}}-ca            
     else
       echo "  No CA root detected - no reset required"
     fi
@@ -168,24 +140,9 @@ Templates:
       echo "==========================================================================="
       echo "drpcli plugins runaction certs deleteroot certs/root {{.Param "vault/name"}}-ca"            
       echo "==========================================================================="
-      echo "Try to add unsafe/rs-username with value: <your-non-default-username>, and unsafe/rs-password with value: <your-non-default-password>, on your profile and re-run the krib-hard-reset-cluster workflow"
       
       sleep 1
-      {{if .ParamExists "unsafe/rs-username"}}
-        USERNAME="{{.Param "unsafe/rs-username"}}"
-      {{else}}
-        USERNAME="rocketskates"
-      {{end}}          
-      {{if .ParamExists "unsafe/rs-password"}}
-        PASSWORD="{{.Param "unsafe/rs-password"}}"
-      {{else}}
-        PASSWORD="r0cketsk8ts"
-      {{end}}
-
-      HOLD_TOKEN=$RS_TOKEN
-      unset RS_TOKEN
-      drpcli -U "$USERNAME" -P "$PASSWORD" plugins runaction certs deleteroot certs/root {{.Param "vault/name"}}-ca            
-      export RS_TOKEN=$HOLD_TOKEN
+      drpcli plugins runaction certs deleteroot certs/root {{.Param "vault/name"}}-ca            
     else
       echo "  No CA root detected - no reset required"
     fi

--- a/krib/tasks/krib-dev-reset.yaml
+++ b/krib/tasks/krib-dev-reset.yaml
@@ -3,13 +3,15 @@ Description: "DEV: Reset Profile values between Test Runs"
 Name: "krib-dev-reset"
 Documentation: |
   Clears Created Params: krib/*, etcd/*
+ExtraClaims:
+  - scope: "plugins"
+    action: "*"
+    specific: "*"
 RequiredParams:
   - krib/cluster-profile
   - etcd/cluster-profile
 OptionalParams:
   - krib/cluster-is-production
-  - unsafe/rs-username
-  - unsafe/rs-password
 Templates:
 - Contents: |-
     #!/bin/bash
@@ -45,25 +47,11 @@ Templates:
       echo "drpcli plugins runaction certs deleteroot certs/root {{.Param "etcd/name"}}-server-ca"
       echo "drpcli plugins runaction certs deleteroot certs/root {{.Param "etcd/name"}}-peer-ca"
       echo "==========================================================================="
-      echo "Try to add unsafe/rs-username with value: <your-non-default-username>, and unsafe/rs-password with value: <your-non-default-password>, on your profile and re-run the krib-reset-cluster workflow"
 
       sleep 1
-      {{if .ParamExists "unsafe/rs-username"}}
-        USERNAME="{{.Param "unsafe/rs-username"}}"
-      {{else}}
-        USERNAME="rocketskates"
-      {{end}}          
-      {{if .ParamExists "unsafe/rs-password"}}
-        PASSWORD="{{.Param "unsafe/rs-password"}}"
-      {{else}}
-        PASSWORD="r0cketsk8ts"
-      {{end}}
-      HOLD_TOKEN=$RS_TOKEN
-      unset RS_TOKEN
-      drpcli -U "$USERNAME" -P "$PASSWORD" plugins runaction certs deleteroot certs/root {{.Param "etcd/name"}}-client-ca
-      drpcli -U "$USERNAME" -P "$PASSWORD" plugins runaction certs deleteroot certs/root {{.Param "etcd/name"}}-server-ca
-      drpcli -U "$USERNAME" -P "$PASSWORD" plugins runaction certs deleteroot certs/root {{.Param "etcd/name"}}-peer-ca
-      export RS_TOKEN=$HOLD_TOKEN
+      drpcli plugins runaction certs deleteroot certs/root {{.Param "etcd/name"}}-client-ca
+      drpcli plugins runaction certs deleteroot certs/root {{.Param "etcd/name"}}-server-ca
+      drpcli plugins runaction certs deleteroot certs/root {{.Param "etcd/name"}}-peer-ca
     else
       echo "  No CA root detected - no reset required"
     fi
@@ -126,24 +114,8 @@ Templates:
       echo "==========================================================================="
       echo "drpcli plugins runaction certs deleteroot certs/root {{.Param "consul/name"}}-ca"
       echo "==========================================================================="
-      echo "Try to add unsafe/rs-username with value: <your-non-default-username>, and unsafe/rs-password with value: <your-non-default-password>, on your profile and re-run the krib-reset-cluster workflow"
-
       sleep 1
-      {{if .ParamExists "unsafe/rs-username"}}
-        USERNAME="{{.Param "unsafe/rs-username"}}"
-      {{else}}
-        USERNAME="rocketskates"
-      {{end}}          
-      {{if .ParamExists "unsafe/rs-password"}}
-        PASSWORD="{{.Param "unsafe/rs-password"}}"
-      {{else}}
-        PASSWORD="r0cketsk8ts"
-      {{end}}
-
-      HOLD_TOKEN=$RS_TOKEN
-      unset RS_TOKEN
-      drpcli -U "$USERNAME" -P "$PASSWORD" plugins runaction certs deleteroot certs/root {{.Param "consul/name"}}-ca
-      export RS_TOKEN=$HOLD_TOKEN
+      drpcli plugins runaction certs deleteroot certs/root {{.Param "consul/name"}}-ca
     else
       echo "  No CA root detected - no reset required"
     fi
@@ -209,23 +181,9 @@ Templates:
       echo "==========================================================================="
       echo "drpcli plugins runaction certs deleteroot certs/root {{.Param "vault/name"}}-ca"
       echo "==========================================================================="
-      echo "Try to add unsafe/rs-username with value: <your-non-default-username>, and unsafe/rs-password with value: <your-non-default-password>, on your profile and re-run the krib-reset-cluster workflow"
 
       sleep 1
-      {{if .ParamExists "unsafe/rs-username"}}
-        USERNAME="{{.Param "unsafe/rs-username"}}"
-      {{else}}
-        USERNAME="rocketskates"
-      {{end}}          
-      {{if .ParamExists "unsafe/rs-password"}}
-        PASSWORD="{{.Param "unsafe/rs-password"}}"
-      {{else}}
-        PASSWORD="r0cketsk8ts"
-      {{end}}
-      HOLD_TOKEN=$RS_TOKEN
-      unset RS_TOKEN
-      drpcli -U "$USERNAME" -P "$PASSWORD" plugins runaction certs deleteroot certs/root {{.Param "vault/name"}}-ca
-      export RS_TOKEN=$HOLD_TOKEN
+      drpcli plugins runaction certs deleteroot certs/root {{.Param "vault/name"}}-ca
     else
       echo "  No CA root detected - no reset required"
     fi


### PR DESCRIPTION
finally removed unsafe reset hack and moved to use correct ExtraClaims approach.
old method would NOT work because of the RS_PROXY behavior of drpcli in v4 versions.

Change will require 4x DRP w/ ExtraClaims support (which is added as a required feature in the meta data)