### PR TITLE
Preliminary uefi secure boot support

### DIFF
--- a/content/._RequiredFeatures.meta
+++ b/content/._RequiredFeatures.meta
@@ -1,1 +1,1 @@
-sane-exit-codes, job-exit-states, fsm-runner, workflows, default-workflow, http-range-header, roles, tenants, sprig, multiarch
+sane-exit-codes, job-exit-states, fsm-runner, workflows, default-workflow, http-range-header, roles, tenants, sprig, multiarch, overridable-bootloaders

--- a/content/bootenvs/centos-7.6.1810.yml
+++ b/content/bootenvs/centos-7.6.1810.yml
@@ -9,6 +9,8 @@ Meta:
   icon: "linux"
   color: "blue"
   title: "Digital Rebar Community Content"
+Loaders:
+  amd64-uefi: EFI/BOOT/BOOTX64.EFI
 OS:
   Family: "redhat"
   Name: "centos-7.6.1810"
@@ -74,6 +76,9 @@ Templates:
   - ID: "default-grub.tmpl"
     Name: "grub-mac"
     Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'
+  - Name: grub-secure
+    Path: '{{.Env.PathForArch "tftp" "" "amd64"}}/EFI/BOOT/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
+    ID: grub-secure.tmpl
   - ID: "select-kickseed.tmpl"
     Name: "compute.ks"
     Path: "{{.Machine.Path}}/compute.ks"

--- a/content/bootenvs/centos-7.7.1908.yml
+++ b/content/bootenvs/centos-7.7.1908.yml
@@ -9,6 +9,8 @@ Meta:
   icon: "linux"
   color: "blue"
   title: "Digital Rebar Community Content"
+Loaders:
+  amd64-uefi: EFI/BOOT/BOOTX64.EFI
 OS:
   Family: "redhat"
   Name: "centos-7.7.1908"
@@ -74,6 +76,9 @@ Templates:
   - ID: "default-grub.tmpl"
     Name: "grub-mac"
     Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'
+  - Name: grub-secure
+    Path: '{{.Env.PathForArch "tftp" "" "amd64"}}/EFI/BOOT/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
+    ID: grub-secure.tmpl
   - ID: "select-kickseed.tmpl"
     Name: "compute.ks"
     Path: "{{.Machine.Path}}/compute.ks"

--- a/content/bootenvs/centos-7.yml
+++ b/content/bootenvs/centos-7.yml
@@ -9,6 +9,8 @@ Meta:
   icon: "linux"
   color: "blue"
   title: "Digital Rebar Community Content"
+Loaders:
+  amd64-uefi: EFI/BOOT/BOOTX64.EFI
 OS:
   Family: "redhat"
   Name: "centos-7"
@@ -74,6 +76,9 @@ Templates:
   - ID: "default-grub.tmpl"
     Name: "grub-mac"
     Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'
+  - Name: grub-secure
+    Path: '{{.Env.PathForArch "tftp" "" "amd64"}}/EFI/BOOT/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
+    ID: grub-secure.tmpl
   - ID: "select-kickseed.tmpl"
     Name: "compute.ks"
     Path: "{{.Machine.Path}}/compute.ks"

--- a/content/bootenvs/discovery.yml
+++ b/content/bootenvs/discovery.yml
@@ -16,16 +16,18 @@ Meta:
   color: "blue"
   title: "Digital Rebar Community Content"
 OnlyUnknown: true
+Loaders:
+  amd64-uefi: e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/shimx64.efi
 OS:
   Family: "redhat"
   Name: "sledgehammer"
   SupportedArchitectures:
     amd64:
-      IsoFile: "sledgehammer-c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1.amd64.tar"
-      IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1/sledgehammer-c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1.amd64.tar"
-      Kernel: "c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1/vmlinuz0"
+      IsoFile: "sledgehammer-e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da.amd64.tar"
+      IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/sledgehammer-e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da.amd64.tar"
+      Kernel: "e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/vmlinuz0"
       Initrds:
-        - "c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1/stage1.img"
+        - "e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/stage1.img"
       BootParams: >-
         rootflags=loop
         root=live:/sledgehammer.iso
@@ -228,6 +230,9 @@ Templates:
         source (tftp)/grub/${grub_cpu}.cfg
       fi
       boot
+  - Name: "grub-secure"
+    Path: "sledgehammer/e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/grub.cfg"
+    ID: grub-secure.tmpl
   - Name: "grub-i386"
     Path: "grub/i386.cfg"
     Contents: |

--- a/content/bootenvs/sledgehammer.yml
+++ b/content/bootenvs/sledgehammer.yml
@@ -16,16 +16,18 @@ Meta:
   icon: "microchip"
   color: "green"
   title: "Digital Rebar Community Content"
+Loaders:
+  amd64-uefi: e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/shimx64.efi
 OS:
   Family: "redhat"
   Name: "sledgehammer"
   SupportedArchitectures:
     amd64:
-      IsoFile: "sledgehammer-c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1.amd64.tar"
-      IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1/sledgehammer-c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1.amd64.tar"
-      Kernel: "c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1/vmlinuz0"
+      IsoFile: "sledgehammer-e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da.amd64.tar"
+      IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/sledgehammer-e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da.amd64.tar"
+      Kernel: "e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/vmlinuz0"
       Initrds:
