### PR TITLE
krib: move to use download() and apply proxy when necessary

### DIFF
--- a/krib/templates/krib-config.sh.tmpl
+++ b/krib/templates/krib-config.sh.tmpl
@@ -5,6 +5,10 @@ set -e
 # Get access and who we are.
 {{ template "setup.tmpl" .}}
 
+{{ template "download-tools.tmpl" .}}
+
+{{ template "krib-runtime-proxy.tmpl" .}}
+
 {{ if .ParamExists "krib/cluster-profile" -}}
 CLUSTER_PROFILE={{ .Param "krib/cluster-profile" }}
 PROFILE_TOKEN={{ .GenerateProfileToken (.Param "krib/cluster-profile") 7200 }}
@@ -100,7 +104,7 @@ if [[ $MASTER_INDEX != notme ]] ; then
     echo "# externally defined template specified by 'krib/kubeadm-cfg'" > /tmp/kubeadm.cfg
     echo "# source: '$KC'" >> /tmp/kubeadm.cfg
     T=$(mktemp /tmp/kube.cfg.XXXXXXXXX)
-    curl -gfsSL -o $T $KC
+    download -gfsSL -o $T $KC
     cat $T >> /tmp/kubeadm.cfg && rm -f $T
     {{ end -}}
 
@@ -145,7 +149,7 @@ if [[ $MASTER_INDEX != notme ]] ; then
           echo -e "[keyfile]\nunmanaged-devices=interface-name:cali*;interface-name:tunl*" > /etc/NetworkManager/conf.d/calico.conf
         fi
 
-        curl -gfsSL {{ .Param "provider/calico-config" }} > /tmp/calico.yaml
+        download -gfsSL {{ .Param "provider/calico-config" }} > /tmp/calico.yaml
         # This next line assures that in the event of multiple NICs in the node, the NIC able to reach 1.1.1.1 will be chosen
         # This can optionally be changed to a regex or even an explicit NIC name
         sed -i "/autodetect\"/a\            - name: IP_AUTODETECTION_METHOD\n              value: \"can-reach=1.1.1.1\"" /tmp/calico.yaml
@@ -178,7 +182,7 @@ if [[ $MASTER_INDEX != notme ]] ; then
         ;;
       flannel)
         echo "Starting flannel networking..."
-        curl -gfsSL {{ .Param "provider/flannel-config" }} | kubectl apply -f -
+        download -gfsSL {{ .Param "provider/flannel-config" }} | kubectl apply -f -
         ;;
       weave)
         echo "Starting weave networking..."

--- a/krib/templates/krib-dashboard.sh.tmpl
+++ b/krib/templates/krib-dashboard.sh.tmpl
@@ -5,6 +5,10 @@ set -e
 # Get access and who we are.
 {{template "setup.tmpl" .}}
 
+{{ template "download-tools.tmpl" .}}
+
+{{ template "krib-runtime-proxy.tmpl" .}}
+
 {{if .ParamExists "krib/cluster-profile" -}}
 CLUSTER_PROFILE={{.Param "krib/cluster-profile"}}
 PROFILE_TOKEN={{.GenerateProfileToken (.Param "krib/cluster-profile") 7200}}
@@ -34,7 +38,7 @@ if [[ $MASTER_INDEX == 0 ]] ; then
     install wget
   fi
 
-  wget -O /tmp/kubernetes-dashboard.yaml {{ .Param "krib/dashboard-config" }}
+  download -o /tmp/kubernetes-dashboard.yaml {{ .Param "krib/dashboard-config" }}
 
   OPWD=$(pwd)
   cd /tmp

--- a/krib/templates/krib-helm-init.sh.tmpl
+++ b/krib/templates/krib-helm-init.sh.tmpl
@@ -5,6 +5,11 @@ set -e
 # Get access and who we are.
 {{template "setup.tmpl" .}}
 
+{{ template "download-tools.tmpl" .}}
+
+# get_helm.sh script needs proxy exported
+{{ template "krib-runtime-proxy.tmpl" .}}
+
 echo "Configure helm on the master (skip for minions)..."
 
 {{if .ParamExists "krib/cluster-profile" -}}
