### PR TITLE
fix(secureBoot): Fix up boot for UEFI Secure Boot on arm64

### DIFF
--- a/content/bootenvs/centos-7.6.1810.yml
+++ b/content/bootenvs/centos-7.6.1810.yml
@@ -11,6 +11,7 @@ Meta:
   title: "Digital Rebar Community Content"
 Loaders:
   amd64-uefi: EFI/BOOT/BOOTX64.EFI
+  arm64-uefi: EFI/BOOT/grubaa64.efi
 OS:
   Family: "redhat"
   Name: "centos-7.6.1810"
@@ -77,10 +78,10 @@ Templates:
     Name: "grub-mac"
     Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'
   - Name: grub-secure-mac
-    Path: '{{.Env.PathForArch "tftp" "" "amd64"}}/EFI/BOOT/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
+    Path: '{{.Env.PathFor "tftp" ""}}/EFI/BOOT/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
     ID: default-grub.tmpl
   - Name: grub-secure
-    Path: '{{.Env.PathForArch "tftp" "" "amd64"}}/EFI/BOOT/grub.cfg-{{.Machine.HexAddress}}'
+    Path: '{{.Env.PathFor "tftp" ""}}/EFI/BOOT/grub.cfg-{{.Machine.HexAddress}}'
     ID: default-grub.tmpl
   - ID: "select-kickseed.tmpl"
     Name: "compute.ks"

--- a/content/bootenvs/centos-7.7.1908.yml
+++ b/content/bootenvs/centos-7.7.1908.yml
@@ -11,6 +11,7 @@ Meta:
   title: "Digital Rebar Community Content"
 Loaders:
   amd64-uefi: EFI/BOOT/BOOTX64.EFI
+  arm64-uefi: EFI/BOOT/grubaa64.efi
 OS:
   Family: "redhat"
   Name: "centos-7.7.1908"
@@ -77,10 +78,10 @@ Templates:
     Name: "grub-mac"
     Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'
   - Name: grub-secure-mac
-    Path: '{{.Env.PathForArch "tftp" "" "amd64"}}/EFI/BOOT/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
+    Path: '{{.Env.PathFor "tftp" ""}}/EFI/BOOT/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
     ID: default-grub.tmpl
   - Name: grub-secure
-    Path: '{{.Env.PathForArch "tftp" "" "amd64"}}/EFI/BOOT/grub.cfg-{{.Machine.HexAddress}}'
+    Path: '{{.Env.PathFor "tftp" ""}}/EFI/BOOT/grub.cfg-{{.Machine.HexAddress}}'
     ID: default-grub.tmpl
   - ID: "select-kickseed.tmpl"
     Name: "compute.ks"

--- a/content/bootenvs/centos-7.yml
+++ b/content/bootenvs/centos-7.yml
@@ -11,6 +11,7 @@ Meta:
   title: "Digital Rebar Community Content"
 Loaders:
   amd64-uefi: EFI/BOOT/BOOTX64.EFI
+  arm64-uefi: EFI/BOOT/grubaa64.efi
 OS:
   Family: "redhat"
   Name: "centos-7"
@@ -77,10 +78,10 @@ Templates:
     Name: "grub-mac"
     Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'
   - Name: grub-secure-mac
-    Path: '{{.Env.PathForArch "tftp" "" "amd64"}}/EFI/BOOT/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
+    Path: '{{.Env.PathFor "tftp" ""}}/EFI/BOOT/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
     ID: default-grub.tmpl
   - Name: grub-secure
-    Path: '{{.Env.PathForArch "tftp" "" "amd64"}}/EFI/BOOT/grub.cfg-{{.Machine.HexAddress}}'
+    Path: '{{.Env.PathFor "tftp" ""}}/EFI/BOOT/grub.cfg-{{.Machine.HexAddress}}'
     ID: default-grub.tmpl
   - ID: "select-kickseed.tmpl"
     Name: "compute.ks"

--- a/content/bootenvs/fedora-31.yml
+++ b/content/bootenvs/fedora-31.yml
@@ -59,10 +59,10 @@ Templates:
     Name: "grub-mac"
     Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'
   - Name: grub-secure-mac
-    Path: '{{.Env.PathForArch "tftp" "" "amd64"}}/EFI/BOOT/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
+    Path: '{{.Env.PathFor "tftp" ""}}/EFI/BOOT/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
     ID: default-grub.tmpl
   - Name: grub-secure
-    Path: '{{.Env.PathForArch "tftp" "" "amd64"}}/EFI/BOOT/grub.cfg-{{.Machine.HexAddress}}'
+    Path: '{{.Env.PathFor "tftp" ""}}/EFI/BOOT/grub.cfg-{{.Machine.HexAddress}}'
     ID: default-grub.tmpl
   - ID: "select-kickseed.tmpl"
     Name: "compute.ks"

