### PR TITLE
fix(drp-community-content): Fix uefi boot; remove current boot number

### DIFF
--- a/content/tasks/fix-uefi-boot-order.yaml
+++ b/content/tasks/fix-uefi-boot-order.yaml
@@ -50,7 +50,7 @@ Templates:
       if [[ ! $order ]]; then
           efibootmgr -o "$current"
       else
-          efibootmgr -B -b "${current}"
+          efibootmgr -o "${current},${order}"
       fi
       efibootmgr -D || :
       efibootmgr -v || :

--- a/content/tasks/fix-uefi-boot-order.yaml
+++ b/content/tasks/fix-uefi-boot-order.yaml
@@ -50,7 +50,7 @@ Templates:
       if [[ ! $order ]]; then
           efibootmgr -o "$current"
       else
-          efibootmgr -o "${current},${order}"
+          efibootmgr -B -b "${current}"
       fi
       efibootmgr -D || :
-      efivootmgr -v || :
+      efibootmgr -v || :


### PR DESCRIPTION
- fixes the remove boot current boot order to remove instead of prepend to current, which causes double current
- fix typo `efivootmgr` to `efibootmgr`