@@ -49,6 +54,7 @@ if [[ $MASTER_INDEX != notme ]] ; then
       {{ if eq $helmversion "latest" -}}
       # curl has exit code 23... meh
       set +e
+      # FIXME: this will be rate limited!
       HELM_VERSION=$(curl -skX GET "https://api.github.com/repos/helm/helm/releases/latest" | awk '/tag_name/{print $4;exit}' FS='[""]')
       set -e
       {{ else -}}

--- a/krib/templates/krib-ingress-nginx-tillerless.sh.tmpl
+++ b/krib/templates/krib-ingress-nginx-tillerless.sh.tmpl
@@ -5,6 +5,8 @@ set -e
 # Get access and who we are.
 {{template "setup.tmpl" .}}
 
+{{ template "download-tools.tmpl" .}}
+
 {{if .ParamExists "krib/cluster-profile" -}}
 CLUSTER_PROFILE={{.Param "krib/cluster-profile"}}
 PROFILE_TOKEN={{.GenerateProfileToken (.Param "krib/cluster-profile") 7200}}
@@ -18,13 +20,10 @@ MASTER_INDEX=$(find_me $KRIB_MASTERS_PARAM "Uuid" $RS_UUID)
 
 if [[ $MASTER_INDEX == 0 ]] ; then
   export KUBECONFIG=/etc/kubernetes/admin.conf
-  if ! which wget ; then
-    install wget
-  fi
 
   # Get manifests, and duplicate service manifest for optional additional external ingress
-  wget -O /tmp/nginx-ingress-mandatory.yaml {{ .Param "krib/ingress-nginx-mandatory" }}
-  wget -O /tmp/nginx-ingress-service.yaml {{ .Param "krib/ingress-nginx-config" }}
+  download -o /tmp/nginx-ingress-mandatory.yaml {{ .Param "krib/ingress-nginx-mandatory" }}
+  download -o /tmp/nginx-ingress-service.yaml {{ .Param "krib/ingress-nginx-config" }}
 
   # Replace references to "master" with the user-specified tag (if user has left the default at "master" this will have no effect)
   sed -i 's/nginx-ingress-controller:.*/nginx-ingress-controller:{{ .Param "krib/nginx-ingress-version" }}/' /tmp/nginx-ingress-mandatory.yaml
@@ -127,7 +126,7 @@ if [[ $MASTER_INDEX == 0 ]] ; then
   # now cert-manager
 {{if .ParamExists "certmanager/email"}}
   echo "Start cert-manager install"
-  wget -O /tmp/certmanager-manifests.yaml {{ .Param "certmanager/manifests" }}
+  download -o /tmp/certmanager-manifests.yaml {{ .Param "certmanager/manifests" }}
 
   echo "Preparing namespace and disabling validation.."
   kubectl create namespace cert-manager || echo "Failed to create namespace, it probably already exists. Proceeding..."

--- a/krib/templates/krib-ingress-nginx.sh.tmpl
+++ b/krib/templates/krib-ingress-nginx.sh.tmpl
@@ -5,6 +5,9 @@ set -e
 # Get access and who we are.
 {{template "setup.tmpl" .}}
 
+# helm install needs proxy
+{{ template "krib-runtime-proxy.tmpl" .}}
+
 echo "Run helm install on the master (skip for minions)..."
 
 {{if .ParamExists "krib/cluster-profile" -}}

--- a/krib/templates/krib-metallb.sh.tmpl
+++ b/krib/templates/krib-metallb.sh.tmpl
@@ -5,6 +5,8 @@ set -e
 # Get access and who we are.
 {{template "setup.tmpl" .}}
 
+{{ template "download-tools.tmpl" .}}
+
 # these need to be before krib-lib template
 {{if .ParamExists "krib/cluster-profile" -}}
 CLUSTER_PROFILE={{.Param "krib/cluster-profile"}}
@@ -21,11 +23,10 @@ MASTER_INDEX=$(find_me $KRIB_MASTERS_PARAM "Uuid" $RS_UUID)
 
 if [[ $MASTER_INDEX == 0 ]] ; then
   export KUBECONFIG=/etc/kubernetes/admin.conf