--- a/content/bootenvs/ubuntu-16.04.yml
+++ b/content/bootenvs/ubuntu-16.04.yml
@@ -73,10 +73,10 @@ Templates:
     Name: "net-post-install.sh"
     Path: "{{.Machine.Path}}/post-install.sh"
   - Name: grub-secure-mac
-    Path: '{{.Env.PathForArch "tftp" "" "amd64"}}/EFI/BOOT/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
+    Path: '{{.Env.PathFor "tftp" ""}}/EFI/BOOT/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
     ID: default-grub.tmpl
   - Name: grub-secure
-    Path: '{{.Env.PathForArch "tftp" "" "amd64"}}/EFI/BOOT/grub.cfg-{{.Machine.HexAddress}}'
+    Path: '{{.Env.PathFor "tftp" ""}}/EFI/BOOT/grub.cfg-{{.Machine.HexAddress}}'
     ID: default-grub.tmpl
   - ID: "default-grub.tmpl"
     Name: "grub"

--- a/content/bootenvs/ubuntu-18.04.yml
+++ b/content/bootenvs/ubuntu-18.04.yml
@@ -105,10 +105,10 @@ Templates:
     Name: "net-post-install.sh"
     Path: "{{.Machine.Path}}/post-install.sh"
   - Name: grub-secure-mac
-    Path: '{{.Env.PathForArch "tftp" "" "amd64"}}/EFI/BOOT/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
+    Path: '{{.Env.PathFor "tftp" ""}}/EFI/BOOT/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
     ID: default-grub.tmpl
   - Name: grub-secure
-    Path: '{{.Env.PathForArch "tftp" "" "amd64"}}/EFI/BOOT/grub.cfg-{{.Machine.HexAddress}}'
+    Path: '{{.Env.PathFor "tftp" ""}}/EFI/BOOT/grub.cfg-{{.Machine.HexAddress}}'
     ID: default-grub.tmpl
   - ID: "default-grub.tmpl"
     Name: "grub"

--- a/sledgehammer-builder/bootenvs/build-sledgehammer.yaml
+++ b/sledgehammer-builder/bootenvs/build-sledgehammer.yaml
@@ -7,14 +7,14 @@ Documentation: |
   a basic CentOS install on a sacrificial machine.  The tasks that run after the install
   has finished are responsible for stripping out everything we do not need for Sledgehammer
   to boot as an in-memory OS image and packaging everything up for distribution.
+Loaders:
+  amd64-uefi: EFI/BOOT/BOOTX64.EFI
+  arm64-uefi: EFI/BOOT/grubaa64.efi
 OS:
   Family: "redhat"
   Name: "centos-7"
   SupportedArchitectures:
     x86_64:
-      IsoFile: "CentOS-7-x86_64-Minimal-1810.iso"
-      IsoUrl: "http://mirror.math.princeton.edu/pub/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-1810.iso"
-      Sha256: "38d5d51d9d100fd73df031ffd6bd8b1297ce24660dc8c13a3b8b4534a4bd291c"
       Kernel: "images/pxeboot/vmlinuz"
       Initrds:
         - "images/pxeboot/initrd.img"
@@ -27,9 +27,6 @@ OS:
         {{.Param "kernel-console"}}
     aarch64:
       Loader: "grubarm64.efi"
-      IsoFile: CentOS-7-aarch64-Minimal-1810.iso
-      Sha256: "864596b2fb971c8d8c0f3618981cca4725f6c2347f6eb2f130e0aefa3413c0ef"
-      IsoUrl: http://mirror.centos.org/altarch/7/isos/aarch64/CentOS-7-aarch64-Minimal-1810.iso
       Kernel: "images/pxeboot/vmlinuz"
       Initrds:
         - "images/pxeboot/initrd.img"
@@ -59,6 +56,12 @@ Templates:
   - ID: "default-grub.tmpl"
     Name: "grub-mac"
     Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'
+  - ID: "default-grub.tmpl"
+    Name: "grub-secure"
+    Path: "sledgehammer/e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/grub.cfg-{{.Machine.HexAddress}}"
+  - ID: "default-grub.tmpl"
+    Name: "grub-secure-mac"
+    Path: 'sledgehammer/e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
   - Name: "sledgehammer.ks"
     Path: "{{.Machine.Path}}/sledgehammer.ks"
     Contents: |


### PR DESCRIPTION
OK, this doesn't really add secure boot support on arm64, mostly due
to my vms having no way of actually testing it.  Instead, it fixes up
the paths that we serve grub.cfg on for secure boot to work on arm64
as well as amd64, and arrange to use the built-in grub binary (instead
of the shim loader, which crashes qemu right now)

This also removes ISO information frim the sledgehanner builder
bootenv, as it should just be tracking whatever the current version of
centos is instead of pinning it at centos 7.6