### PR TITLE
enhance(drp-community-content): Add Machine name set from 'hostname' Param

### DIFF
--- a/content/stages/set-machine-name-from-hostname.yaml
+++ b/content/stages/set-machine-name-from-hostname.yaml
@@ -1,0 +1,21 @@
+---
+Name: "set-machine-name-from-hostname"
+Description: "A stage to set Machine.Name from the Param 'hostname'."
+Documentation: |
+  This Stage sets the Machine Object ``.Machine.Name`` value to the current
+  Machine objects Parameter named ``hostname``.  This is often used in
+  discovery stages, where the Classify functions may set a Machines Param
+  ``hostname`` to a value based on the classify actions.
+
+  This Stage should be run **after** any Classify action Stages which perform
+  ``add_parameter hostname BOB`` actions - or similar Stages that set the
+  Machine objects ``hostname`` Param.
+
+Tasks:
+  - "set-machine-name-from-hostname"
+  - "set-hostname"
+Meta:
+  icon: "key"
+  color: "blue"
+  title: "Digital Rebar Community Content"
+  feature-flags: "sane-exit-codes"

--- a/content/tasks/set-hostname.yaml
+++ b/content/tasks/set-hostname.yaml
@@ -5,6 +5,8 @@ Templates:
   - ID: "set-hostname.sh.tmpl"
     Name: "Set the hostname on the machine"
     Path: ""
+    Meta:
+      OS: "linux"
 Meta:
   type: "id"
   icon: "key"

--- a/content/tasks/set-machine-name-from-hostname.yaml
+++ b/content/tasks/set-machine-name-from-hostname.yaml
@@ -1,0 +1,24 @@
+---
+Name: "set-machine-name-from-hostname"
+Description: "A task to set Machine.Name from the Param 'hostname'."
+Documentation: |
+  This Task sets the Machine Object ``.Macine.Name`` value to the current
+  Machine objects Parameter named ``hostname``.  This is often used in
+  discovery stages, where the Classify functions may set a Machines Param
+  ``hostname`` to a value based on the classify actions.
+
+  This Task should be run **after** any Classify action Stages which perform
+  ``add_parameter hostname BOB`` actions - or similar Tasks that set the
+  Machine objects ``hostname`` Param.
+
+Templates:
+  - ID: "set-machine-name-from-hostname.sh.tmpl"
+    Name: "set-machine-name-from-hostname"
+    Path: ""
+    Meta:
+      OS: "linux"
+Meta:
+  icon: "key"
+  color: "blue"
+  title: "Digital Rebar Community Content"
+  feature-flags: "sane-exit-codes"

--- a/content/templates/set-hostname.sh.tmpl
+++ b/content/templates/set-hostname.sh.tmpl
@@ -1,4 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# set the Machines hostname in the Operating System (linux, esxi)
+
+# set to 'sh' type for ESXi compatibility
+
 #
 # This template populates the HOSTNAME of the system in various places.
 # It also exports the HOSTNAME variable for use by other templates.
@@ -13,12 +17,24 @@
 # Defaults:
 #
 HOSTNAME="{{.Machine.Name}}"
+CURRENT=$(hostname)
 
-if [ -f /etc/sysconfig/network ] ; then
-    sed -i -e "s/HOSTNAME=.*/HOSTNAME=${HOSTNAME}/" /etc/sysconfig/network
+if [[ "$HOSTNAME" == "$CURRENT" ]]
+then
+    echo ">>> Hostname already matches requested name, no changes made"
+    exit 0
+else
+    echo ">>> Attempting to set OS hostname to $HOSTNAME"
+    if [ -f /etc/sysconfig/network ] ; then
+        sed -i -e "s/HOSTNAME=.*/HOSTNAME=${HOSTNAME}/" /etc/sysconfig/network
+    fi
+    echo "${HOSTNAME#*.}" >/etc/domainname
+    echo "$HOSTNAME" >/etc/hostname
+    hostname "$HOSTNAME"
+    echo ">>> 'hostname' now reports:"
+    hostname
+    export HOSTNAME
 fi
-echo "${HOSTNAME#*.}" >/etc/domainname
-echo "$HOSTNAME" >/etc/hostname
-hostname "$HOSTNAME"
-export HOSTNAME
+
+exit 0
 

--- a/content/templates/set-machine-name-from-hostname.sh.tmpl
+++ b/content/templates/set-machine-name-from-hostname.sh.tmpl
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+# set machine object Name based on 'hostname'
+
+# set to 'sh' type for ESXi compatibility
+
+{{ template "setup.tmpl" . }}
+
+NAME=$(drpcli machines get $RS_UUID param hostname | jq -r '.')
+CURRENT={{.Machine.Name}}
+
+if [[ "$NAME" == "$CURRENT" ]]
+then
+  echo ">>> My current name ('$CURRENT') matches requested hostname ('$NAME'), nothing done."
+  exit 0
+fi
+
+if [[ -n "$NAME" && "$NAME" != "null" ]]
+then
+  drpcli machines exists Name:$NAME 2> /dev/null && OK=0 || OK=1
+  if (( $OK ))
+  then
+    drpcli machines update $RS_UUID "{\"Name\":\"$NAME\"}" | jq -r '.Name'
+  else
+    echo "FATAL: A Machine with name '$NAME' exists already, can't rename Machine (UUID: $RS_UUID)"
+    exit 1
+  fi
+else
+  echo ">>> Param 'hostname' not found on Machine ('$RS_UUID') - not changing name."
+fi
+
+exit 0


### PR DESCRIPTION
- Sets the Machine object `Name` to value of the Param `hostname` if set
- Modifies the `set-hostname` OS set templates to test if the names match, then do nothing
- Useful for Classify to set parameter `hostname` to a value, then this Stage subsequently can modify the Machine Object to match