### PR TITLE
fix(sledgehamer-builder): Increase wget retry count for STP

### DIFF
--- a/sledgehammer-builder/tasks/sledgehammer-place-stage1-assets.yaml
+++ b/sledgehammer-builder/tasks/sledgehammer-place-stage1-assets.yaml
@@ -96,7 +96,7 @@ Templates:
       postportdelay=${postportdelay#*=}
       routedelay=${routedelay#*=}
       wgetretrycount=${wgetretrycount#*=}
-      wgetretrycount=${wgetretrycount:-10}
+      wgetretrycount=${wgetretrycount:-65}
 
       pxedev=""
       for dev in /sys/class/net/*; do


### PR DESCRIPTION
The default number of retries (10) means that most switchports
which have STP enabled will fail. Increasing the count to 65
should allow most timeouts (up to about 70s) to expire while
attempting to download the second stage. This should have no
impact on non-STP ports, or ports where STP "portfast" are
enabled as the kernel takes a few seconds to complete other
tasks before the 2nd stage download is attempted.