### PR TITLE
refactor(task-library): change from docker to podman in context bootstrap

### DIFF
--- a/task-library/params/cluster-profile.yaml
+++ b/task-library/params/cluster-profile.yaml
@@ -8,4 +8,5 @@ Meta:
   color: "blue"
   icon: "object group outline"
   title: "RackN Content"
+  route: "profiles"
   copyright: "RackN 2019"

--- a/task-library/tasks/bootstrap-contexts.yaml
+++ b/task-library/tasks/bootstrap-contexts.yaml
@@ -7,18 +7,19 @@ Documentation: |
   This task is idempotent.
 
   IMPORANT NOTES: 
-  * Stage installs Docker and the Docker Plugin even if you do not have Docker-Contexts defined
-  * Contexts are a licensed feature (the stage works, but Contexts will not)
+  * Stage installs Podman and the Docker-Context Plugin even if you do not have Docker-Contexts defined
+  * Contexts are a licensed feature (the stage will abort if no license is exists)
 
-  1. Installs Containerd and Docker-CE on DRP Host
+  1. Installs Podman on DRP Host
   1. Installs the Docker-Context from Catalog
+  1. Creates the runner context if missing
   1. Attempts to build & upload images for all Docker-Contexts
-  1. Initializes Docker for all Contexts
+  1. Initializes Podman for all Contexts
 
-  Docker build files are discovered in the following precidence order:
-  1. using Docker Buildfile from files/contexts/docker-build/[contextname]
+  Podman build files are discovered in the following precidence order:
+  1. using Container Buildfile from files/contexts/docker-build/[contextname]
   1. using URL from Meta.Imagepull
-  1. using Docker Buildfile downloaded Context Meta.Dockerfile
+  1. using Container  Buildfile downloaded Context Meta.Dockerfile
   1. using Docker Image from Context Meta.Dockerpull
   Once downloaded and built, they are uploaded to the correct files location
 ExtraClaims:
@@ -34,6 +35,9 @@ ExtraClaims:
   - scope: "plugin_providers"
     action: "*"
     specific: "*"
+  - scope: "contents"
+    action: "get"
+    specific: "rackn-license"
 Templates:
   - Contents: |-
       {
@@ -58,42 +62,41 @@ Templates:
       set -e
       {{template "setup.tmpl" .}}
 
+      if drpcli contents exists rackn-license ; then
+        echo "license installed, no action"
+      else
+        echo "SKIPPING due to missing RackN license"
+        exit 0
+      fi
+
       if [[ "$(drpcli contexts list Engine=docker-context | jq length)" == "0" ]]; then
         echo "No Docker Contexts"
       fi
 
-      if ! which docker ; then
+      if ! which podman ; then
         FAMILY=$(grep "^ID=" /etc/os-release | tr -d '"' | cut -d '=' -f 2)
-        echo "Installing Containerd"
+        echo "Installing Podman"
         case $FAMILY in
-          redhat|centos) yum install -y dnf; dnf install -y https://download.docker.com/linux/centos/7/x86_64/stable/Packages/containerd.io-1.2.6-3.3.el7.x86_64.rpm ;;
-          debian|ubuntu) apt install -y containerd ;;
+          redhat|centos) yum install -y dnf; dnf install -y podman ;;
+          debian|ubuntu) . /etc/os-release
+            echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+            curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+            sudo apt-get update -qq; sudo apt-get -qq -y install podman ;;
           *) >&2 echo "Unsupported package manager family '$FAMILY'."
              exit 1 ;;
         esac
-        echo "Installing Docker-CE"      
-        case $FAMILY in
-          redhat|centos) dnf install -y https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-cli-19.03.9-3.el7.x86_64.rpm https://download.docker.com/linux/centos/7/x86_64/stable/Packages/docker-ce-19.03.9-3.el7.x86_64.rpm ;;
-          debian|ubuntu) apt install -y docker.io ;;
-          *) >&2 echo "Unsupported package manager family '$FAMILY'."
-             exit 1 ;;
-        esac
-        sudo systemctl enable --now docker
-        sudo usermod -aG docker $USER
       fi
 
