### PR TITLE
fix(drp-community-content): add wipefs to the cleaning items.

### DIFF
--- a/content/tasks/erase-hard-disks-for-os-install.yaml
+++ b/content/tasks/erase-hard-disks-for-os-install.yaml
@@ -47,6 +47,7 @@ Templates:
           [[ $name = fd* ]] && continue
           echo "Forcibly removing any RAID metadata on /dev/$name. Failures are OK if readonly"
           mdadm --misc --zero-superblock --force /dev/$name || :
+          wipefs -a -f /dev/$name || :
           if (( blocks >= 4096)); then
               echo "Zeroing the first and last 2 megs of /dev/$name. Failures are OK if readonly"
               dd "if=/dev/zero" "of=/dev/$name" "bs=512" "count=4096" || :


### PR DESCRIPTION
This should help with some of the cleaning up of VMWare VSAN
partitions.  It is not guaranteed, but should clear more spots
that the dd might miss.  Running before dd helps get some other
spots.