### PR TITLE
bug(cloud-wrapper): needed new line in loop

### DIFF
--- a/cloud-wrappers/templates/cloud-provision-reference.tf.tmpl
+++ b/cloud-wrappers/templates/cloud-provision-reference.tf.tmpl
@@ -84,7 +84,7 @@ resource "aws_instance" "drp_node" {
 		Name 		= "{{ .Machine.Name }}"
 		DRP_ID		= "{{ .Machine.Uuid }}"
 		Provisoner	= "DigitalRebar"
-	{{ range $i, $p := .Machine.Profiles -}}
+	{{ range $i, $p := .Machine.Profiles }}
 		{{$p}}		= "DRP-Profile{{$i}}"
 	{{- end }} }
 	{{ if .ParamExists "rsa/key-public" -}}


### PR DESCRIPTION
in the range loop, the new line was required to keep the items from stringing together.
terraform syntax required each pair on a new line