### PR TITLE
krib: docker/apply-http-proxy param to install proxy env vars

### DIFF
--- a/krib/params/docker-apply-http-proxy.yaml
+++ b/krib/params/docker-apply-http-proxy.yaml
@@ -1,0 +1,12 @@
+---
+Name: "docker/apply-http-proxy"
+Description: "Apply HTTP/HTTPS proxy from to the Docker daemon"
+Documentation: |
+  "Apply HTTP/HTTPS proxy from to the Docker daemon"
+Schema:
+  type: "boolean"
+  default: false
+Meta:
+  color: "blue"
+  icon: "boxes"
+  title: "Community Content"

--- a/krib/templates/docker-install.sh.tmpl
+++ b/krib/templates/docker-install.sh.tmpl
@@ -44,6 +44,14 @@ cat /etc/docker/daemon.json
 echo "Skipping custom etc/docker/daemon.json: No docker/daemon defined"
 {{end}}
 
+{{ if .Param "docker/apply-http-proxy" }}
+mkdir -p /etc/systemd/system/docker.service.d/
+cat <<EOF >/etc/systemd/system/docker.service.d/proxy.conf
+[Service]
+Environment="HTTP_PROXY={{ index (.Param "proxy-servers") 0 }}" "HTTPS_PROXY={{ index (.Param "proxy-servers") 0 }}"{{if .ParamExists "no-proxy" }} "NO_PROXY={{ .Param "no-proxy" | join "," }}"{{ end }}
+EOF
+{{ end }}
+
 echo "Starting Docker Service"
 service docker enable
 service docker start


### PR DESCRIPTION
Applies HTTP_PROXY and NO_PROXY from proxy-servers and no-proxy env vars permanently to the Docker engine via systemd unit file.