### PR TITLE
fix(flash): dell-flash-list treat rc 5 as ignore.

### DIFF
--- a/flash/tasks/dell-firmware-flash-list.yml
+++ b/flash/tasks/dell-firmware-flash-list.yml
@@ -72,7 +72,7 @@ Templates:
              failed=yes;;
           5)
              echo "Unquailifed update for $FILENAME"
-             failed=yes;;
+             echo "Either missing or not applicable - skipping";;
           6)
              echo "Reboot started!! for $FILENAME"
              want_reboot=yes;;

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,7 @@ github.com/digitalrebar/provision/v4 v4.2.0-beta3/go.mod h1:jgoqgcAQDK8oM6frAPVI
 github.com/digitalrebar/provision/v4 v4.2.0-beta7/go.mod h1:jgoqgcAQDK8oM6frAPVITyDeXciE2hqq1lucU1FsfhI=
 github.com/digitalrebar/provision/v4 v4.3.0-alpha2/go.mod h1:jgoqgcAQDK8oM6frAPVITyDeXciE2hqq1lucU1FsfhI=
 github.com/digitalrebar/provision/v4 v4.3.0-beta2/go.mod h1:tDXTyuCMmPbSWBDVYdEzcS2+NHCv4y8UFQ3uoe3ewVU=
+github.com/digitalrebar/provision/v4 v4.3.0-beta6/go.mod h1:tDXTyuCMmPbSWBDVYdEzcS2+NHCv4y8UFQ3uoe3ewVU=
 github.com/digitalrebar/tftp v2.1.0+incompatible h1:CzBcnsUaMtdLSOf3dSycinnfpajAAro7l8oo/ILyzOI=
 github.com/digitalrebar/tftp v2.1.0+incompatible/go.mod h1:k1tcsyQwHE72oTU5sfXPJdOCHFiZUt3M2BdYdHsfw6c=
 github.com/digitalrebar/tftp/v3 v3.0.0 h1:Ft2i3s2gCZ795rISs9vlcy3YSqfd6mtodxGoUcPSrhs=


### PR DESCRIPTION
By treating rc5 as ignore, we can have flash lists that work
on extra pieces of hardware that are missing in some models.