### PR TITLE
fix(flash): mc info can return before usb available on lenovo gear.

### DIFF
--- a/flash/tasks/lenovo-firmware-flash-list.yml
+++ b/flash/tasks/lenovo-firmware-flash-list.yml
@@ -123,12 +123,11 @@ Templates:
                 sleep 20
                 set +e
                 while true ; do
-                    ipmitool mc info && break
+                    ./attach-usb-lan.sh && /opt/OneCli/OneCli inventory getdevices && break
                     echo "Not up yet"
                     sleep 5
                 done
                 set -e
-                ./attach-usb-lan.sh
                 echo "BMC is back up"
             else
                 echo "Want to reboot system"


### PR DESCRIPTION
Use the usb attach script to see if it can be used to handle test of up