### PR TITLE
feat(whoami): Refactor discovery scripts to use whoami if present

### DIFF
--- a/content/bootenvs/discovery.yml
+++ b/content/bootenvs/discovery.yml
@@ -228,6 +228,9 @@ Templates:
   - Name: "grub-discovery"
     Path: "grub/discovery.cfg"
     ID: allarch-grub.tmpl
+  - Name: "common-bootstrap.sh"
+    Path: "machines/common-bootstrap.sh"
+    ID: discovery-common-bootstrap.sh.tmpl
   - Name: "join-up.sh"
     Path: "machines/join-up.sh"
     Contents: |
@@ -255,143 +258,31 @@ Templates:
       # CUMULUS-AUTOPROVISIONING
 
       export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-
-      # to be generic, we do NOT assume access to cloud provider APIs to determine things
-      get_macs() {
-          local maclist=""
-          local nic=""
-          for nic in /sys/class/net/*; do
-              [[ -f $nic/type && -f $nic/address && $(cat "$nic/type") == 1 ]] || continue
-              maclist="$maclist,\"$(cat "$nic/address")\""
-          done
-          printf '[%s]' "${maclist#,}"
-      }
-
-      PROVISIONER_WEB="{{.ProvisionerURL}}"
-      ARCH="$(uname -m)"
-      case $ARCH in
-          amd64|x86_64) ARCH=amd64;;
-          arm64|aarch64) ARCH=arm64;;
-          *)
-              echo "Unknown arch $ARCH"
-              exit 1;;
-      esac
-      # Perform minimal required bootstrapping for discovery
-      export RS_TOKEN="{{.GenerateToken}}"
-      export RS_ENDPOINT="{{.ApiURL}}"
-      mkdir -p /usr/local/bin
-      grep -q '/usr/local/bin' <<< "$PATH" || export PATH="$PATH:/usr/local/bin"
-      for tool in drpcli jq; do
-          which "$tool" &>/dev/null && continue
-          echo "Installing $tool in /usr/local/bin"
-          case $tool in
-              drpcli) curl -gsfLo "/usr/local/bin/$tool" "{{.ProvisionerURL}}/files/drpcli.$ARCH.linux";;
-              jq)     curl -gsfLo "/usr/local/bin/$tool" "{{.ProvisionerURL}}/files/jq";;
-          esac
-          chmod 755 "/usr/local/bin/$tool"
-      done
-      unset tool
-
       set -x
+      curl -o /tmp/discovery-common-bootstrap.sh \
+          '{{.ProvisionerURL}}/machines/common-bootstrap.sh'
 
-      # Check just in case we pxe booted.
-      host_re='rs\.uuid=([^ ]+)'
-      if [[ $(cat /proc/cmdline) =~ $host_re ]]; then
-        RS_UUID="${BASH_REMATCH[1]}"
-      fi
+      . /tmp/discovery-common-bootstrap.sh
 
-      # Check Hostname to find us
-      if [[ $RS_UUID == null || $RS_UUID == "" ]]; then
-        RS_UUID=$(drpcli machines list Name=$HOSTNAME | jq -r .[0].Uuid)
-        if [[ $RS_UUID == null || $RS_UUID == "" ]]; then
-          RS_UUID=$(drpcli machines show Name:$HOSTNAME | jq -r .Uuid)
-        fi
-      fi
-
-      # If no uuid, check to see if we have one stored from before
-      if [[ $RS_UUID == null || $RS_UUID == "" ]]; then
-        # See if we have already been created based on dropping uuid file
-        if [[ -f /etc/rs-uuid ]]; then
-            luuid="$(tail -n 1 /etc/rs-uuid)"
-            RS_UUID=$(drpcli machines list Uuid=$luuid | jq -r .[0].Uuid)
-            if [[ $RS_UUID == null || $RS_UUID == "" ]]; then
-              RS_UUID=$(drpcli machines show $luuid | jq -r .Uuid)
-            fi
-        fi
-      fi
-
-      # If we still don't have RS_UUID - check the IP address.
-      IP=""
-      BOOTDEV="eth0"
-      bootdev_ip4_re='inet ([0-9.]+)/([0-9]+)'
-      bootdev_ip6_re='inet6 ([0-9a-fA-F:.]+)/([0-9]+) scope global'
-      if [[ $(ip -4 -o addr show dev $BOOTDEV) =~ $bootdev_ip4_re ]]; then
-          IP="${BASH_REMATCH[1]}"
-      else
-          if [[ $(ip -6 -o addr show dev $BOOTDEV) =~ $bootdev_ip6_re ]]; then
-              IP="${BASH_REMATCH[1]}"
-          fi
-      fi
-      if [[ $RS_UUID == null || $RS_UUID == "" ]]; then
-        RS_UUID=$(drpcli machines list Address=$IP | jq -r .[0].Uuid)
-      fi
-
-      # If we still don't have a UUID, then create a machine
-      if [[ $RS_UUID == null || $RS_UUID == "" ]]; then
-        echo "Machine UUID file not found.  Adding $HOSTNAME..."
-
-        # Create a new node for us,
-        while ! JSON="$(drpcli machines create "{\"Name\": \"$HOSTNAME\",
-                                             \"Address\": \"$IP\",
-                                             \"Arch\": \"$ARCH\",
-                                             \"Meta\": {\"icon\":\"cloud\"},
-                                             \"HardwareAddrs\": $(get_macs)}")"; do
-            echo "We could not create a node for ourself, trying again."
-            sleep 5
-        done
-        RS_UUID="$(jq -r '.Uuid' <<< "$JSON")"
-        echo "${RS_UUID}" > /etc/rs-uuid
-        echo "Machine $HOSTNAME added with UUID $RS_UUID"
-      else
-        echo "Machine $HOSTNAME found in DRPCLI! Using $RS_UUID"
-        echo "${RS_UUID}" > /etc/rs-uuid
-      fi
-
-      {{template "profile.tmpl" .}}
-
-      echo "$PROVISIONER_WEB/machines/$RS_UUID/control.sh"
-      if ! curl -g -s -f -L -o /tmp/control.sh "$PROVISIONER_WEB/machines/$RS_UUID/control.sh" && \
-          grep -q '^exit 0$' /tmp/control.sh && \
-          head -1 /tmp/control.sh | grep -q '^#!/bin/bash'; then
-          echo "Could not load our control.sh!"
-          exit 1
-      fi
-      chmod 755 /tmp/control.sh
-
-      export RS_UUID BOOTDEV PROVISIONER_WEB MAC DOMAIN DNS_SERVERS HOSTNAME IP
-
-      echo "transfer from start-up to control script"
-
-      [[ -x /tmp/control.sh ]] && exec /tmp/control.sh
-
-      echo "Did not get control.sh from $PROVISIONER_WEB/machines/$RS_UUID/control.sh"
-      exit 1
+      find_by_whoami ||
+          find_by_saved_uuid ||
+          find_by_hwaddrs ||
+          find_by_kernel_cmdline ||
+          find_by_hostname ||
+          create_machine ||
+          cannot_find_or_create
+      switch_to_control
   - Name: "start-up.sh"
     Path: "machines/start-up.sh"
     Contents: |
       #!/bin/bash
-      export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
       set +x
+      export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
 
-      get_macs() {
-          local maclist=""
-          local nic=""
-          for nic in /sys/class/net/*; do
-              [[ -f $nic/type && -f $nic/address && $(cat "$nic/type") == 1 ]] || continue
-              maclist="$maclist,\"$(cat "$nic/address")\""
-          done
-          printf '[%s]' "${maclist#,}"
-      }
+      curl -o /tmp/discovery-common-bootstrap.sh \
+          '{{.ProvisionerURL}}/machines/common-bootstrap.sh'
+
+      . /tmp/discovery-common-bootstrap.sh
 
       if [[ ! -f /etc/systemd/network/20-bootif.network ]]; then
           get_param() {
@@ -455,29 +346,6 @@ Templates:
               fi
           fi
       fi
-      ARCH="$(uname -m)"
-      case $ARCH in
-          amd64|x86_64) ARCH=amd64;;
-          arm64|aarch64) ARCH=arm64;;
-          *)
-              echo "Unknown arch $ARCH"
-              exit 1;;
-      esac
-      # Perform minimal required bootstrapping for discovery
-      export RS_TOKEN="{{.GenerateToken}}"
-      export RS_ENDPOINT="{{.ApiURL}}"
-      mkdir -p /usr/local/bin
-      grep -q '/usr/local/bin' <<< "$PATH" || export PATH="$PATH:/usr/local/bin"
-      for tool in drpcli jq; do
-          which "$tool" &>/dev/null && continue
-          echo "Installing $tool in /usr/local/bin"
-          case $tool in
-              drpcli) curl -gsfLo "/usr/local/bin/$tool" "{{.ProvisionerURL}}/files/drpcli.$ARCH.linux";;
-              jq)     curl -gsfLo "/usr/local/bin/$tool" "{{.ProvisionerURL}}/files/jq";;
-          esac
-          chmod 755 "/usr/local/bin/$tool"
-      done
-      unset tool
 
       IP=""
       bootdev_ip4_re='inet ([0-9.]+)/([0-9]+)'
@@ -490,54 +358,24 @@ Templates:
           fi
       fi
       # See if we have already been created.
-      if [[ $(cat /proc/cmdline) =~ $host_re ]]; then
-          RS_UUID="${BASH_REMATCH[1]}"
-          json="$(drpcli machines show "$RS_UUID")"
-          # If we did not get a hostname from DHCP, get it from DigitalRebar Provision.
-          if [[ ! $HOSTNAME ]]; then
-              HOSTNAME="$(jq -r '.Name' <<< "$json")"
-          fi
-      else
-          # If we did not get a hostname from DHCP, generate one for ourselves.
-          [[ $HOSTNAME ]] || HOSTNAME="d${MAC//:/-}.${DOMAIN}"
+      find_by_whoami ||
+          find_by_hwaddrs ||
+          find_by_kernel_cmdline ||
+          create_machine ||
+          cannot_find_or_create
 
-          # Create a new node for us,
-          while ! json="$(drpcli machines create "{\"Name\": \"$HOSTNAME\",
-                                               \"Address\": \"$IP\",
-                                               \"Arch\": \"$ARCH\",
-                                               \"HardwareAddrs\": $(get_macs)}")"; do
-              echo "We could not create a node for ourself, trying again."
-              sleep 5
-          done
-          RS_UUID="$(jq -r '.Uuid' <<< "$json")"
-
+      json="$(drpcli machines show "$RS_UUID")"
+      # If we did not get a hostname from DHCP, get it from DigitalRebar Provision.
+      if [[ ! $HOSTNAME ]]; then
+          HOSTNAME="$(jq -r '.Name' <<< "$json")"
       fi
-      echo "${RS_UUID}" > /etc/rs-uuid
-      # Set our hostname for everything else.
       if [ -f /etc/sysconfig/network ] ; then
           sed -i -e "s/HOSTNAME=.*/HOSTNAME=${HOSTNAME}/" /etc/sysconfig/network
       fi
       echo "${HOSTNAME#*.}" >/etc/domainname
       hostname "$HOSTNAME"
 
-      {{template "profile.tmpl" .}}
-
       # Force reliance on DNS
       echo '127.0.0.1 localhost' >/etc/hosts
-
-      if ! curl -g -s -f -L -o /tmp/control.sh "$PROVISIONER_WEB/machines/$RS_UUID/control.sh" && \
-          grep -q '^exit 0$' /tmp/control.sh && \
-          head -1 /tmp/control.sh | grep -q '^#!/bin/bash'; then
-          echo "Could not load our control.sh!"
-          exit 1
-      fi
-      chmod 755 /tmp/control.sh
-
-      export RS_UUID BOOTDEV PROVISIONER_WEB MAC DOMAIN DNS_SERVERS HOSTNAME IP
-
-      echo "transfer from start-up to control script"
-
-      [[ -x /tmp/control.sh ]] && exec /tmp/control.sh
-
-      echo "Did not get control.sh from $PROVISIONER_WEB/machines/$RS_UUID/control.sh"
-      exit 1
+      switch_to_control
+      # /tmp/control.sh

--- a/content/bootenvs/sledgehammer.yml
+++ b/content/bootenvs/sledgehammer.yml
@@ -225,6 +225,9 @@ Templates:
       # used below.  Reset the token to the longer machine token.
       export RS_TOKEN="{{.GenerateInfiniteToken}}"
 
+      drpcli machines set "$RS_UUID" param gohai-inventory to '{}' &>/dev/null
+      drpcli gohai | drpcli machines set "$RS_UUID" param gohai-inventory to - &>/dev/null
+
       # If we do not have hardware addresses set on the machine, set them now.
       get_macs() {
           local maclist=""
@@ -243,9 +246,6 @@ Templates:
       # The machine does not have hardware addresses set, so set them
       if [[ "$(jq '.HardwareAddrs | length' <<< "$json")" = 0 ]]; then
           drpcli machines update "$RS_UUID" "{\"HardwareAddrs\": $(get_macs)}" &>/dev/null
-      fi
-      if [[ $IP && "$(jq -r '.Address' <<< "$json")" != $IP ]]; then
-          drpcli machines update "$RS_UUID" "{\"Address\":\"$IP\"}" &>/dev/null
       fi
       unset get_macs json
 

--- a/content/stages/discover-no-gohai.yaml
+++ b/content/stages/discover-no-gohai.yaml
@@ -7,6 +7,7 @@ Documentation: |
   Pre gohai/skip Parameter, used to run discovery without gohai action.
 BootEnv: "sledgehammer"
 Tasks:
+  - set-machine-ip-in-sledgehammer
   - "ssh-access"
 Meta:
   deprecated: "25 June 2018"

--- a/content/stages/discover.yaml
+++ b/content/stages/discover.yaml
@@ -11,9 +11,9 @@ Documentation: |
   machine is not using sledgehammer then use `discover-nobootenv`.
 BootEnv: "sledgehammer"
 Tasks:
-  - "enforce-sledgehammer"
-  - "gohai"
-  - "ssh-access"
+  - enforce-sledgehammer
+  - set-machine-ip-in-sledgehammer
+  - ssh-access
 Meta:
   icon: "spinner"
   color: "purple"

--- a/content/tasks/set-machine-ip.yaml
+++ b/content/tasks/set-machine-ip.yaml
@@ -1,0 +1,21 @@
+---
+Name: set-machine-ip-in-sledgehammer
+ExtraClaims:
+  - scope: "machines"
+    action: "list, get, update"
+    specific: "*"
+Templates:
+  - Name: set-machine-ip
+    Contents: |
+      #!/usr/bin/env bash
+      # This logic replicates what our DHCP server does
+      # behind the scenes to make sure that machines do not
+      # have conflicting addresses.  This works because
+      # and Address of 0.0.0.0 is unset.
+      addr='{{.Machine.Address}}'
+      [[ $IP && $addr != $IP ]] || exit 0
+      while read other; do
+          drpcli machines update "$other" '{"Address": "0.0.0.0"}'
+      done < <(drpcli machines list Address=$IP |jq -r '.[] |.Uuid')
+      drpcli machines update "$RS_UUID" "{\"Address\":\"$IP\"}" &>/dev/null
+      

--- a/content/templates/discovery-common-bootstrap.sh.tmpl
+++ b/content/templates/discovery-common-bootstrap.sh.tmpl
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#
+# Common routines for either registering a machine into dr-provision,
+# or discovering that we already have a machine registration for
+# whatever machine we are running on.
+
+macs=()
+for nic in /sys/class/net/*; do
+    [[ -f $nic/type && -f $nic/address && $(cat "$nic/type") == 1 ]] || continue
+    macs+=($(cat "$nic/address"))
+done
+hwaddrs="$(printf '"%s",' "${macs[@]}")"
+hwaddrs="[${hawaddrs%,}]"
+maclist="$(printf '%s,' "${macs[@]}")"
+maclist="${maclist%,}"
+export PROVISIONER_WEB="{{.ProvisionerURL}}"
+export ARCH="$(uname -m)"
+case $ARCH in
+    amd64|x86_64) ARCH=amd64;;
+    arm64|aarch64) ARCH=arm64;;
+    *)
+        echo "Unknown arch $ARCH"
+        exit 1;;
+esac
+# Perform minimal required bootstrapping for discovery
+export RS_TOKEN="{{.GenerateToken}}"
+export RS_ENDPOINT="{{.ApiURL}}"
+mkdir -p /usr/local/bin
+grep -q '/usr/local/bin' <<< "$PATH" || export PATH="$PATH:/usr/local/bin"
+for tool in drpcli jq; do
+    which "$tool" &>/dev/null && continue
+    echo "Installing $tool in /usr/local/bin"
+    case $tool in
+        drpcli) curl -gsfLo "/usr/local/bin/$tool" "{{.ProvisionerURL}}/files/drpcli.$ARCH.linux";;
+        jq)     curl -gsfLo "/usr/local/bin/$tool" "{{.ProvisionerURL}}/files/jq";;
+    esac
+    chmod 755 "/usr/local/bin/$tool"
+done
+unset tool
+
+# If we did not get a hostname from DHCP, generate one for ourselves.
+[[ $HOSTNAME ]] || export HOSTNAME="d${MAC//:/-}.${DOMAIN}"
+
+
+switch_to_control() {
+    echo "${RS_UUID}" > /etc/rs-uuid
+    {{template "profile.tmpl" .}}
+
+    echo "$PROVISIONER_WEB/machines/$RS_UUID/control.sh"
+    if ! curl -g -s -f -L -o /tmp/control.sh "$PROVISIONER_WEB/machines/$RS_UUID/control.sh" && \
+            grep -q '^exit 0$' /tmp/control.sh && \
+            head -1 /tmp/control.sh | grep -q '^#!/bin/bash'; then
+        echo "Could not load our control.sh!"
+        exit 1
+    fi
+    chmod 755 /tmp/control.sh
+    export RS_UUID BOOTDEV PROVISIONER_WEB MAC DOMAIN DNS_SERVERS HOSTNAME IP
+    echo "transfer from start-up to control script"
+    [[ -x /tmp/control.sh ]] && exec /tmp/control.sh
+    echo "Did not get control.sh from $PROVISIONER_WEB/machines/$RS_UUID/control.sh"
+    exit 1
+}
+
+create_machine() {
+    # Create a new node for us,
+    while ! JSON="$(drpcli machines create "{\"Name\": \"$HOSTNAME\",
+                                             \"Arch\": \"$ARCH\",
+                                             \"Meta\": {\"icon\":\"cloud\"},
+                                             \"HardwareAddrs\": $hwaddrs}")"; do
+        echo "We could not create a node for ourself, trying again."
+        sleep 5
+    done
+    export RS_UUID="$(jq -r '.Uuid' <<< "$JSON")"
+}
+
+find_by_whoami() {
+    if ! resp="$(drpcli machines whoami)"; then
+        echo "Find by whoami not available"
+        return 1
+    fi
+    score="$(jq '.Result.Score' <<< "$resp")"
+    if [[ $score  && $score != null ]]; then
+        # The returned Result has a Score, so this machine already
+        # exists.
+        export RS_UUID="$(jq -r '.Result.Uuid' <<< "$resp")"
+        export RS_TOKEN="$(jq -r '.Result.Token' <<< "$resp")"
+        echo "Whoami says we are $RS_UUID"
+    else
+        echo "Whoami did not find machine"
+        return 1
+    fi
+}
+
+find_by_kernel_cmdline() {
+    local host_re='rs\.uuid=([^ ]+)'
+    if ! [[ $(cat /proc/cmdline) =~ $host_re ]]; then
+        echo "No kernel cmdline supplied RS_UUID"
+        return 1
+    fi
+    export RS_UUID="${BASH_REMATCH[1]}"
+    echo "Kernel cmdline supplied $RS_UUID"
+}
+
+find_by_hostname() {
+    export RS_UUID=$(drpcli machines show Name:$HOSTNAME | jq -r .Uuid)
+    if [[ !$RS_UUID || $RS_UUID = null ]]; then
+        echo "Unable to map $HOSTNAME back to a UUID"
+        unset RS_UUID
+        return 1
+    fi
+    echo "$HOSTNAME lookup found $RS_UUID"
+}
+
+find_by_saved_uuid() {
+    if ![[ -f /etc/rs-uuid ]]; then
+        echo "No saved UUID"
+        return 1
+    fi
+    luuid="$(tail -n 1 /etc/rs-uuid)"
+    export RS_UUID=$(drpcli machines show $luuid | jq -r .Uuid)
+    if [[ !$RS_UUID || $RS_UUID = null ]]; then
+        echo "Saved UUID does not map back to a machine"
+        unset RS_UUID
+        return 1
+    fi
+    echo "Using saved UUID $RS_UUID"
+}
+
+find_by_hwaddrs() {
+    local machines
+    if grep -q '"HardwareAddr"' < <(drpcli machines indexes); then
+        # The fast way
+        machines="$(drpcli machines list "HardwareAddr=$maclist" --slim 'Params,Meta')"
+        case $(jq 'length' <<< "$machines") in
+            0)  # A new machine needs to be created
+                echo "No machine matching mac list $maclist"
+                return 1;;
+            1)  # it'sa me, Machinio
+                export RS_UUID="$(jq -r '.[0].Uuid' <<< "$machines")"
+                echo "Found $RS_UUID via mac address lookup"
+                return 0;;
+            *)  # This will not end well no matter what we do.
+                echo "More than one machine present with our macaddresses ($maclist)"
+                echo "No way to create a non-conflicting machine for this system."
+                echo "Conflicting machines:"
+                jq -r '.[] |.Uuid' <<< "$machines"
+                exit 1;;
+            esac
+    fi
+    # The slow way
+    machines="$(drpcli machines list --slim 'Params,Meta')"
+    local -A toCheck
+    for tc in $(IFS=',' printf '%s ' "$maclist"); do
+        toCheck["$tc"]="$tc"
+    done
+    while read -rs machine; do
+        for hwaddr in $(jq -r '.HardwareAddrs | .[]' <<< "$machine"); do
+            [[ ${toCheck["$hwaddr"]} ]] || continue
+            if [[ $RS_UUID ]]; then
+                echo "More than one machine with HardwareAddr $hwaddr"
+                echo "Cannot safely create machine in an automated fashion"
+                exit 1
+            fi
+            export RS_UUID="$(jq -r '.Uuid' <<< "$machine")"
+            break
+        done
+    done
+    if ! [[ $RS_UUID ]]; then
+        echo "No machine found for $maclist"
+        return 1
+    fi
+    echo "Found $RS_UUID via mac address matching"
+}
+
+cannot_find_or_create() {
+    echo "Unable to find or create a machine record"
+    exit 1
+}

--- a/content/templates/reset-workflow.tmpl
+++ b/content/templates/reset-workflow.tmpl
@@ -7,9 +7,9 @@
 v=$(drpcli machines get "{{.Machine.UUID}}" param "start-over" --aggregate | jq -r .)
 if [[ "$v" == "false" ]] ; then
     # Reset the current task list and mark the machine runnable.
-    drpcli machines remove "{{.Machine.UUID}}" param "start-over" 2>/dev/null >/dev/null || true
+    drpcli machines remove "{{.Machine.UUID}}" param "start-over" || true
     drpcli machines update "{{.Machine.UUID}}" '{ "Runnable": true }'
 else
     # Reset the current task list and mark the machine runnable.
     drpcli machines update "{{.Machine.UUID}}" '{ "Runnable": true, "CurrentTask": -1 }'
-fi
+fi &>/dev/null

--- a/sledgehammer-builder/bootenvs/build-sledgehammer.yaml
+++ b/sledgehammer-builder/bootenvs/build-sledgehammer.yaml
@@ -1,6 +1,12 @@
 ---
 Name: "sledgehammer-install"
 Description: "Install bootenv for building Sledgehammer images"
+Documentation: |
+  This BootEnv is used as the basis for building Sledgehammer, our in-memory discovery
+  and inventory management environment.  This bootenv is reponsible for performing
+  a basic CentOS install on a sacrificial machine.  The tasks that run after the install
+  has finished are responsible for stripping out everything we do not need for Sledgehammer
+  to boot as an in-memory OS image and packaging everything up for distribution.
 OS:
   Family: "redhat"
   Name: "centos-7"

--- a/sledgehammer-builder/params/sledgehammer.extra-ifs.yaml
+++ b/sledgehammer-builder/params/sledgehammer.extra-ifs.yaml
@@ -2,7 +2,10 @@
 Name: "sledgehammer/extra-ifs"
 Description: "Extra interfaces to configure during sledgehammer builds"
 Documentation: |
-  Extra interfaces to configure during sledgehammer builds.
+  Extra interfaces to configure during sledgehammer builds.  This is only
+  required if you are building a Sledgehammer instance on a VM with nonstandard
+  networking, and it does not have anything to do with how Sledgehammer behaves
+  at runtime.
 
 Schema:
   type: "array"

--- a/sledgehammer-builder/stages/sledgehammer-build.yaml
+++ b/sledgehammer-builder/stages/sledgehammer-build.yaml
@@ -1,5 +1,12 @@
 ---
 Name: sledgehammer-build
+Description: Build a Sledgehammer image.
+Documentation: |
+  This stage is responsible for building a Sledgehammer image.  To use it,
+  set a machine to this Stage and reboot it.  dr-provision will then
+  install a trimmed-down version of CentOS on the machine, strip out
+  non -essential bits, then package the remainder up as a Sledgehammer
+  image that everyone will be able to use.
 BootEnv: sledgehammer-install
 Tasks:
   - sledgehammer-stage-bits

--- a/sledgehammer-builder/tasks/sledgehammer-stage-bits.yaml
+++ b/sledgehammer-builder/tasks/sledgehammer-stage-bits.yaml
@@ -1,6 +1,84 @@
 ---
 Name: sledgehammer-stage-bits
 Description: Stage Sledgehammer pieces needed for initial discovery and bootstrapping.
+Documentaion: |
+  This task is responsible for transforming the OS installed by the
+  sledgehammer-install bootenv into a Sledgehammer image.  It is
+  structured as a series of Templates that are put in place and a
+  couple that are executed to strip out unwanted bits and package up
+  the rest.  The Templates are as follows:
+
+  * sledgehammer-start-up.sh
+
+    This script is run as a systemd service once Sledgehammer has
+    started.  It is responsible for making sure the image was booted
+    with the necessary kernel parameters and then downloading and
+    executing the machine-independent startup script from
+    dr-provision.
+
+  * sledgehammer-motd
+
+    This sets the default login banner.
+
+  * sledgehammer-ssh-config
+
+    This sets the default sshd configuration.  We default to allowing
+    root logins only via key based authentication and allowing sftp.
+
+  * sledgehammer-service
+
+    This is the systemd unit file that is responsible for starting
+    sledgehammer-start-up.sh when Sledgehammer boots.  It waits until
+    the network has been configured and is online before starting.
+
+  * sledgehammer-stage1-init
+
+    This script is run when the Sledgehammer kernel and initrd have
+    been loaded.  It is responsible for transferring the stage2 image
+    from dr-provision and transferring control to it.
+
+  * sledgehammer-stage1-udhcpc-config
+
+    This script is invoked by udhcpc whenever it gets or releases a lease.
+    It is responsible for actually configuring the network interface.
+
+  * squashfs-excludes
+
+    this file defines what will be excluded from the stage2 squashfs image.
+
+  * install-sipcalc, update-systemd, and update-parted
+
+    These install updated versions of various components we want to be
+    available on Sledgehammer.
+
+  * remove-unwanted-pkgs
+
+    This script is responsible for removing any packages and files
+    that we do not want in the final Sledgehammer image.
+
+  * fix-up-services
+
+    This script is responsible for making sure that all the services
+    we want to start when Sledgeahmmer starts are configured properly.
+    It also disables services that are not needed.
+
+  * prepare-stage-1
+
+    This script builds the stage1 initramfs.  This stage needs to be
+    just barely smart enough to pull down stage2, and should be as
+    small as possible to minimize the amount of data transferred over
+    tftp.
+
+  * make-stage-2
+
+    This script is responsible for making the stage2 initramfs.  It
+    compresses everything down using squashfs to make sure that the
+    image is as small as it gan get.
+
+  * make-sledgehammer
+
+    This script packages everything created by the previous steps and
+    uploads it to dr-provision.
 ExtraClaims:
   - scope: "contents"
     action: "get"
@@ -339,10 +417,12 @@ Templates:
       done
 
       echo "" >/proc/sys/kernel/hotplug
+      # pkill -9 here to keep udhcpc from releasing the IP
+      # address when we will want it back in a second or two.
       if [[ "$ip6" == "" ]] ; then
-          pkill udhcpc
+          pkill -9 udhcpc
       else
-          pkill udhcpc6
+          pkill -9 udhcpc6
       fi
       ip link set "$pxedev" down
 


### PR DESCRIPTION
This refactors the discovery and join-up scripts to use a variety
of methods to determine what machine UUID matches the machine they
are running on.  It also refactors the code implementing the discovery
methods out to its own script for ease of ongoing maintenance.

The discovery methods are:

* Whoami
* MAC address matching
* Kernel command line.
* Machine-local saved UUID
* Hostname matching.

Note the lack of address based matching -- experience at one of our
largest customers has taught us that IP based matching cannot be relied upon.

This also refrains from setting the machine Address on machine creation,
and includes a task (that is included in the base discover stage) that uses
the same logic our DHCP server uses to fix up the Address field in the face
of oversubscribed DHCP address ranges.