### PR TITLE
feat(content): Debian 10 Support

### DIFF
--- a/content/bootenvs/debian-10.yml
+++ b/content/bootenvs/debian-10.yml
@@ -1,45 +1,42 @@
 ---
-Name: "debian-9-install"
-Description: "Debian 9 install BootEnv"
+Name: "debian-10-install"
+Description: "Debian 10 install BootEnv"
 Documentation: |
-  This BootEnv installs Debian 9 via the "mini" ISO file.
+  This BootEnv installs Debian 10 via netinst ISO file.
 Meta:
   feature-flags: "change-stage-v2"
   icon: "linux"
   color: "black"
   title: "Digital Rebar Community Content"
 OS:
-  Name: "debian-9"
+  Name: "debian-10"
   Family: "debian"
-  IsoFile: "debian-9.12.0-amd64-netinst.iso"
-  IsoSha256: "3c47f64693435b0b42b6ef59624edbffa7c4004317d9f9a3f04ecb6a4e30f191"
-  IsoUrl: "https://cdimage.debian.org/cdimage/archive/9.12.0/amd64/iso-cd/debian-9.12.0-amd64-netinst.iso"
-  Version: "9"
-Initrds:
-  - "initrd.gz"
-Kernel: "linux"
-BootParams: >-
-  priority=critical
-  console-tools/archs=at
-  console-setup/charmap=UTF-8
-  console-keymaps-at/keymap=us
-  popularity-contest/participate=false
-  passwd/root-login=false
-  keyboard-configuration/xkb-keymap=us
-  netcfg/get_domain=unassigned-domain
-  console-setup/ask_detect=false
-  debian-installer/locale=en_US.utf8
-  console-setup/layoutcode=us
-  keyboard-configuration/layoutcode=us
-  netcfg/dhcp_timeout=120
-  netcfg/choose_interface=auto
-  url={{.Machine.Url}}/seed
-  netcfg/get_hostname={{.Machine.Name}}
-  root=/dev/ram
-  rw
-  quiet
-  {{.Param "kernel-options"}}
-  {{.Param "kernel-console"}}
+  Version: "10"
+  SupportedArchitectures:
+    amd64:
+      Initrds:
+        - "initrd.gz"
+      Kernel: "linux"
+      BootParams: >-
+        auto
+        preseed/url={{.Machine.Url}}/seed
+        netcfg/enable=true
+        hostname={{.Machine.ShortName}}
+        console-setup/charmap=UTF-8
+        console-keymaps-at/keymap=us
+        popularity-contest/participate=false
+        passwd/root-login=false
+        keyboard-configuration/xkb-keymap=us
+        netcfg/get_domain=unassigned-domain
+        console-setup/ask_detect=false
+        debian-installer/locale=en_US.utf8
+        console-setup/layoutcode=us
+        keyboard-configuration/layoutcode=us
+        hw-detect/load_firmware=true
+        rw
+        quiet
+        {{.Param "kernel-options"}}
+        {{.Param "kernel-console"}}
 RequiredParams:
 OptionalParams:
   - "part-scheme"

--- a/content/bootenvs/debian-8.yml
+++ b/content/bootenvs/debian-8.yml
@@ -14,7 +14,7 @@ OS:
   IsoFile: "debian-8.11.1-amd64-netinst.iso"
   IsoSha256: "ea444d6f8ac95fd51d2aedb8015c57410d1ad19b494cedec6914c17fda02733c"
   IsoUrl: "https://cdimage.debian.org/cdimage/archive/8.11.1/amd64/iso-cd/debian-8.11.1-amd64-netinst.iso"
-  Version: "8.11.1"
+  Version: "8"
 Initrds:
   - "initrd.gz"
 Kernel: "linux"

--- a/content/params/package-repositories.yaml
+++ b/content/params/package-repositories.yaml
@@ -308,14 +308,57 @@ Schema:
         - restricted
         - universe
         - multiverse
+    - tag: debian-10
+      os:
+        - "debian-10"
+      arch: amd64
+      installSource: true
+      url: "http://deb.debian.org/debian"
+      distribution: buster
+      bootloc: http://deb.debian.org/debian/dists/buster/main/installer-amd64/current/images/netboot/debian-installer/amd64/
+      components:
+        - main
+        - contrib
+        - non-free
+    - tag: "debian-10-updates"
+      os:
+        - "debian-10"
+      arch: any
+      url: "http://deb.debian.org/debian"
+      distribution: buster-updates
+      components:
+        - main
+        - contrib
+        - non-free
+    - tag: "debian-10-backports"
+      os:
+        - "debian-10"
+      arch: any
+      url: "http://deb.debian.org/debian"
+      distribution: buster-backports
+      components:
+        - main
+        - contrib
+        - non-free
+    - tag: "debian-10-security"
+      os:
+        - "debian-10"
+      arch: any
+      url: "http://security.debian.org/debian-security/"
+      securitySource: true
+      distribution: buster/updates
+      components:
+        - contrib
+        - main
+        - non-free
     - tag: debian-9-install
       os:
         - "debian-9"
       arch: amd64
       installSource: true
