### PR TITLE
Creates a new setup task for chef-bootstrap

### DIFF
--- a/chef-bootstrap/content/stages/chef-bootstrap.yaml
+++ b/chef-bootstrap/content/stages/chef-bootstrap.yaml
@@ -7,6 +7,7 @@ Reboot: false
 RunnerWait: true
 Tasks:
   - "chef-bootstrap-configure"
+  - "chef-bootstrap-setup"
   - "chef-bootstrap-install"
   - "chef-bootstrap-join"
 Meta:

--- a/chef-bootstrap/content/tasks/chef-bootstrap-configure.yaml
+++ b/chef-bootstrap/content/tasks/chef-bootstrap-configure.yaml
@@ -1,37 +1,16 @@
 ---
 Name: "chef-bootstrap-configure"
-Description: "A task to prepare for chef-client installation"
+Description: "A task to prepare for chef-bootstrap setup"
 Documentation: |
-  Takes care of configuring client.rb file, setting up temporary validation/admin credentials and other
-  optional settings, like encrypted data bag secret, or first run user-defined json.
-RequiredParams:
-  - "chef-bootstrap/organization"
-  - "chef-bootstrap/user"
-  - "chef-bootstrap/user_key"
+  Takes care of making sure that "chef-bootstrap/node_name" param is set and Chef directories exist.
+
+  Using a separate task because we can't render the now chef-bootstrap-setup task contents before
+  having "chef-bootstrap/node_name" defined.
 OptionalParams:
   - "chef-bootstrap/node_name"
-  - "chef-bootstrap/environment"
-  - "chef-bootstrap/chef_server"
-  - "chef-bootstrap/policy_name"
-  - "chef-bootstrap/policy_group"
-  - "chef-bootstrap/first_boot"
-  - "chef-bootstrap/named_runlist"
-  - "chef-bootstrap.encrypted_data_bag_secret"
 Templates:
 - ID: "chef-bootstrap-configure.sh.tmpl"
   Name: "Minor preparations"
-- ID: "chef-bootstrap.etc.user.pem.tmpl"
-  Name: "Chef admin user key"
-  Path: '/etc/chef/{{.Param "chef-bootstrap/user"}}.pem'
-- ID: "chef-bootstrap.etc.client.rb.tmpl"
-  Name: "Chef client configuration"
-  Path: "/etc/chef/client.rb"
-- ID: "chef-bootstrap.etc.encrypted.data.bag.secret.tmpl"
-  Name: "Chef Encrypted Data Bag secret"
-  Path: "/etc/chef/encrypted_data_bag_secret"
-- ID: "chef-bootstrap.etc.first-boot.json.tmpl"
-  Name: "First boot attributes and run_list"
-  Path: "/etc/chef/first-boot.json"
 Meta:
   color: "orange"
   icon: "server"

--- a/chef-bootstrap/content/tasks/chef-bootstrap-setup.yaml
+++ b/chef-bootstrap/content/tasks/chef-bootstrap-setup.yaml
@@ -1,0 +1,36 @@
+---
+Name: "chef-bootstrap-setup"
+Description: "A task to prepare for chef-client installation"
+Documentation: |
+  Takes care of configuring client.rb file, setting up temporary validation/admin credentials and other
+  optional settings, like encrypted data bag secret, or first run user-defined json.
+RequiredParams:
+  - "chef-bootstrap/organization"
+  - "chef-bootstrap/user"
+  - "chef-bootstrap/user_key"
+  - "chef-bootstrap/node_name"
+OptionalParams:
+  - "chef-bootstrap/environment"
+  - "chef-bootstrap/chef_server"
+  - "chef-bootstrap/policy_name"
+  - "chef-bootstrap/policy_group"
+  - "chef-bootstrap/first_boot"
+  - "chef-bootstrap/named_runlist"
+  - "chef-bootstrap.encrypted_data_bag_secret"
+Templates:
+- ID: "chef-bootstrap.etc.user.pem.tmpl"
+  Name: "Chef admin user key"
+  Path: '/etc/chef/{{.Param "chef-bootstrap/user"}}.pem'
+- ID: "chef-bootstrap.etc.client.rb.tmpl"
+  Name: "Chef client configuration"
+  Path: "/etc/chef/client.rb"
+- ID: "chef-bootstrap.etc.encrypted.data.bag.secret.tmpl"
+  Name: "Chef Encrypted Data Bag secret"
+  Path: "/etc/chef/encrypted_data_bag_secret"
+- ID: "chef-bootstrap.etc.first-boot.json.tmpl"
+  Name: "First boot attributes and run_list"
+  Path: "/etc/chef/first-boot.json"
+Meta:
+  color: "orange"
+  icon: "server"
+  title: "Digital Rebar Community Content"


### PR DESCRIPTION
I just noticed that all task templates are rendered at start which
 means we can't have a machine reaching the previously defined
 chef-bootstrap-configure task without "chef-bootstrap/node_name" being
 defined.
Because of the that we need to have a separate task which takes care of
 defining that, and in the future other, parameter(s).

Signed-off-by: Manuel Torrinha <manuel.torrinha@tecnico.ulisboa.pt>