### PR TITLE
fix(content-dockerfile): download cli 

### DIFF
--- a/integrations/docker-context/ansible-dockerfile
+++ b/integrations/docker-context/ansible-dockerfile
@@ -28,8 +28,12 @@ RUN pip3 install --no-cache-dir --upgrade yq
 RUN pip3 install --no-cache-dir --upgrade mitogen boto3
 # Linode
 RUN pip3 install --no-cache-dir --upgrade linode-api4
-COPY drpcli /usr/bin/drpcli
-RUN chmod 755 /usr/bin/drpcli
-RUN ln -s /usr/bin/drpcli /usr/bin/jq
-RUN ln -s /usr/bin/drpcli /usr/bin/drpjq
+RUN curl -o drpcli420 https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.2.0/amd64/linux/drpcli && \
+    chmod 755 drpcli420 && \
+    ./drpcli420 catalog item download drpcli to /usr/bin/drpcli && \
+    chmod 755 /usr/bin/drpcli && \
+    rm drpcli420 && \
+    ln -s /usr/bin/drpcli /usr/bin/jq && \
+    ln -s /usr/bin/drpcli /usr/bin/drpjq && \
+    echo "Installed DRPCLI $(drpcli version)"
 ENTRYPOINT /usr/bin/drpcli machines processjobs

--- a/integrations/docker-context/runner-dockerfile
+++ b/integrations/docker-context/runner-dockerfile
@@ -1,7 +1,11 @@
 FROM alpine:latest
 RUN apk --no-cache add bash curl
-COPY drpcli /usr/bin/drpcli
-RUN chmod 755 /usr/bin/drpcli
-RUN ln -s /usr/bin/drpcli /usr/bin/jq
-RUN ln -s /usr/bin/drpcli /usr/bin/drpjq
+RUN curl -o drpcli420 https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.2.0/amd64/linux/drpcli && \
+	chmod 755 drpcli420 && \
+	./drpcli420 catalog item download drpcli to /usr/bin/drpcli && \
+	chmod 755 /usr/bin/drpcli && \
+	rm drpcli420 && \
+    ln -s /usr/bin/drpcli /usr/bin/jq && \
+    ln -s /usr/bin/drpcli /usr/bin/drpjq && \
+    echo "Installed DRPCLI $(drpcli version)"
 ENTRYPOINT /usr/bin/drpcli machines processjobs

--- a/integrations/docker-context/terraform-dockerfile
+++ b/integrations/docker-context/terraform-dockerfile
@@ -1,7 +1,11 @@
 FROM hashicorp/terraform:light
 RUN apk --no-cache add bash
-COPY drpcli /usr/bin/drpcli
-RUN chmod 755 /usr/bin/drpcli
-RUN ln -s /usr/bin/drpcli /usr/bin/drp
-RUN ln -s /usr/bin/drpcli /usr/bin/drpjq
+RUN curl -o drpcli420 https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.2.0/amd64/linux/drpcli && \
+	chmod 755 drpcli420 && \
+	./drpcli420 catalog item download drpcli to /usr/bin/drpcli && \
+	chmod 755 /usr/bin/drpcli && \
+	rm drpcli420 && \
+    ln -s /usr/bin/drpcli /usr/bin/jq && \
+    ln -s /usr/bin/drpcli /usr/bin/drpjq && \
+    echo "Installed DRPCLI $(drpcli version)"
 ENTRYPOINT /usr/bin/drpcli machines processjobs


### PR DESCRIPTION
when building docker image, don't relying on local DRPCLI copy
this code fixes the docker build in a sustainable way
it downloads a known good DRPCLI
then uses that to download the latest stable DRPCLI

future enhancement possible to allow environmental variables