### PR TITLE
fix(vmware-lib): Change the container context to match dockerhub images

### DIFF
--- a/vmware-lib/content/contexts/govc.yaml
+++ b/vmware-lib/content/contexts/govc.yaml
@@ -3,10 +3,15 @@ Name: "govc"
 Description: "govc context using container image digitalrebar-govc"
 Documentation: |
   Executes the command referenced in the ``govc/command`` Param, in the
-  container context ``digitalrebar-govc``.
+  container context ``digitalrebar/govc``.
+
+  You can pull the container image from docker hub for both Docker and
+  Podman environments, eg:
+
+    * ``docker pull digitalrebar/govc``
 
 Engine: "docker-context"
-Image: "digitalrebar-govc"
+Image: "digitalrebar/govc"
 Meta:
   color: blue
   icon: terminal

--- a/vmware-lib/content/contexts/vcsa-deploy.yaml
+++ b/vmware-lib/content/contexts/vcsa-deploy.yaml
@@ -3,10 +3,15 @@ Name: "vcsa-deploy"
 Description: "vcsa-deploy context using image digitalrebar-vcsa-deploy"
 Documentation: |
   Context that executes the command specified in ``vcsa-deploy/command`` Param,
-  in container context ``digitalrebar-vcsa-deploy``.
+  in container context ``digitalrebar/vcsa-deploy``.
+
+  You can pull the container image from docker hub for both Docker and
+  Podman environments, eg:
+
+    * ``docker pull digitalrebar/vcsa-deploy``
 
 Engine: "docker-context"
-Image: "digitalrebar-vcsa-deploy"
+Image: "digitalrebar/vcsa-deploy"
 Meta:
   color: orange
   icon: terminal


### PR DESCRIPTION
We now publish containers in dockerhub, however, the new container name doesn't match the original context Image name.  This fixes the container name to match the container image in dockerhub.