### PR TITLE
Add Chef version and channel specification

### DIFF
--- a/chef-bootstrap/content/params/chef-bootstrap.chef_channel.yaml
+++ b/chef-bootstrap/content/params/chef-bootstrap.chef_channel.yaml
@@ -1,0 +1,13 @@
+---
+Name: "chef-bootstrap/chef_channel"
+Description: "Specify Chef infra channel"
+Documentation: |
+  The source channel from where to get Chef Software, defaults to the stable channel
+
+Schema:
+  type: "string"
+  default: "stable"
+Meta:
+  color: "blue"
+  icon: "tag"
+  title: "Digital Rebar Community Content"

--- a/chef-bootstrap/content/params/chef-bootstrap.chef_version.yaml
+++ b/chef-bootstrap/content/params/chef-bootstrap.chef_version.yaml
@@ -1,0 +1,13 @@
+---
+Name: "chef-bootstrap/chef_version"
+Description: "Specify Chef infra version"
+Documentation: |
+  The version of the Chef Software to install, defaults to the latest available
+
+Schema:
+  type: "string"
+  default: "latest"
+Meta:
+  color: "blue"
+  icon: "tag"
+  title: "Digital Rebar Community Content"

--- a/chef-bootstrap/content/tasks/chef-bootstrap-install.yaml
+++ b/chef-bootstrap/content/tasks/chef-bootstrap-install.yaml
@@ -5,6 +5,8 @@ Documentation: |
   Takes care of installing the chef-client software.
 RequiredParams:
   - "chef-bootstrap/chef_install_source"
+  - "chef-bootstrap/chef_channel"
+  - "chef-bootstrap/chef_version"
 Templates:
 - ID: "chef-bootstrap-install.sh.tmpl"
   Name: "Chef install"

--- a/chef-bootstrap/content/templates/chef-bootstrap-install.sh.tmpl
+++ b/chef-bootstrap/content/templates/chef-bootstrap-install.sh.tmpl
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
+
+# An error exit function
+error_exit() {
+  echo "$1" 1>&2
+  exit 1
+}
+
 # Installs chef-client software
 cd /etc/chef
 
-# this isn't the most pretty installation method, should revisit this
-curl -L {{.Param "chef-bootstrap/chef_install_source"}} | bash || error_exit 'could not install chef'
+# should we support more parameters?
+curl -L {{.Param "chef-bootstrap/chef_install_source"}} | bash -s -- -c {{.Param "chef-bootstrap/chef_channel"}} -v {{.Param "chef-bootstrap/chef_version"}}|| error_exit 'could not install chef'
 
 exit 0


### PR DESCRIPTION
Adds two new parameters:

  - "chef-bootstrap/chef_channel"
  - "chef-bootstrap/chef_version"

"chef-bootstrap/chef_channel" can be usually one of

  - "stable"
  - "current"

"chef-bootstrap/chef_version" is the Chef version you want to install
 in the semver form `x.y.z`, it supports partial versioning, i.e:

   - if you want the highest available 14 version you can just specify
     as "14"
   - if you want the highest available 14.8 version you can specify as
     "14.8"

Also adds a missing error_exit function in the install template

Signed-off-by: Manuel Torrinha <manuel.torrinha@tecnico.ulisboa.pt>