-      url: "http://mirrors.kernel.org/debian"
+      url: "http://deb.debian.org/debian"
       distribution: stretch
-      bootloc: http://mirrors.kernel.org/debian/dists/stretch/main/installer-amd64/current/images/netboot/debian-installer/amd64/
+      bootloc: http://deb.debian.org/debian/dists/stretch/main/installer-amd64/current/images/netboot/debian-installer/amd64/
       components:
         - main
         - contrib
@@ -324,7 +367,7 @@ Schema:
       os:
         - "debian-9"
       arch: any
-      url: "http://mirrors.kernel.org/debian"
+      url: "http://deb.debian.org/debian"
       distribution: stretch-updates
       components:
         - main
@@ -334,7 +377,7 @@ Schema:
       os:
         - "debian-9"
       arch: any
-      url: "http://mirrors.kernel.org/debian"
+      url: "http://deb.debian.org/debian"
       distribution: stretch-backports
       components:
         - main

--- a/content/stages/debian-10-install.yaml
+++ b/content/stages/debian-10-install.yaml
@@ -1,0 +1,11 @@
+---
+Name: "debian-10-install"
+Description: "Debian 10 install stage.  References the latest Debian 10 image"
+BootEnv: "debian-10-install"
+Tasks:
+  - "debian-drp-only-repos"
+  - "ssh-access"
+Meta:
+  icon: "download"
+  color: "yellow"
+  title: "Digital Rebar Community Content"

--- a/content/tasks/debian-drp-only-repos.yaml
+++ b/content/tasks/debian-drp-only-repos.yaml
@@ -1,0 +1,14 @@
+---
+Description: "A task to force the node to switch to DRP hosted-only debian repos."
+Name: "debian-drp-only-repos"
+OptionalParams:
+  - "local-repo"
+Templates:
+  - ID: "debian-drp-only-repos.sh.tmpl"
+    Name: "Force node to install from drp hosted repos"
+    Path: ""
+Meta:
+  icon: "key"
+  color: "blue"
+  title: "Digital Rebar Community Content"
+  feature-flags: "sane-exit-codes"

--- a/content/templates/deb10-net-seed.tmpl
+++ b/content/templates/deb10-net-seed.tmpl
@@ -1,0 +1,94 @@
+# Rebar seed file for Debian/Ubuntu installs
+# Locale and Language Settings
+d-i debian-installer/locale string en_US.UTF-8
+d-i keyboard-configuration/xkb-keymap select us
+d-i keyboard-configuration/toggle select No toggling
+
+# Serial Console
+d-i debian-installer/serial-console boolean true
+d-i finish-install/keep-consoles boolean true
+
+# Network Configuration
+d-i netcfg/choose_interface select auto
+d-i netcfg/dhcp_timeout string 120
+d-i netcfg/get_hostname string {{.Machine.ShortName}}
+{{if .ParamExists "dns-domain" -}}
+d-i netcfg/get_domain string {{.Param "dns-domain"}}
+{{end}}
+
+d-i mirror/country string manual
+{{range .InstallRepos -}}
+{{ .Install }}
+{{end -}}
+
+{{if .ParamExists "proxy-servers" -}}
+d-i mirror/http/proxy string {{index (.Param "proxy-servers") 0}}
+{{else -}}
+d-i mirror/http/proxy string
+{{end -}}
+
+# Clock
+d-i clock-setup/utc boolean true
+{{if .ParamExists "ntp-servers" -}}
+d-i clock-setup/ntp boolean true
+d-i clock-setup/ntp-server string {{index (.Param "ntp-servers") 0}}
+{{else -}}
+d-i clock-setup/ntp boolean false
+{{end -}}
+d-i time/zone string UTC
+
+# Partitioner Label Default (GPT)
+d-i partman-efi/non_efi_system boolean true
+d-i partman/default_filesystem string xfs
+d-i partman/choose_label string gpt
+d-i partman-basicfilesystems/choose_label string gpt
+d-i partman-partitioning/choose_label string gpt
+d-i partman/default_label string gpt
+d-i partman-basicfilesystems/default_label string gpt
+d-i partman-partitioning/default_label string gpt
+# Partitioner Prompt Confirmations
+d-i partman-auto/purge_lvm_from_device boolean true
+d-i partman-md/confirm boolean true
+d-i partman-md/device_remove_md boolean true
+d-i partman-md/confirm_nochanges boolean true
+d-i partman-md/confirm_nooverwrite boolean true
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman-lvm/device_remove_lvm_span boolean true
+d-i partman-lvm/confirm_nochanges boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-basicfilesystems/no_swap boolean false
+#Partitioning Scheme
+{{if .ParamExists "part-scheme" -}}
+{{$templateName := (printf "part-scheme-%s.tmpl" (.Param "part-scheme")) -}}
+{{.CallTemplate $templateName .}}
+{{else -}}
+{{template "part-scheme-default.tmpl" .}}
+{{end -}}
+d-i partman/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+
+# Default User Setup
+d-i passwd/user-uid string {{if .ParamExists "provisioner-default-uid"}}{{.Param "provisioner-default-uid"}}{{else}}1000{{end}}
+d-i passwd/user-fullname string {{if .ParamExists "provisioner-default-fullname"}}{{.Param "provisioner-default-fullname"}}{{else if .ParamExists "provisioner-default-user"}}{{.Param "provisioner-default-user"}}{{else}}Rocket Skates{{end}}
+d-i passwd/username string {{if .ParamExists "provisioner-default-user"}}{{.Param "provisioner-default-user"}}{{else}}rocketskates{{end}}
+d-i passwd/user-password-crypted password {{if .ParamExists "provisioner-default-password-hash"}}{{.Param "provisioner-default-password-hash"}}{{else}}$6$drprocksdrprocks$upAIK9ynEEdFmaxJ5j0QRvwmIu2ruJa1A1XB7GZjrnYYXXyNr4qF9FttxMda2j.cmh.TSiLgn4B/7z0iSHkDC1{{end}}
+d-i user-setup/encrypt-home boolean false
+
+d-i debian-installer/allow_unauthenticated string true
+tasksel tasksel/first multiselect standard, server
+d-i pkgsel/include string openssh-server curl efibootmgr {{if .ParamExists "extra-packages"}}{{ range $index, $element := (.Param "extra-packages") }}{{if $index}} {{end}}{{$element}}{{end}}{{end}}
+d-i pkgsel/update-policy select none
+
+{{if .ParamExists "kernel-console"}}d-i debian-installer/add-kernel-opts string {{.Param "kernel-console"}}{{end}}
+# Completion questions
+d-i cdrom-detect/eject boolean false
+d-i finish-install/reboot_in_progress note
+
+xserver-xorg xserver-xorg/autodetect_monitor boolean true
+xserver-xorg xserver-xorg/config/monitor/selection-method select medium
+xserver-xorg xserver-xorg/config/monitor/mode-list select 1024x768 @ 60 Hz
+
+d-i preseed/late_command string wget {{.Machine.Url}}/post-install.sh -O /target/net-post-install.sh ; chmod +x /target/net-post-install.sh ; /target/net-post-install.sh

