### PR TITLE
refactor(edge-lab): expand storage attach logic to use array of inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ edge-lab/edge-lab.yaml
 edge-lab/admin.conf
 edge-lab/kube.config
 task-library/task-library.yaml
+bundle.yaml

--- a/edge-lab/._Documentation.meta
+++ b/edge-lab/._Documentation.meta
@@ -37,21 +37,36 @@ Setup K3s Cluster
 
 Before starting, install `kubectl` has been installed on client system
 
+.. note:: You _must_ have attached storage in each node for the k3s cluster to operate!  This could be an SDcard or USB drive.  If the partitions are not xfs, the code will wipe the drive!
+
 To build your cluster:
 
 #. select the nodes for installation and apply the `k3s-install` workflow
 #. wait for workflow to complete on leader
-#. use `drpcli profiles get cluster01 param k3s/admin-conf --decode > admin.conf`
+#. use `drpcli profiles get cluster01 param k3s/admin-conf --decode > kube.conf`
 
 To access on the DRP server or cluster:
 
-#. test with `kubectl --kubeconfig=admin.conf get nodes`
+#. test with `kubectl --kubeconfig=kube.conf get nodes`
 
 To access from another system, use an SSH tunnel:
 
 #. setup an ssh tunnel: `ssh root@[host wifi ip] -L 6443:[leader node ip]:6443`
 #. modify your `admin.conf` file to use `127.0.0.1` instead of the leader node ip
