### PR TITLE
fix(discoverName): Name generation during discovery was broken.

### DIFF
--- a/content/bootenvs/discovery.yml
+++ b/content/bootenvs/discovery.yml
@@ -307,7 +307,6 @@ Templates:
     Contents: |
       #!/bin/bash
       export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-      set +x
 
       get_macs() {
           local maclist=""
@@ -318,69 +317,45 @@ Templates:
           done
           printf '[%s]' "${maclist#,}"
       }
-
-      if [[ ! -f /etc/systemd/network/20-bootif.network ]]; then
-          get_param() {
-              [[ $(cat /proc/cmdline) =~ $1 ]] && echo "${BASH_REMATCH[1]}"
-          }
-
-          dhcp_param() {
-              [[ $(cat /var/lib/dhclient/dhclient.leases) =~ $1 ]] && echo "${BASH_REMATCH[1]}"
-          }
-
-
-      # Since we are not using normal networking, make sure that
-      # dhclient will stick around forever even if we exit
-          cat >"/etc/systemd/system/dhclient-$BOOTDEV.service" << EOF
-      [Unit]
-      Description=dhclient for $BOOTDEV.service
-      After=network-online.target
-      Wants=network-online.target
-
-      [Service]
-      Type=simple
-      ExecStart=/sbin/dhclient --no-pid -d $BOOTDEV
-
-      [Install]
-      WantedBy=multi-user.target
-      EOF
-
-          systemctl daemon-reload
-          dhclient -x
-          systemctl start "dhclient-$BOOTDEV"
-          sleep 5
-
-          # Stuff from sledgehammer file that makes this command debuggable
-          # Some useful boot parameter matches
-          ip_re='([0-9a-f.:]+/[0-9]+)'
-          host_re='rs\.uuid=([^ ]+)'
-          hostname_re='option host-name "([^"]+)'
-          fixed_ip='fixed-address ([0-9a-f.:]+)'
-          uuid_re='^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$'
-          netname_re='"network":"([^ ]+)"'
-
-          # Assume nothing about the hostname.
-          unset HOSTNAME
-
-          # Check for DHCP set host name.  Expand it to a FQDN if needed.
-          if dhcp_hostname="$(dhcp_param "$hostname_re")"; then
-              echo "Hostname set by DHCP to $dhcp_hostname"
-              if [[ ${dhcp_hostname%%.*} == $dhcp_hostname ]]; then
-                  HOSTNAME="${dhcp_hostname}.${DOMAIN}"
-              else
-                  HOSTNAME="$dhcp_hostname"
-              fi
+      # Sigh, stuff is broken in sledgehammer-start-up.sh
+      runningLink="$(networkctl |awk "/$BOOTDEV/ {print \$1}"|head -1)"
+      leaseFile="/var/run/systemd/netif/leases/$runningLink"
+      dhcp_param() {
+          awk -F= "/^$1/ {print \$2}" < "$leaseFile"
+      }
+      if [[ -e $leaseFile ]] ; then
+          HOSTNAME="$(dhcp_param HOSTNAME)"
+          DOMAIN="$(dhcp_param DOMAINNAME)"
+          DNS_SERVERS="$(dhcp_param DNS)"
+          IP="$(dhcp_param ADDRESS)"
+      fi
+      [[ $DOMAIN ]] || DOMAIN="unspecified.domain.local"
+      [[ $DNS_SERVERS ]] || DNS_SERVERS="8.8.8.8"
+      if [[ ! $IP ]]; then
+          bootdev_ip4_re='inet ([0-9.]+)/([0-9]+)'
+          bootdev_ip6_re='inet6 ([0-9a-fA-F:.]+)/([0-9]+) scope global'
+          if [[ $(ip -4 -o addr show dev $BOOTDEV) =~ $bootdev_ip4_re ]]; then
+              IP="${BASH_REMATCH[1]}"
           else
-              dhcp_ip="$(dhcp_param "$fixed_ip")"
-              if [[ $dhcp_ip != "" ]]  ; then
-                  lookup_1=$(getent hosts $dhcp_ip | awk '{print $2}')
-                  lookup_2=$(getent hosts $dhcp_ip | awk '{print $2}')
-                  if [[ $lookup_1 && $lookup_1 == $lookup_2 && $lookup_1 != localhost* ]]; then
-                      HOSTNAME=$lookup_1
-                  fi
+              if [[ $(ip -6 -o addr show dev $BOOTDEV | grep "scope global" | head -1) =~ $bootdev_ip6_re ]]; then
+                  IP="${BASH_REMATCH[1]}"
               fi
           fi
       fi
+      if [[ ! $HOSTNAME ]]; then
+          # Try DNS reverse lookup
+          candidate="$(getent hosts $IP |awk "/$IP/ {print \$2}" |head -1)"
+          if [[ $candidate && $candidate != localhost* ]]; then
+              # Found a sane one
+              HOSTNAME="$candidate"
+          else
+              # Go with the default.
+              default_host=true
+              HOSTNAME="d${MAC//:/-}"
+          fi
+      fi
+      # If we have a hostname that is not in FQDN form, append $DOMAIN to it.
+      [[ $HOSTNAME = ${HOSTNAME%%.*} ]] && HOSTNAME="${HOSTNAME}.${DOMAIN}"
       ARCH="$(uname -m)"
       case $ARCH in
           amd64|x86_64) ARCH=amd64;;
@@ -405,28 +380,18 @@ Templates:
       done
       unset tool
 
-      IP=""
-      bootdev_ip4_re='inet ([0-9.]+)/([0-9]+)'
-      bootdev_ip6_re='inet6 ([0-9a-fA-F:.]+)/([0-9]+) scope global'
-      if [[ $(ip -4 -o addr show dev $BOOTDEV) =~ $bootdev_ip4_re ]]; then
-          IP="${BASH_REMATCH[1]}"
-      else
-          if [[ $(ip -6 -o addr show dev $BOOTDEV | grep "scope global" | head -1) =~ $bootdev_ip6_re ]]; then
-              IP="${BASH_REMATCH[1]}"
-          fi
-      fi
       # See if we have already been created.
       if [[ $(cat /proc/cmdline) =~ $host_re ]]; then
           RS_UUID="${BASH_REMATCH[1]}"
+          set +x
           json="$(drpcli machines show "$RS_UUID")"
-          # If we did not get a hostname from DHCP, get it from DigitalRebar Provision.
-          if [[ ! $HOSTNAME ]]; then
+          # If the hostname is the default, then use the one from dr-provision instead
+          if [[ $default_host ]]; then
               HOSTNAME="$(jq -r '.Name' <<< "$json")"
           fi
+          set -x
       else
           # If we did not get a hostname from DHCP, generate one for ourselves.
-          [[ $HOSTNAME ]] || HOSTNAME="d${MAC//:/-}.${DOMAIN}"
-
           # Create a new node for us,
           while ! json="$(drpcli machines create "{\"Name\": \"$HOSTNAME\",
                                                \"Address\": \"$IP\",


### PR DESCRIPTION
getent hosts during Sledgehammer startup was not filtering out
localhost entries properly, which could (in combination with other
issues) lead to the system getting a hostname of
`localhost\nlocalhost`, which would wig out the rest of the machine
name generation process.  Fixing thios at the point it was broken
would require a respin of Sledgeahmmer, so in the meantime work around
it in start-up.sh in the discover bootenv.