--- a/content/templates/debian-drp-only-repos.sh.tmpl
+++ b/content/templates/debian-drp-only-repos.sh.tmpl
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export LC_ALL=C LANGUAGE=C LANG=C
+export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
+cat >/etc/apt/sources.list <<"EOFLOCALREPO"
+{{range .MachineRepos }}
+{{ .Lines }}
+{{end}}
+EOFLOCALREPO
+
+apt-get -y --force-yes update

--- a/content/templates/select-kickseed.tmpl
+++ b/content/templates/select-kickseed.tmpl
@@ -30,6 +30,8 @@
   {{if and (eq "redhat" .Env.OS.FamilyName) (.Env.OS.VersionEq "7") -}} {{template "centos-7.ks.tmpl" .}} {{end -}}
   {{if and (eq "redhat" .Env.OS.FamilyName) (.Env.OS.VersionEq "8") -}} {{template "centos-8.ks.tmpl" .}} {{end -}}
   {{if (eq "fedora" .Env.OS.FamilyName) -}} {{template "centos-7.ks.tmpl" .}} {{end -}}
-  {{if (eq "debian" .Env.OS.FamilyName) -}} {{template "net-seed.tmpl" .}} {{end -}}
+  {{if and (eq "debian" .Env.OS.FamilyName) (.Env.OS.VersionEq "10") -}} {{template "deb10-net-seed.tmpl" .}} {{end -}}
+  {{if and (eq "debian" .Env.OS.FamilyName) (.Env.OS.VersionEq "9") -}} {{template "net-seed.tmpl" .}} {{end -}}
+  {{if and (eq "debian" .Env.OS.FamilyName) (.Env.OS.VersionEq "8") -}} {{template "net-seed.tmpl" .}} {{end -}}
   {{if (eq "ubuntu" .Env.OS.FamilyName) -}} {{template "net-seed.tmpl" .}} {{end -}}
 {{end -}}

--- a/content/workflows/debian-base.yaml
+++ b/content/workflows/debian-base.yaml
@@ -1,0 +1,20 @@
+Name: "debian-base"
+Description: "Basic Debian Install Workflow + Runner"
+Documentation: |
+  This workflow includes the DRP Runner in Ubuntu provisioning process for DRP.
+
+  After the install completes, the workflow installs the runner
+  in a waiting state so that DRP will automatically detect and start a
+  new workflow if the Machine.Workflow is updated.
+
+  .. note:: To enable, upload the firmware-10 ISO as per the debian-10 BootEnv
+
+Stages:
+  - debian-10-install
+  - runner-service
+  - finish-install
+  - complete
+Meta:
+  color: green
+  icon: download
+  title: RackN Content


### PR DESCRIPTION
Adds new workflow and bootenv for Debian 10
Fixes errors in previous Debian bootenvs
Add ubuntu-base like workflow for Debian 10
Only works for Network installs, could not find a way to do off-line installs due to limitations with the Debian Installer