-#. test with `kubectl --kubeconfig=admin.conf get nodes`
+#. test with `kubectl --kubeconfig=kube.conf get nodes`
+
+Access Kubernetes Dashboard
+---------------------------
+
+The Kubernetes Dashboard v2 is automatically installed by the k3s-install` workflow.
+Admin and service accounts are created for access.
+
+To access the Dashboard:
+
+#. use `kubectl --kubeconfig=kube.conf proxy` to create a network
+path to your cluster.
+#. get the Dashboard authentication token `drpcli profiles get cluster01 param edge-lab/dashboard-token --decode`
+#. open the Dashboard using the proxy: http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/login
 
 Install OpenFaaS via Helm
 -------------------------
@@ -59,16 +74,16 @@ Install OpenFaaS via Helm
 The k3s install above will automatically include Helm v3 and run
 charts defined in the `edge-lab/helm-charts` param array.
 
-OpenFaaS is provided as an example in the `openfaas-*` profile.
+OpenFaaS is provided as an example in the `helm-openfaas` profile.
 To include OpenFaaS in the k3s install, simply assign the
-`openfaas-arm64` or `openfaas-amd64` profile on cluster leader based on your architecture
+`helm-openfaas` profile on cluster leader based on your architecture
 (you can assign it to all cluster machines and it will be ignore on the non-leaders).
 
 Since the helm stages are idempotent, either include the profile
 before running the `k3s-install` workflow or re-run the workflow.
 
 The OpenFaaS helm chart install will write its password to the
-cluster profile using `openfaas/password`.
+cluster profile using `openfaas/password`.  To retrieve the password use `drpcli profiles get cluster01 param openfaas/password --decode`.
 
 
 Machine Reset

--- a/edge-lab/params/edge-lab-mount-devices.yaml
+++ b/edge-lab/params/edge-lab-mount-devices.yaml
@@ -1,0 +1,79 @@
+---
+Name: "edge-lab/mount-devices"
+Description: "Attached Storage Devices to Mount"
+Documentation: |
+  .. _edgelab_storage:
+
+  Mount Attached Storage
+  ++++++++++++++++++++++
+
+  Ordered list of of devices to attempt mounting from the OS.
+
+  The EdgeLab K3s install will attempt to mount all the drives
+  in the list in in order.  If the desired mount point is already
+  in use then the code will skip attempting to assign it.
+
+  This design allows operators to specific multiple mount points
+  or have a single point with multiple potential configurations.
+
+  example:
+
+    ::
+
+      [
+        {
+          disk: "/dev/mmcblk0",
+          partition: "/dev/mmcblkp1"
+          mount: "/mnt/storage",
+          type: "xfs",
+          rebuild: true
+        }
+        {
+          disk: "/dev/sda",
+          partition: "/dev/sda1"
+          mount: "/mnt/storage",
+          type: "xfs",
+          rebuild: true
+        }
+      ]
+
+Schema:
+  default:
+    - disk: "/dev/mmcblk0"
+      partition: "/dev/mmcblk0p2"
+      mount: "/mnt/storage"
+      type: "ext4"
+      rebuild: false
+    - disk: "/dev/mmcblk0"
+      partition: "/dev/mmcblk0p1"
+      mount: "/mnt/storage"
+      type: "xfs"
+      rebuild: true
+    - disk: "/dev/sda"
+      partition: "/dev/sda1"
+      mount: "/mnt/storage"
+      type: "xfs"
+      rebuild: true
+  type: array
+  items:
+    required:
+      - disk
+      - partition
+      - mount
+      - type
+      - rebuild
+    properties:
+      disk:
+        type: string
+      partition:
+        type: string
+      mount:
+        type: string
+      type:
+        type: string
+      rebuild:
+        type: boolean
+Meta:
+  color: "blue"
+  icon: "disk"
+  title: "Community Content"

--- a/edge-lab/params/edge-lab-mount-devices.yaml
+++ b/edge-lab/params/edge-lab-mount-devices.yaml
@@ -23,14 +23,14 @@ Documentation: |
       [
         {
           disk: "/dev/mmcblk0",
-          partition: "/dev/mmcblkp1"
+          partition: "/dev/mmcblkp1",
           mount: "/mnt/storage",
           type: "xfs",
           rebuild: true
         }
         {
           disk: "/dev/sda",
-          partition: "/dev/sda1"
+          partition: "/dev/sda1",
           mount: "/mnt/storage",
           type: "xfs",
           rebuild: true

--- a/edge-lab/params/k3s-admin-conf.yaml
+++ b/edge-lab/params/k3s-admin-conf.yaml
@@ -4,10 +4,13 @@ Description: "Admin config file"
 Documentation: |
   Param is set (output) by the cluster building process
 
-  To use the file, save to `$HOME/.kube` or pass `--kubeconfig=[kube.config]` to the kubectl or other tools.
+  To use the file, use one of the following
+  * save to `$HOME/.kube`
+  * `export KUBECONFIG=[file]`
+  * pass `--kubeconfig=[kube.config]` to the kubectl or other tools.
 
   If your cluster is using the default `cluster01` then tou can retrieve the `admin.conf` file using:
-  `drpcli profiles get cluster01 param  k3s/admin-conf --decode > admin.conf`
+  `drpcli profiles get cluster01 param  k3s/admin-conf --decode > kube.conf`
 
   Note: this is stored as a secure object so the decode is required
 Secure: true

--- a/edge-lab/templates/k3s-install.sh.tmpl
+++ b/edge-lab/templates/k3s-install.sh.tmpl
@@ -80,50 +80,63 @@ fi
 # Check for a scsi device or a ssd card
 #
 mkdir -p /mnt/storage
-# if sda is present, check to use it or blow it away
-if lsblk /dev/sda 2>/dev/null >/dev/null ; then
-  echo "Checking for first scsi device"
-  rebuild=true
-  if lsblk /dev/sda1 2>/dev/null >/dev/null ; then
-    echo "Found existing partition on /dev/sda"
-    rebuild=false
-    mount /dev/sda1 /mnt/storage
-    fstype=$(mount | grep /mnt/storage | awk '{ print $5 }')
-    if [[ "$fstype" != "xfs" ]] ; then
-      echo "Not xfs filesystem, rebuild it"
-      umount /mnt/storage
-      rebuild=true
-    fi
+
+echo "Attempting to mount attached storage from edge-lab/mount-devices"
+{{range $index, $device := (.Param "edge-lab/mount-devices") }}
+  echo "=============== {{$index}}: {{$device.partition}} ==============="
+  if grep -qs {{$device.mount}} /proc/mounts ; then
+    echo "{{$device.mount}} already mounted, cannot redefine at {{$device.partition}}... skipping"
   else
-    echo "no filesystem found on /dev/sda - rebuild it"
+    echo "attempting to mount {{$device.mount}} from {{$device.partition}}"
+    if lsblk {{$device.disk}} 2>/dev/null >/dev/null ; then
+      echo "found disk {{$device.disk}}, checking partition {{$device.partition}}"
+      rebuild={{$device.rebuild}}
+      if lsblk {{$device.partition}} 2>/dev/null >/dev/null ; then
+        rebuild=false
+        echo "found partition {{$device.partition}}, mounting to {{$device.mount}}"
+        if mount {{$device.partition}} {{$device.mount}} ; then
+          fstype=$(mount | grep /mnt/storage | awk '{ print $5 }')
+          if [[ "$fstype" != "{{$device.type}}" ]] ; then
+            echo "Was $fstype filesystem, needed {{$device.type}} filesystem. rebuild it"
+            rebuild=true
+            umount {{$device.mount}}
+          else
+            echo "Partition is already {{$device.type}}, no change needed"
+          fi
+        else
+          echo "could not mount {{$device.partition}} {{$device.mount}}, moving on..."
+        fi
+      else
+        echo "no disk {{$device.disk}}, trying next disk in array"
+      fi
+      if [[ $rebuild == true ]] ; then
+        wipefs -a {{$device.disk}}
+        parted {{$device.disk}} mklabel GPT
+        parted {{$device.disk}} mkpart primary 2048s 100%
+        mkfs -t {{$device.type}} {{$device.partition}}
+        mount {{$device.partition}} {{$device.mount}}
+      fi
+    else
+      echo "no {{$device.disk}} found, moving on..."
+    fi
   fi
+{{else}}
+  echo "no attached storage drives defined"
+{{end}}
 
-  if [[ $rebuild == true ]] ; then
-    echo "Rebuilding the filesystems"
-    wipefs -a /dev/sda
-    parted /dev/sda mklabel GPT
-    parted /dev/sda mkpart primary 2048s 100%
-    mkfs -t xfs /dev/sda1
-    mount /dev/sda1 /mnt/storage
+if grep -qs /mnt/storage /proc/mounts ; then
+  # Reset the storage if it isn't ours.
+  echo "Checking for storage marker"
+  if [[ "$(cat /mnt/storage/marker)" != "$RS_UUID" ]] ; then
+    echo "Marker didn't match.  Reset the container space"
+    rm -rf /mnt/storage/containerd
+    echo -n "$RS_UUID" > /mnt/storage/marker
   fi
+  mkdir -p /mnt/storage/containerd
 else
-  echo "Checking for SSD"
-  # ssd check and mount the partition in place.
-  # This is really RPI specific.
-  if lsblk /dev/mmcblk0 2>/dev/null >/dev/null ; then
-    echo "Mounting the SSD for /mnt/storage"
-    mount /dev/mmcblk0p2 /mnt/storage
-  fi
+  echo "HALTING: Install requires external storage."
+  exit 1
 fi
-
-# Reset the storage if it isn't ours.
-echo "Checking for storage marker"
-if [[ "$(cat /mnt/storage/marker)" != "$RS_UUID" ]] ; then
-  echo "Marker didn't match.  Reset the container space"
-  rm -rf /mnt/storage/containerd
-  echo -n "$RS_UUID" > /mnt/storage/marker
-fi
-mkdir -p /mnt/storage/containerd
 
 # Link to attached storage if there.
 mkdir -p /var/lib/rancher/k3s/agent

--- a/edge-lab/templates/k3s-install.sh.tmpl
+++ b/edge-lab/templates/k3s-install.sh.tmpl
@@ -98,7 +98,7 @@ echo "Attempting to mount attached storage from edge-lab/mount-devices"
           fstype=$(mount | grep /mnt/storage | awk '{ print $5 }')
           if [[ "$fstype" != "{{$device.type}}" ]] ; then
             echo "Was $fstype filesystem, needed {{$device.type}} filesystem. rebuild it"
-            rebuild=true
+            rebuild={{$device.rebuild}}
             umount {{$device.mount}}
           else
             echo "Partition is already {{$device.type}}, no change needed"
@@ -110,11 +110,14 @@ echo "Attempting to mount attached storage from edge-lab/mount-devices"
         echo "no disk {{$device.disk}}, trying next disk in array"
       fi
       if [[ $rebuild == true ]] ; then
+        echo "do rebuild disk flag set - will wipefs and partition"
         wipefs -a {{$device.disk}}
         parted {{$device.disk}} mklabel GPT
         parted {{$device.disk}} mkpart primary 2048s 100%
         mkfs -t {{$device.type}} {{$device.partition}}
         mount {{$device.partition}} {{$device.mount}}
+      else
+        echo "do not rebuild disk (request was rebuild={{$device.rebuild}})"
       fi
     else
       echo "no {{$device.disk}} found, moving on..."


### PR DESCRIPTION
This expands on the approach from @galthaus but removes the hard coded paths in favor of pulling from an array defined as a param.  It also allow for more error detection so that a bad mount will not break the logic (but k3s install tests for the mounts later).  

This approach will allow operators to override the default order and type.

For now, the k3s install still relies on a specific path, but that could be split out and parameterized in the future.  If the storage approach is generally useful, this could be refactored as a stand alone task and pulled into common libraries.