-  if ! which wget ; then
-    install wget
-  fi
 
-  wget -O /tmp/metallb.yaml {{ .Param "krib/metallb-config" }}
+  download -o /tmp/metallb-namespace.yaml https://raw.githubusercontent.com/metallb/metallb/{{ .Param "krib/metallb-version" }}/manifests/namespace.yaml
+  download -o /tmp/metallb.yaml https://raw.githubusercontent.com/metallb/metallb/{{ .Param "krib/metallb-version" }}/manifests/metallb.yaml
+
 {{$port := .Param "metallb/monitoring-port"}}
   sed -i 's/prometheus.io\/port: "7472"/prometheus.io\/port: "{{$port}}"/' /tmp/metallb.yaml
   sed -i 's/- --port=7472/- --port={{$port}}/' /tmp/metallb.yaml
@@ -48,6 +49,8 @@ if [[ $MASTER_INDEX == 0 ]] ; then
   if [[ -n $(kubectl get namespaces | grep -w metallb-system) ]] ; then
     echo "Purging existing metallb install"
     kubectl delete -f /tmp/metallb.yaml
+  else
+    kubectl apply -f /tmp/metallb-namespace.yaml
   fi
 
 {{$l2_ip_range := .Param "metallb/l2-ip-range"}}
@@ -80,11 +83,9 @@ MASTER_INDEX=$(find_me $KRIB_MASTERS_PARAM "Uuid" $RS_UUID)
 
 if [[ $MASTER_INDEX == 0 ]] ; then
   export KUBECONFIG=/etc/kubernetes/admin.conf
-  if ! which wget ; then
-    install wget
-  fi
 
-  wget -O /tmp/metallb.yaml https://github.com/danderson/metallb/raw/{{ .Param "krib/metallb-version" }}/manifests/metallb.yaml
+  download -o /tmp/metallb-namespace.yaml https://raw.githubusercontent.com/metallb/metallb/{{ .Param "krib/metallb-version" }}/manifests/namespace.yaml
+  download -o /tmp/metallb.yaml https://raw.githubusercontent.com/metallb/metallb/{{ .Param "krib/metallb-version" }}/manifests/metallb.yaml
 
   # Replace references to "master" with the user-specified tag (if user has left the default at "master" this will have no effect)
   sed -i 's/speaker:master/speaker:{{ .Param "krib/metallb-version" }}/' /tmp/metallb.yaml
@@ -112,6 +113,8 @@ if [[ $MASTER_INDEX == 0 ]] ; then
   if [[ -n $(kubectl get namespaces | grep -w metallb-system) ]] ; then
     echo "Purging existing metallb install"
     kubectl delete -f /tmp/metallb.yaml
+  else
+    kubectl apply -f /tmp/metallb-namespace.yaml
   fi
 
 {{$l3_ip_range := .Param "metallb/l3-ip-range"}}

--- a/krib/templates/krib-runtime-install.sh.tmpl
+++ b/krib/templates/krib-runtime-install.sh.tmpl
@@ -2,6 +2,8 @@
 
 {{template "setup.tmpl" .}}
 
+{{ template "set-proxy-servers.sh.tmpl" .}}
+
 cr={{.Param "krib/container-runtime"}}
 case $cr in
   docker) tasks="docker-install";;

--- a/krib/templates/krib-runtime-proxy.tmpl
+++ b/krib/templates/krib-runtime-proxy.tmpl
@@ -1,0 +1,7 @@
+{{ if .ParamExists "proxy-servers" -}}
+export http_proxy="{{ index (.Param "proxy-servers") 0 }}"
+export https_proxy="{{ index (.Param "proxy-servers") 0 }}"
+{{ end -}}
+{{ if .ParamExists "no-proxy" -}}
+export no_proxy="{{ .Param "no-proxy" | join "," }}"
+{{ end -}}


### PR DESCRIPTION
Now the installation depends more on the task-library-provided download() function, which benefits from #552.
Also, MetalLB manifests are updated per newest installation instructions.