### PR TITLE
fix(sledgehammer): Bump sledgehammer to fix DHCP RELEASE issue.

### DIFF
--- a/content/bootenvs/discovery.yml
+++ b/content/bootenvs/discovery.yml
@@ -21,11 +21,11 @@ OS:
   Name: "sledgehammer"
   SupportedArchitectures:
     amd64:
-      IsoFile: "sledgehammer-c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1.amd64.tar"
-      IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1/sledgehammer-c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1.amd64.tar"
-      Kernel: "c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1/vmlinuz0"
+      IsoFile: "sledgehammer-46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f.amd64.tar"
+      IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/sledgehammer-46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f.amd64.tar"
+      Kernel: "46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/vmlinuz0"
       Initrds:
-        - "c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1/stage1.img"
+        - "46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/stage1.img"
       BootParams: >-
         rootflags=loop
         root=live:/sledgehammer.iso

--- a/content/bootenvs/sledgehammer.yml
+++ b/content/bootenvs/sledgehammer.yml
@@ -21,11 +21,11 @@ OS:
   Name: "sledgehammer"
   SupportedArchitectures:
     amd64:
-      IsoFile: "sledgehammer-c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1.amd64.tar"
-      IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1/sledgehammer-c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1.amd64.tar"
-      Kernel: "c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1/vmlinuz0"
+      IsoFile: "sledgehammer-46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f.amd64.tar"
+      IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/sledgehammer-46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f.amd64.tar"
+      Kernel: "46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/vmlinuz0"
       Initrds:
-        - "c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1/stage1.img"
+        - "46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/stage1.img"
       BootParams: >-
         rootflags=loop
         root=live:/sledgehammer.iso

--- a/content/params/package-repositories.yaml
+++ b/content/params/package-repositories.yaml
@@ -342,11 +342,11 @@ Schema:
         - contrib
         - main
         - non-free
-    - tag: sledgehammer/c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1
+    - tag: sledgehammer/46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f
       os:
-        - sledgehammer/c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1
+        - sledgehammer/46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f
       arch: amd64
-      url: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/c7305a9ba2c6b12351530c4a9021fd5e07ef1ce1/"
+      url: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/46e1a213a0e9b54e413369a0bcb22ed6a97cfc9f/"
       installSource: true
   type: "array"
   items:


### PR DESCRIPTION
This version of Sledgehammer no longer releases its DHCP lease when
transitioning from stage1 to stage2.  This was undocumented behaviour
that we don't really want (since we will want another lease a few
seconds later), and not all DHCP servers are good about giving you the
same IP address again when the IP was returned via RELEASE.