### PR TITLE
refactor(contexts): runner context should include keygen

### DIFF
--- a/integrations/docker-context/runner-dockerfile
+++ b/integrations/docker-context/runner-dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:latest
-RUN apk --no-cache add bash curl
+RUN apk --no-cache add bash curl openssh-keygen
 RUN curl -o drpcli420 https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.2.0/amd64/linux/drpcli && \
 	chmod 755 drpcli420 && \
 	./drpcli420 catalog item download drpcli to /usr/bin/drpcli && \


### PR DESCRIPTION
...so we can create rsa keys in the runner context

this is required if we want to run the rsa-key-create task inside of the runner context