### PR TITLE
feat(os-other): Add IsoUrl for Linux installers in os-other

### DIFF
--- a/os-other/bootenvs/rhel-server-7-install.yaml
+++ b/os-other/bootenvs/rhel-server-7-install.yaml
@@ -24,7 +24,7 @@ OS:
       Initrds:
       - images/pxeboot/initrd.img
       IsoFile: rhel-server-7.7-x86_64-dvd.iso
-      IsoUrl: ""
+      IsoUrl: "https://rackn-repo.s3.amazonaws.com/isos/redhat/rhel/7/rhel-server-7.7-x86_64-dvd.iso"
       Kernel: images/pxeboot/vmlinuz
       Loader: ""
       Sha256: 88b42e934c24af65e78e09f0993e4dded128d74ec0af30b89b3cdc02ec48f028

--- a/os-other/bootenvs/rhel-server-8-boot-install.yaml
+++ b/os-other/bootenvs/rhel-server-8-boot-install.yaml
@@ -26,7 +26,7 @@ OS:
       Initrds:
         - images/pxeboot/initrd.img
       IsoFile: rhel-8.2-x86_64-boot.iso
-      IsoUrl: ""
+      IsoUrl: "https://rackn-repo.s3.amazonaws.com/isos/redhat/rhel/8/rhel-8.2-x86_64-boot.iso"
       Kernel: images/pxeboot/vmlinuz
       Loader: ""
       Sha256: "d30989c6b3f3b81c262dfbf6e8f711e0d49a6828eb77833c34859e694c24e981"

--- a/os-other/bootenvs/rhel-server-8-dvd-install.yaml
+++ b/os-other/bootenvs/rhel-server-8-dvd-install.yaml
@@ -26,7 +26,7 @@ OS:
       Initrds:
         - images/pxeboot/initrd.img
       IsoFile: "rhel-8.2-x86_64-dvd.iso"
-      IsoUrl: ""
+      IsoUrl: "https://rackn-repo.s3.amazonaws.com/isos/redhat/rhel/8/rhel-8.2-x86_64-dvd.iso"
       Kernel: images/pxeboot/vmlinuz
       Loader: ""
       Sha256: "7fdfed9c7cced4e526a362e64ed06bcdc6ce0394a98625a40e7d05db29bf7b86"


### PR DESCRIPTION
Add RackN controlled S3 bucket for os-other images which are Linux
based. Basically adds support for RHEL 7 and 8 installers.

The ISOs are currently publicly available, but can be license
restricted in the future.