### PR TITLE
fix(task-library): Centos7 needs DNF installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,9 @@ drp
 /.idea/
 bin
 krib/krib.yaml
+content/contents.yaml
+content/content.yaml
 edge-lab/edge-lab.yaml
 edge-lab/admin.conf
+edge-lab/kube.config
+task-library/task-library.yaml

--- a/task-library/tasks/bootstrap-contexts.yaml
+++ b/task-library/tasks/bootstrap-contexts.yaml
@@ -50,7 +50,7 @@ Templates:
         FAMILY=$(grep "^ID=" /etc/os-release | tr -d '"' | cut -d '=' -f 2)
         echo "Installing Containerd"
         case $FAMILY in
-          redhat|centos) dnf install -y https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.6-3.3.el7.x86_64.rpm ;;
+          redhat|centos) yum install -y dnf; dnf install -y https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.6-3.3.el7.x86_64.rpm ;;
           debian|ubuntu) apt install -y containerd ;;
           *) >&2 echo "Unsupported package manager family '$FAMILY'."
              exit 1 ;;

--- a/task-library/tasks/network-firewall.yaml
+++ b/task-library/tasks/network-firewall.yaml
@@ -20,7 +20,7 @@ Templates:
     FAMILY=$(grep "^ID=" /etc/os-release | tr -d '"' | cut -d '=' -f 2)
 
     case $FAMILY in
-      redhat|centos) yum install -y firewall ;;
+      redhat|centos) yum install -y firewalld ;;
       debian|ubuntu) sudo apt install -y ufw ;;
       *) >&2 echo "Unsupported package manager family '$FAMILY'."
          exit 1 ;;


### PR DESCRIPTION
Only tested Cetnos8 and Ubuntu in #502,
This patch catches tests on Centos7 which don't include DNF
So added yum install dnf to install the new installer.