### PR TITLE
refactor(dev-library): expand wait time task to include API activity

### DIFF
--- a/dev-library/params/dev-wait-icons.yaml
+++ b/dev-library/params/dev-wait-icons.yaml
@@ -1,0 +1,21 @@
+---
+Name: "dev/wait-icons"
+Description: "List of Icons to use during wait-time for workflow test"
+Schema:
+  type: array
+  default:
+    - "bath"
+    - "bed"
+    - "fighter jet"
+    - "gamepad"
+    - "glass martini"
+    - "lemon"
+    - "magnet"
+    - "paw"
+    - "rocket"
+    - "shower"
+    - "umbrella"
+Meta:
+  color: "blue"
+  icon: "stopwatch"
+  title: "RackN Content 2020"

--- a/dev-library/params/dev-wait-time.yaml
+++ b/dev-library/params/dev-wait-time.yaml
@@ -6,9 +6,9 @@ Documentation: |
   This can be very helpful to troubleshoot timing issues
   in provisioning.  It should NOT be used in production!
 Schema:
-  type: "integer"
-  minimum: 1
-  default: 5
+  type: "number"
+  default: 1.0
+  minimum: 0.1
 Meta:
   color: "yellow"
   icon: "hourglass half"

--- a/dev-library/tasks/wait-time.yaml
+++ b/dev-library/tasks/wait-time.yaml
@@ -3,35 +3,43 @@ Name: wait-time
 Description: "Wait in Workflow"
 Documentation: |
   Handy for dev/test, this task will sleep for
-  a programmable amount of time
-Meta:
-  title: "RackN Content"
-  color: black
-  feature-flags: sane-exit-codes
-  icon: hourglass half
+  a programmable amount of time.
+
+  It will also excercise the API by changing the machine icons
+  b ased on the wait-icons list.
+RequiredParams:
+  - dev/wait-icons
+  - dev/wait-time
 Templates:
 - Contents: |-
     #!/usr/bin/env bash
-    # clear the workflow for a machine (makes it easy to rerun workflow)
 
     set -e
 
     {{template "setup.tmpl" .}}
 
-    do_sleep() { local _n=$SLEEP; while (( _n>=1 )); do printf "%s " "$_n"; sleep 1; (( _n-- )); done; echo "0"; }
+    icon=$(drpcli machines meta get $RS_UUID icon)
+    color=$(drpcli machines meta get $RS_UUID color)
 
-    export RS_UUID="{{.Machine.UUID}}"
+    {{ $wait := (.Param "dev/wait-time") }}
+    {{ range $index, $icon := (.Param "dev/wait-icons") -}}
+      echo "wait cycle {{$index}}"
+      drpcli machines meta set $RS_UUID key icon to "{{$icon}}"
+      drpcli machines meta set $RS_UUID key color to "green"
+      sleep {{ $wait }}
+    {{ else -}}
+      echo "no icons defined, no wait"
+      exit 0
+    {{ end -}}
 
-    {{if .ParamExists "dev/wait-time" -}}
-    SLEEP={{.Param "dev/wait-time"}}
-    {{else -}}
-    SLEEP="5"
-    {{end -}}
-
-    echo "Wait Start - $SLEEP seconds"
-
-    do_sleep
+    drpcli machines meta set $RS_UUID key icon to "$icon"
+    drpcli machines meta set $RS_UUID key color to "$color"
 
     echo "Wait Finished"
     exit 0
   Name: wait-time
+Meta:
+  title: "RackN Content"
+  color: black
+  feature-flags: sane-exit-codes
+  icon: hourglass half


### PR DESCRIPTION
instead of just sleeping

This is helpful when testing dummy workflows because you can see activity in the UX.

Also could be used for API load testing.