### PR TITLE
bug(drp-community-content): Fix setup.tmpl '<<<' redirect breaks ESXi shell

### DIFF
--- a/content/templates/setup.tmpl
+++ b/content/templates/setup.tmpl
@@ -43,8 +43,7 @@ function fixup_path() {
   for _add_path in $(echo $* | sed 's/[:,]/ /g')
   do
     mkdir -p $_add_path
-    # inject colons to avoid partial match failures
-    grep -q ":$_add_path" <<< ":$PATH:" || export PATH="$PATH:$_add_path"
+    echo ":$PATH:" | grep -q ":$_add_path" || export PATH="$PATH:$_add_path"
   done
 }
 


### PR DESCRIPTION
- use of the `<<<` redirect is not valid on ESXi BusyBox shell
- move to using a more generic construct that is compatible

Results in error on ESXi if run with `<<<` as:
```
-sh: syntax error: unexpected redirection
```

Testing on ESXi:

```
[root@r3r6-u03:~] _add_path=/foo/bar
[root@r3r6-u03:~] grep -q ":$_add_path" <<< ":$PATH:" || export PATH="$PATH:$_add_path"
-sh: syntax error: unexpected redirection

[root@r3r6-u03:~] echo ":$PATH:" | grep -q ":$_add_path" || export PATH="$PATH:$_add_path"
[root@r3r6-u03:~] echo $PATH
/bin:/sbin:/foo/bar
```