### PR TITLE
fix: Update ISO URLs for all operating systems to current values

### DIFF
--- a/content/bootenvs/centos-7.yml
+++ b/content/bootenvs/centos-7.yml
@@ -16,9 +16,9 @@ OS:
   Name: "centos-7"
   SupportedArchitectures:
     x86_64:
-      IsoFile: "CentOS-7-x86_64-Minimal-1908.iso"
-      IsoUrl: "http://mirror.rackspace.com/CentOS/7/isos/x86_64/CentOS-7-x86_64-Minimal-1908.iso"
-      Sha256: "9a2c47d97b9975452f7d582264e9fc16d108ed8252ac6816239a3b58cef5c53d"
+      IsoFile: "CentOS-7-x86_64-Minimal-2003.iso"
+      IsoUrl: "https://mirrors.edge.kernel.org/centos/7.8.2003/isos/x86_64/CentOS-7-x86_64-Minimal-2003.iso"
+      Sha256: "659691c28a0e672558b003d223f83938f254b39875ee7559d1a4a14c79173193"
       Kernel: "images/pxeboot/vmlinuz"
       Initrds:
         - "images/pxeboot/initrd.img"
@@ -32,9 +32,9 @@ OS:
         {{.Param "kernel-console"}}
     aarch64:
       Loader: "grubarm64.efi"
-      IsoFile: "CentOS-7-aarch64-Minimal-1908.iso"
-      Sha256: "079123767bf3f59f1cf4daf5f9c030c5f251267d6ea5abd49d63a44997d7db19"
-      IsoUrl: "http://ftp.osuosl.org/pub/centos-altarch/7/isos/aarch64/CentOS-7-aarch64-Minimal-1908.iso"
+      IsoFile: "CentOS-7-aarch64-Minimal-2003.iso"
+      Sha256: "36f48ca26a284442f6abba221cc1279fca103289ade411ee298d38cbf66967bc"
+      IsoUrl: "http://ftp.osuosl.org/pub/centos-altarch/7/isos/aarch64/CentOS-7-aarch64-Minimal-2003.iso"
       Kernel: "images/pxeboot/vmlinuz"
       Initrds:
         - "images/pxeboot/initrd.img"

--- a/content/bootenvs/debian-8.yml
+++ b/content/bootenvs/debian-8.yml
@@ -11,10 +11,10 @@ Meta:
 OS:
   Name: "debian-8"
   Family: "debian"
-  IsoFile: "debian-8-amd64-mini.iso"
-  IsoSha256: "61a852072514c385d3a22005bafeb083a2da40efa816a115c4acfa682d112b2b"
-  IsoUrl: "http://mirrors.kernel.org/debian/dists/jessie/main/installer-amd64/current/images/netboot/mini.iso"
-  Version: "8.11"
+  IsoFile: "debian-8.11.1-amd64-netinst.iso"
+  IsoSha256: "ea444d6f8ac95fd51d2aedb8015c57410d1ad19b494cedec6914c17fda02733c"
+  IsoUrl: "https://cdimage.debian.org/cdimage/archive/8.11.1/amd64/iso-cd/debian-8.11.1-amd64-netinst.iso"
+  Version: "8.11.1"
 Initrds:
   - "initrd.gz"
 Kernel: "linux"

--- a/content/bootenvs/debian-9.yml
+++ b/content/bootenvs/debian-9.yml
@@ -11,10 +11,10 @@ Meta:
 OS:
   Name: "debian-9"
   Family: "debian"
-  IsoFile: "debian-9-amd64-mini.iso"
-  IsoSha256: "e93011cf474c91d89bc382efec825549a136c86f59794261834e1c6f17ed53d0"
-  IsoUrl: "http://mirrors.kernel.org/debian/dists/stretch/main/installer-amd64/current/images/netboot/mini.iso"
-  Version: "9.6"
+  IsoFile: "debian-9.12.0-amd64-netinst.iso"
+  IsoSha256: "3c47f64693435b0b42b6ef59624edbffa7c4004317d9f9a3f04ecb6a4e30f191"
+  IsoUrl: "https://cdimage.debian.org/cdimage/archive/9.12.0/amd64/iso-cd/debian-9.12.0-amd64-netinst.iso"
+  Version: "9.12"
 Initrds:
   - "initrd.gz"
 Kernel: "linux"

--- a/content/bootenvs/ubuntu-18.04.yml
+++ b/content/bootenvs/ubuntu-18.04.yml
@@ -25,7 +25,7 @@ OS:
   SupportedArchitectures:
     amd64:
       IsoFile: "ubuntu-18.04.4-server-amd64.iso"
-      IsoUrl: "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.4-server-amd64.iso"
+      IsoUrl: "http://cdimage.ubuntu.com/ubuntu/releases/18.04.4/release/ubuntu-18.04.4-server-amd64.iso"
       IsoSha256: "e2ecdace33c939527cbc9e8d23576381c493b071107207d2040af72595f8990b"
       Kernel: "install/netboot/ubuntu-installer/amd64/linux"
       Initrds:
@@ -45,7 +45,7 @@ OS:
         {{.Param "kernel-console"}}
     arm64:
       IsoFile: "ubuntu-18.04.4-server-arm64.iso"
-      IsoUrl: "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.4-server-arm64.iso"
+      IsoUrl: "http://cdimage.ubuntu.com/ubuntu/releases/18.04.4/release/ubuntu-18.04.4-server-arm64.iso"
       IsoSha256: "8eb3c1866ca3b68e4cd22ec9d7c02f97f4d2b3713447370f3c252a4189116824"
       Kernel: "install/netboot/ubuntu-installer/arm64/linux"
       Loader: "grubarm64.efi"


### PR DESCRIPTION
Bumped Debian 8 to 8.11.1
Bumped CentOS 7 to build 2003
Bumped Debian 9 to 9.12
Fixed URLs for Ubuntu 18.04