-        - "c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1/stage1.img"
+        - "e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/stage1.img"
       BootParams: >-
         rootflags=loop
         root=live:/sledgehammer.iso

--- a/content/bootenvs/ubuntu-16.04.yml
+++ b/content/bootenvs/ubuntu-16.04.yml
@@ -72,3 +72,12 @@ Templates:
   - ID: "net-post-install.sh.tmpl"
     Name: "net-post-install.sh"
     Path: "{{.Machine.Path}}/post-install.sh"
+  - Name: grub-secure
+    Path: '{{.Env.PathForArch "tftp" "" "amd64"}}/EFI/BOOT/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
+    ID: grub-secure.tmpl
+  - ID: "default-grub.tmpl"
+    Name: "grub"
+    Path: "grub/{{.Machine.Address}}.cfg"
+  - ID: "default-grub.tmpl"
+    Name: "grub-mac"
+    Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'

--- a/content/bootenvs/ubuntu-18.04.yml
+++ b/content/bootenvs/ubuntu-18.04.yml
@@ -104,3 +104,12 @@ Templates:
   - ID: "net-post-install.sh.tmpl"
     Name: "net-post-install.sh"
     Path: "{{.Machine.Path}}/post-install.sh"
+  - Name: grub-secure
+    Path: '{{.Env.PathForArch "tftp" "" "amd64"}}/EFI/BOOT/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
+    ID: grub-secure.tmpl
+  - ID: "default-grub.tmpl"
+    Name: "grub"
+    Path: "grub/{{.Machine.Address}}.cfg"
+  - ID: "default-grub.tmpl"
+    Name: "grub-mac"
+    Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'

--- a/content/templates/grub-secure.tmpl
+++ b/content/templates/grub-secure.tmpl
@@ -1,0 +1,1 @@
+source (tftp)/grub/grub.cfg

--- a/sledgehammer-builder/bootenvs/build-sledgehammer.yaml
+++ b/sledgehammer-builder/bootenvs/build-sledgehammer.yaml
@@ -123,6 +123,8 @@ Templates:
       man-db
       mdadm
       {{if (eq .Machine.Arch "amd64")}}
+      grub2-efi-x64
+      shim-x64
       microcode_ctl
       {{end}}
       mktemp

--- a/sledgehammer-builder/tasks/sledgehammer-stage-bits.yaml
+++ b/sledgehammer-builder/tasks/sledgehammer-stage-bits.yaml
@@ -617,8 +617,11 @@ Templates:
       echo "Making module/firmware archive"
       find lib |sort |cpio -o -R 0:0 --format=newc |xz -T0 -c >initrd/lib.cpio.xz
       rm -rf lib
-      echo "Staging kernel and busybox for stage1 initramfs"
+      echo "Staging bootloader, kernel and busybox for stage1 initramfs"
       cp /boot/$KERNEL /IMAGE/vmlinuz0
+      cp /boot/efi/EFI/centos/grubx64.efi /IMAGE/grubx64.efi
+      cp /boot/efi/EFI/centos/shimx64.efi /IMAGE/shimx64.efi
+      rpm -e grub2-efi-x64 shim-x64
       cd /IMAGE/initrd
       mkdir -p dev proc sys bin lib etc usr/share/udhcpc tmp newinitramfs
       curl -fgL -o bin/busybox http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/busybox-1.29.3.${ARCH}
@@ -667,9 +670,9 @@ Templates:
       # Tar it all up
       tarname=sledgehammer-$signature.{{.Machine.Arch}}.tar
       echo "Creating Sledgehammer $signature archive"
-      sha1sum vmlinuz0 stage1.img root.squashfs >sha1sums
+      sha1sum vmlinuz0 stage1.img root.squashfs grubx64.efi shimx64.efi >sha1sums
       mkdir $signature
-      mv sha1sums vmlinuz0 stage1.img root.squashfs $signature
+      mv sha1sums vmlinuz0 stage1.img root.squashfs grubx64.efi shimx64.efi $signature
       tar cf $tarname $signature
       # Push back to dr-provision
       unset RS_TOKEN

--- a/sledgehammer-builder/tasks/sledgehammer-stage-bits.yaml
+++ b/sledgehammer-builder/tasks/sledgehammer-stage-bits.yaml
@@ -675,7 +675,6 @@ Templates:
       mv sha1sums vmlinuz0 stage1.img root.squashfs grubx64.efi shimx64.efi $signature
       tar cf $tarname $signature
       # Push back to dr-provision
-      unset RS_TOKEN
       echo "Uploading Sledgehammer to dr-provision"
       drpcli isos upload $tarname as $tarname
       echo "$tarname uploaded to isos"


### PR DESCRIPTION
WIP -- do not pull until the corresponding PR has been merged into dr-provision.

This pull request updates Sledgehammer and the CentOS install bootenvs to be compatible with UEFI Secure Boot.  Making Ubuntu and Debian compatible will require further effort, as their install ISOs do not contain signed bootloaders that can netboot.