### PR TITLE
fix(flash): dell flash list - skip rc 5

### DIFF
--- a/flash/tasks/dell-firmware-flash-list.yml
+++ b/flash/tasks/dell-firmware-flash-list.yml
@@ -72,7 +72,7 @@ Templates:
              failed=yes;;
           5)
              echo "Unquailifed update for $FILENAME"
-             failed=yes;;
+             echo "Either missing or not applicable - skipping";;
           6)
              echo "Reboot started!! for $FILENAME"
              want_reboot=yes;;


### PR DESCRIPTION
This allows missing hardware to be skipped and the flash
list can cover more variants.