### PR TITLE
task-library: allow download-tools to use proxy

### DIFF
--- a/content/params/no-proxy.yaml
+++ b/content/params/no-proxy.yaml
@@ -1,0 +1,20 @@
+---
+Name: "no-proxy"
+Description: "List of items for NO_PROXY env var"
+Documentation: |
+  This is an array of locations that are exempt from the Proxy configured via
+  the proxy-servers parameter.
+
+Schema:
+  default:
+    - "10.0.0.0/8"
+    - "192.168.0.0/16"
+    - "172.16.0.0/16"
+  type: "array"
+  items:
+    type: "string"
+
+Meta:
+  icon: "browser"
+  color: "blue"
+  title: "Digital Rebar Community Content"

--- a/task-library/templates/download-tools.tmpl
+++ b/task-library/templates/download-tools.tmpl
@@ -32,5 +32,50 @@ with_backoff() {
 }
 
 download() {
+  {{ if .ParamExists "proxy-servers" -}}
+  PROXY="{{ index (.Param "proxy-servers") 0 }}"
+
+  if [[ -n "$PROXY" && "$PROXY" != "nil" ]]
+  then
+    if [ -z ${http_proxy+x} ]; then
+      local old_http_proxy="$http_proxy"
+    fi
+    if [ -z ${https_proxy+x} ]; then
+      local old_https_proxy="$https_proxy"
+    fi
+    export http_proxy="$PROXY"
+    export https_proxy="$PROXY"
+    local we_set_proxy=1
+  fi
+  {{ end -}}
+
+{{ if .ParamExists "no-proxy" -}}
+  if [ -z ${no_proxy+x} ]; then
+    local old_no_proxy="$no_proxy"
+  fi
+  export no_proxy="{{ .Param "no-proxy" | join "," }}"
+  local we_set_no_proxy=1
+{{ end }}
+
   with_backoff curl --connect-timeout 10 --max-time 360 --retry 1 --retry-delay 1 --retry-max-time 40 -sS "$@"
+
+  if [ -z ${we_set_proxy+x} ]; then
+    unset http_proxy
+    unset https_proxy
+
+    if [ -z ${old_http_proxy+x} ]; then
+      export http_proxy="$old_http_proxy"
+    fi
+    if [ -z ${old_https_proxy+x} ]; then
+      export https_proxy="$old_https_proxy"
+    fi
+  fi
+
+  if [ -z ${we_set_no_proxy+x} ]; then
+    unset no_proxy
+
+    if [ -z ${old_no_proxy+x} ]; then
+      export no_proxy="$old_no_proxy"
+    fi
+  fi
 }


### PR DESCRIPTION
The `download()` function from download-tools is commonly use to download stuff in a multitude of places.
Currently, it would use the proxy if the environment has the HTTP_PROXY-style variables exported. However, those are frequently overridden and notoriously hard to keep track of. We've noticed that it's much cleaner to augment the `download()` function and promote its usage, rather then copy-paste the boilerplate HTTP_PROXY exports and tweak the wget/curl invocations all over the place.

This code aims to isolate its changes to the environment and undo them right after the `download()` function finishes. Three env vars (`http_proxy`, `https_proxy` and `no_proxy`) are checked, memorized and reverted after `download()` finishes.

This code reuses the already existing parameter called `proxy-servers` and defines a new one called `no-proxy`.

A potential backwards compatibility problem is when existing code starts using proxy where it's not intended to. The coupling of this feature with the pre-existing `proxy-servers` Param could be considered limiting in certain scenarios.