### PR TITLE
fix(flash): hpe setup chooser shoud not fail because of set -e

### DIFF
--- a/flash/tasks/hpe-firmware-flash-list.yml
+++ b/flash/tasks/hpe-firmware-flash-list.yml
@@ -53,6 +53,7 @@ Templates:
         {{ end }}
 
         # Check to see if RPM is already installed.
+        set +e
         RPMNAME=$(basename {{$elem.File}} | sed "s/.rpm//")
         if ! rpm -q ${RPMNAME} 2>/dev/null >/dev/null ; then
           rpm -ivh $FILENAME
@@ -62,6 +63,13 @@ Templates:
         if [[ "$SETUP" = "" ]] ; then
           SETUP=$(rpm -ql $RPMNAME | grep '/hpsetup$')
         fi
+        if [[ "$SETUP" = "" ]] ; then
+          echo "Failed to find a setup script!"
+          echo "Files in $RPMNAME"
+          rpm -ql $RPMNAME
+          exit 1
+        fi
+        set -e
         # One day make this an argument
         TPMARG=""
         if [[ "$RPMNAME" =~ ^firmware-system ]] ; then


### PR DESCRIPTION
This ignores set -e for choosing a setup script and then fails
when missing.