### PR TITLE
feat(content): provide a universal break out of workflow option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ edge-lab/admin.conf
 edge-lab/kube.config
 task-library/task-library.yaml
 bundle.yaml
+bundle.json
 rel_notes
 rebar-catalog

--- a/content/params/workflow-escape.yaml
+++ b/content/params/workflow-escape.yaml
@@ -1,0 +1,35 @@
+---
+Name: "workflow/escape"
+Description: "Seconds to pause, then break workflows in process (embedded in setup.tmpl)"
+Documentation: |
+  Allows operators to interrupt workflows from a global, profile or machine
+  basis by overriding this one param.  Requires that the workflow task(s) use
+  the setup.tmpl.
+
+  By default, value of -1 is ignored an workflow is not interrupted.
+
+  If value is 0 then task will `exit 1` out of the task and stop the workflow.
+
+  If value is >0 then the task will sleep 1 second and the value will decremented
+  and stored on the machine running the task.  
+
+  Values >0 allow operators to specify a pause before the workflow is halted.
+  If the workflow/escape param is removed from the machine before it reaches 0
+  then the task can continue without interruption.   This allows for operators
+  to choose between fast fail (workflow/escape = 0) or delayed fail ater X Seconds
+  (workflow/escape > 0).
+
+  If the machine's param value is removed before the value reaches 0 then the
+  workflow will continue without interruption.
+
+  NOTE: if you set the workflow/escape value on a machine to -1 then it
+  will disable the ability to override at a higher level.
+Schema:
+  type: integer
+  default: -1
+  minimum: -1
+Meta:
+  type: "value"
+  icon: "hand paper"
+  color: "purple"
+  title: "Digital Rebar Community Content"

--- a/content/templates/setup.tmpl
+++ b/content/templates/setup.tmpl
@@ -84,6 +84,30 @@ if [[ ! -e $INSTALL_DIR/jq ]] ; then
 fi
 unset INSTALL_DIR
 
+# UNIVERSAL ESCAPE PATTERN
+# normally ignored, this allows operators to set a workflow "pause"
+{{ if .ParamExists "workflow/escape" }}
+{{ if ne -1 (int (.Param "workflow/escape")) }}
+echo "Detected workflow/escape (value is {{.Param "workflow/escape"}})"
+i={{int (.Param "workflow/escape")}}
+while [[ "$i" != "null" ]]; do
+  if [[ $i == 0 ]]; then
+    echo "ALERT! workflow/escape Reached 0 - Removing and Breaking Workflow"
+    drpcli machines remove $RS_UUID param "workflow/escape" > /dev/null
+    exit 1
+  else
+    i=$((i-1))
+    echo "WARNING! workflow/escape Countdown at ${i}"
+    drpcli machines set $RS_UUID param "workflow/escape" to $i > /dev/null
+  fi
+  sleep 1
+  i=$(drpcli machines get $RS_UUID param "workflow/escape") > /dev/null
+done
+{{ else }}
+echo "No workflow/escape set - continue"
+{{ end }}
+{{ end }}
+
 # Helper is rendered by the agent, and includes additional helpful functions; for
 # source, see repo https://github.com/digitalrebar/provision and file agent/cmdHelper.go
 if [[ -r ./helper ]]; then

--- a/task-library/workflows/discover-joinup.yaml
+++ b/task-library/workflows/discover-joinup.yaml
@@ -5,6 +5,11 @@ Documentation: |
 
   This workflow is recommended for joining cloud machines instead of `discover-base`.
 
+  NOTE: You must set `DefaulBootEnv` to `discover` in order to use join-up
+  to discover machines.  Alternatively, you can create placeholder
+  machines with `.BootEnv: discover` and use `join-up.sh` to connect to the placeholder
+  using the UUID. See the `ansible-joinup` task for an example.
+
   These added stages help for existing machines that may already
   have basic configuration (like firewalld) and a stable operating
   system (runner-service allows reboots).


### PR DESCRIPTION
based on some community questions - create a way to interrupt workflows using a settable param

this design allows operators to first pause the workflow for a settable amount before it breaks the workflow
the goal is to make breaking easy on a per machine basis and provide a fast "panic button" at the global level too.

Since this changes setup.tmpl, the risk is VERY HIGH.  REVIEW CAREFULLY 

Once this is in, it would make sense to include a UX set workflow/escape = 60 button.