### PR TITLE
fix(sledgehammer): Bump sledgehammer to fix DHCP RELEASE issue.

### DIFF
--- a/content/bootenvs/discovery.yml
+++ b/content/bootenvs/discovery.yml
@@ -19,17 +19,17 @@ Meta:
   title: "Digital Rebar Community Content"
 OnlyUnknown: true
 Loaders:
-  amd64-uefi: e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/shimx64.efi
+  amd64-uefi: 46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/shimx64.efi
 OS:
   Family: "redhat"
   Name: "sledgehammer"
   SupportedArchitectures:
     amd64:
-      IsoFile: "sledgehammer-e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da.amd64.tar"
-      IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/sledgehammer-e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da.amd64.tar"
-      Kernel: "e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/vmlinuz0"
+      IsoFile: "sledgehammer-46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f.amd64.tar"
+      IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/sledgehammer-46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f.amd64.tar"
+      Kernel: "46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/vmlinuz0"
       Initrds:
-        - "e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/stage1.img"
+        - "46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/stage1.img"
       BootParams: >-
         rootflags=loop
         root=live:/sledgehammer.iso
@@ -227,7 +227,7 @@ Templates:
         source (tftp)/grub/discovery.cfg
       fi
   - Name: "grub-secure-discovery"
-    Path: "sledgehammer/e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/grub.cfg"
+    Path: "sledgehammer/46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/grub.cfg"
     ID: allarch-grub.tmpl
   - Name: "grub-discovery"
     Path: "grub/discovery.cfg"

--- a/content/bootenvs/sledgehammer.yml
+++ b/content/bootenvs/sledgehammer.yml
@@ -17,17 +17,17 @@ Meta:
   color: "green"
   title: "Digital Rebar Community Content"
 Loaders:
-  amd64-uefi: e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/shimx64.efi
+  amd64-uefi: 46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/shimx64.efi
 OS:
   Family: "redhat"
   Name: "sledgehammer"
   SupportedArchitectures:
     amd64:
-      IsoFile: "sledgehammer-e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da.amd64.tar"
-      IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/sledgehammer-e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da.amd64.tar"
-      Kernel: "e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/vmlinuz0"
+      IsoFile: "sledgehammer-46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f.amd64.tar"
+      IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/sledgehammer-46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f.amd64.tar"
+      Kernel: "46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/vmlinuz0"
       Initrds:
-        - "e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/stage1.img"
+        - "46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/stage1.img"
       BootParams: >-
         rootflags=loop
         root=live:/sledgehammer.iso
@@ -195,10 +195,10 @@ Templates:
     Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'
   - ID: "default-grub.tmpl"
     Name: "grub-secure"
-    Path: "sledgehammer/e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/grub.cfg-{{.Machine.HexAddress}}"
+    Path: "sledgehammer/46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/grub.cfg-{{.Machine.HexAddress}}"
   - ID: "default-grub.tmpl"
     Name: "grub-secure-mac"
-    Path: 'sledgehammer/e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
+    Path: 'sledgehammer/46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
   - Name: "control.sh"
     Path: "{{.Machine.Path}}/control.sh"
     Contents: |

--- a/content/params/package-repositories.yaml
+++ b/content/params/package-repositories.yaml
@@ -394,11 +394,11 @@ Schema:
         - contrib
         - main
         - non-free
-    - tag: sledgehammer/e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da
+    - tag: sledgehammer/46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f
       os:
-        - sledgehammer/e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da
+        - sledgehammer/46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f
       arch: amd64
-      url: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/"
+      url: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/"
       installSource: true
   type: "array"
   items:

--- a/sledgehammer-builder/bootenvs/build-sledgehammer.yaml
+++ b/sledgehammer-builder/bootenvs/build-sledgehammer.yaml
@@ -58,10 +58,10 @@ Templates:
     Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'
   - ID: "default-grub.tmpl"
     Name: "grub-secure"
-    Path: "sledgehammer/e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/grub.cfg-{{.Machine.HexAddress}}"
+    Path: "sledgehammer/46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/grub.cfg-{{.Machine.HexAddress}}"
   - ID: "default-grub.tmpl"
     Name: "grub-secure-mac"
-    Path: 'sledgehammer/e21d2b7f079dfcbd2952dbc79d09a793cd8fe7da/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
+    Path: 'sledgehammer/46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
   - Name: "sledgehammer.ks"
     Path: "{{.Machine.Path}}/sledgehammer.ks"
     Contents: |


### PR DESCRIPTION
This version of Sledgehammer no longer releases its DHCP lease when
transitioning from stage1 to stage2.  This was undocumented behaviour
that we don't really want (since we will want another lease a few
seconds later), and not all DHCP servers are good about giving you the
same IP address again when the IP was returned via RELEASE.