### PR TITLE
doc(edgelab): turn URL into link

### DIFF
--- a/edge-lab/params/edge-lab-dashboard-token.yaml
+++ b/edge-lab/params/edge-lab-dashboard-token.yaml
@@ -5,7 +5,7 @@ Documentation: |
   Param is set (output) by the Dashboard install process
 
   To start the dashboard, use `kubectl proxy` then open
-  http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/login
+  `http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/login <http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#/login>`_
 
   Note: this is stored as a secure object so the decode is required
 Secure: true


### PR DESCRIPTION
it's handy to have this URL present as a link.