-      echo "Starting Docker Service"
-      systemctl daemon-reload
-      systemctl restart docker
-
-      echo "Docker installed successfully"
+      echo "Podman installed successfully"
 
       echo "Install Docker-Context"
-      if drpcli plugins exists docker-context; then
-        echo "Plugin Exists, skipping"
+      pv="stable"
+      if drpcli plugin_providers exists docker-context; then
+        pv="$(drpcli plugin_providers show docker-context | jq .Version -r)"
+        echo "Plugin Exists at version $pv"
       else
-        echo "Plugin Missing, install..."
-        drpcli catalog item install docker-context
+        echo "Plugin (re)install to version $pv"
+        drpcli catalog item install docker-context --version=$pv
       fi
 
       echo "Create Runner Context if missing (requires license)"
@@ -104,10 +107,10 @@ Templates:
         drpcli contexts create runner.json
       fi
 
-      echo "Check which files are uploaded"
+      echo "Check which files are uploaded (error = none)"
       drpcli files list contexts/docker-context || true
 
-      echo "Building the docker images if not already built."
+      echo "Building the container images if not already built."
       cp $(which drpcli) drpcli
       raw=$(drpcli contexts list Engine=docker-context)
       contexts=$(jq -r ".[].Name" <<< "${raw}")
@@ -131,27 +134,28 @@ Templates:
             drpcli files upload $imagepull as "contexts/docker-context/$image"
           else
             echo "  Building Container --tag=$image --file=$context-dockerfile"
+            echo "Installing Buildah"
             dockerbuild=$(drpcli files exists "contexts/docker-build/$context" || true)
             dockerpull=$(jq -r ".[$i].Meta.Dockerpull" <<< "${raw}")
             dockerfile=$(jq -r ".[$i].Meta.Dockerfile" <<< "${raw}")
             if [[ "$dockerbuild" != "" ]]; then
               echo "    pulling dockerfile from contexts/docker-build/$context"
               drpcli files download contexts/docker-build/$context > $context-dockerfile
-              docker build --tag=$image --file="$context-dockerfile" .
+              podman build --tag=$image --file="$context-dockerfile" .
             elif [[ "$dockerfile" != "null" ]]; then
-              echo "    pulling dockerfile from $dockerfile"
+              echo "    pulling docker build from $dockerfile"
               curl -fsSL $dockerfile -o $context-dockerfile
-              docker build --tag=$image --file="$context-dockerfile" .
+              podman build --tag=$image --file="$context-dockerfile" .
             elif [[ "$dockerpull" != "null" ]]; then
-              echo "    pulling docker image from $dockerpull"
-              docker pull $dockerpull
+              echo "    pulling container image from $dockerpull"
+              podman pull $dockerpull
               echo "    tagging $dockerpull as $image"
-              docker tag $dockerpull $image
+              podman tag $dockerpull $image
             else
-              echo "!! Stopping context-bootstrap - missing Docker image for $context"
+              echo "!! Stopping context-bootstrap - missing container image for $context"
               exit 1
             fi
-            docker save $image > /root/$context.tar
+            podman save $image > /root/$context.tar
             gzip /root/$context.tar
             echo "  Uploading Container from /root/$context.tar.gz"
             drpcli files upload /root/$context.tar.gz as "contexts/docker-context/$image"
@@ -170,9 +174,14 @@ Templates:
       for context in $contexts; do
         image=$(jq -r ".[$i].Image" <<< "${raw}")
         echo "Installing Container for $context named from $image"
-        drpcli plugins runaction docker-context imageUpload \
-          context/image-name ${image} \
-          context/image-path files/contexts/docker-context/${image}
+        if drpcli plugins runaction docker-context imageExists context/image-name ${image} ; then
+          echo "${image} installed, no upload needed"
+        else
+          echo "${image} missing, download"
+          drpcli plugins runaction docker-context imageUpload \
+            context/image-name ${image} \
+            context/image-path files/contexts/docker-context/${image}
+        fi
         i=$(($i + 1))
       done
 


### PR DESCRIPTION
always planned to switch to podman, but docker was having networking issues w/ Centos8 nftables so I accelerated the timetable and pulled it out.

relatively minimal updates (except now it works better)