### PR TITLE
refactor(task-library): if missing, create the runner context

### DIFF
--- a/task-library/tasks/bootstrap-contexts.yaml
+++ b/task-library/tasks/bootstrap-contexts.yaml
@@ -36,6 +36,22 @@ ExtraClaims:
     specific: "*"
 Templates:
   - Contents: |-
+      {
+        "Name": "runner",
+        "Description": "Run DRPCLI in Docker Context",
+        "Documentation": "Very minimal container to run the DRPCLI as a starting or idle point for Machines. This provides a very low overhead system to start or complete workflows so that tasks can continue to execute even if the target machine is not available (or never exists).",
+        "Engine": "docker-context",
+        "Image": "digitalrebar-context-runner",
+        "Meta": {
+          "icon": "cube",
+          "color": "green",
+          "copyright": "RackN 2020",
+          "Dockerpull": "digitalrebar/context-runner"
+        }
+      }
+    Name: "runner-context"
+    Path: "runner.json"
+  - Contents: |-
       #!/bin/bash
       # RackN Copyright 2020
 
@@ -78,6 +94,14 @@ Templates:
       else
         echo "Plugin Missing, install..."
         drpcli catalog item install docker-context
+      fi
+
+      echo "Create Runner Context if missing (requires license)"
+      if drpcli contexts exists runner ; then
+        echo "  runner context exists, no action"
+      else
+        echo "  runner context missing, creating"
+        drpcli contexts create runner.json
       fi
 
       echo "Check which files are uploaded"


### PR DESCRIPTION
during docker context advanced bootstrap.
if an operator is installing the context plugin then they will want the runner context

we don't want to create this as static content because it will require a license and that will break the task-library for non-context users.