### PR TITLE
fix(Sledgehammer): Add the mtd subsystem drivers to stage1.

### DIFF
--- a/sledgehammer-builder/tasks/sledgehammer-create-stage-1.yaml
+++ b/sledgehammer-builder/tasks/sledgehammer-create-stage-1.yaml
@@ -35,7 +35,6 @@ Templates:
           drivers/md \
           drivers/mfd \
           drivers/mmc \
-          drivers/mtd \
           drivers/net/can \
           drivers/net/wireless \
           drivers/nvme \


### PR DESCRIPTION
Certain custom nic drivers require it to load, and it is small and
otherwise harmless.