### PR TITLE
refactor(contents): add multiple scopes for access-keys

### DIFF
--- a/content/params/access-keys-global.yaml
+++ b/content/params/access-keys-global.yaml
@@ -1,10 +1,11 @@
 ---
-Name: "access-keys"
-Description: "A map of ssh public keys to install for the root user"
+Name: "access-keys-global"
+Description: "A map of global ssh public keys to install for the root user"
 Documentation: |
-  This map is used to put ssh public keys in place for the root user.
+  Supplements local access-keys by adding global keys (generall from the global profile)
+  Generally, `access-keys` are to be set for narrow use cases such as per machine.
 
-  For shared and global keys to include in addition, use access-keys-shared and access-keys-global
+  This map is used to put additional ssh public keys in place for the root user.
 
   The key of the map is a arbritary name and the value is the ssh
   public key for that name.

--- a/content/params/access-keys-shared.yaml
+++ b/content/params/access-keys-shared.yaml
@@ -1,0 +1,27 @@
+---
+Name: "access-keys-shared"
+Description: "A map of shared ssh public keys to install for the root user"
+Documentation: |
+  Supplements local access-keys by adding group or shared keys (generally from a shared profile)
+  Generally, `access-keys` are to be set for narrow use cases such as per machine.
+
+  This map is used to put ssh public keys in place for the root user.
+
+  The key of the map is a arbritary name and the value is the ssh
+  public key for that name.
+
+  Parameter YAML format:
+  
+    ::
+      access-keys:
+        greg:  ssh-rsa key
+        greg2:  ssh-rsa key
+Schema:
+  type: "object"
+  additionalProperties:
+    type: "string"
+Meta:
+  type: "credential"
+  icon: "key"
+  color: "blue"
+  title: "Digital Rebar Community Content"

--- a/content/stages/ssh-access.yaml
+++ b/content/stages/ssh-access.yaml
@@ -1,9 +1,13 @@
 ---
 Name: "ssh-access"
 Description: "Stage that installs SSH keys and configure SSH access policy"
+Documentation: |
+  Installs SSH keys onto systems
+  Pulls keys from multiple locations: access-keys, access-keys-shared, and access-keys-global
 Tasks:
   - "ssh-access"
 Meta:
+  type: "credential"
   icon: "key"
   color: "yellow"
   title: "Digital Rebar Community Content"

--- a/content/tasks/ssh-access.yaml
+++ b/content/tasks/ssh-access.yaml
@@ -1,14 +1,40 @@
 ---
 Description: "A task to put root ssh keys in place"
 Name: "ssh-access"
+Documentation: |
+  This task populates the root's authorized keys file
+  and makes sure that the sshd config for PermitRootLogin is populated.
+
+  Runs as part of a shell script for kickstart or net-post-install.
+  The template does nothing if access-keys, access-keys-sharedm AND access-keys-global are undefined
+
+  Optional Parameters:
+    access-keys
+    access-keys-shared
+    access-keys-global
+    access-ssh-root-mode
+  
+  Parameter YAML format:
+  
+    access-keys:
+      greg:  ssh-rsa key
+      greg2:  ssh-rsa key
+    access-ssh-root-mode: "without-password|yes|no|forced-commands-only"
+  
+  Defaults:
+    access-keys - empty
+    access-ssh-root-mode - defaults to "without-password" if unspecified
 OptionalParams:
   - "access-keys"
+  - "access-keys-shared"
+  - "access-keys-global"
   - "access-ssh-root-mode"
 Templates:
   - ID: "access-keys.sh.tmpl"
     Name: "Put access keys in place for root user"
     Path: ""
 Meta:
+  type: "credential"
   icon: "key"
   color: "blue"
   title: "Digital Rebar Community Content"

--- a/content/templates/access-keys.sh.tmpl
+++ b/content/templates/access-keys.sh.tmpl
@@ -21,14 +21,26 @@
 # access-ssh-root-mode - defaults to "without-password" if unspecified
 #
 
-{{if .ParamExists "access-keys"}}
+{{if or (.ParamExists "access-keys") (or (.ParamExists "access-keys-global") (.ParamExists "access-shared")) }}
 KEYS=/root/.ssh/authorized_keys
 TMP_KEYS=$(mktemp /tmp/authorized_keys.tmp.XXXXXXX)
 echo "Putting ssh access keys for root in place"
 mkdir -p /root/.ssh
 cat >>$KEYS <<EOFSSHACCESS
+{{if .ParamExists "access-keys" -}}
 {{range $key := .Param "access-keys" -}}
 {{$key}}
+{{end -}}
+{{end -}}
+{{if .ParamExists "access-keys-shared" -}}
+{{range $key := .Param "access-keys-shared" -}}
+{{$key}}
+{{end -}}
+{{end -}}
+{{if .ParamExists "access-keys-global" -}}
+{{range $key := .Param "access-keys-global" -}}
+{{$key}}
+{{end -}}
 {{end -}}
 EOFSSHACCESS
 # if the we are called multiple times we get duplicate keys, lets fix that


### PR DESCRIPTION
for pooling, operators of machines will want to add their own access-keys per machine or profile.
this change allows operators to have global and profile level ssh-keys that will ALSO work
to provide access to machines.

By design, this adds new levels.  It does NOT remove or change access-keys.