### PR TITLE
 fix(task-lib): add retry for joinup to handle intermittent failures

### DIFF
--- a/cloud-wrappers/tasks/cloud-validate.yaml
+++ b/cloud-wrappers/tasks/cloud-validate.yaml
@@ -82,6 +82,15 @@ Templates:
             drpcli machines update $RS_UUID '{"Description":"ERROR: You must define the linode/token!"}'
             exit 1
           {{ end }}
+          {{ range $i, $p := .Machine.Profiles }}
+          s="{{$p}}"
+          if [[ ${#s} -gt 2  ]]; then
+            echo "  verified \"$s\" tag length (must be >2 characters, was ${#s})"
+          else
+            echo "FAIL! \"$s\" profile IS NOT >2 characters. Min 3 is required by Linode"
+            exit 1
+          fi
+          {{ end }}
 
         {{ end }}
 

--- a/task-library/tasks/ansible-join-up.yaml
+++ b/task-library/tasks/ansible-join-up.yaml
@@ -55,7 +55,7 @@ Templates:
           - name: check if drpcli is running (makes join idempotent)
             service_facts:
 
-          - name: "drpcli is installed - no further actions"
+          - name: "drpcli is installed? - skip if drpcli is installed"
             debug:
               msg: "DRPCLI status is {{`{{ services['drpcli.service'].status }}`}}"
             when: "'drpcli.service' in services"
@@ -78,6 +78,34 @@ Templates:
           - name: run join-up script
             become: true
             shell: "nohup ./join-up.sh >/dev/null 2>&1 &"
+            when: "'drpcli.service' not in services"
+
+          - name: wait for joinup
+            pause:
+              seconds: 10
+            when: "'drpcli.service' not in services"
+
+          - name: check for drpcli pids (makes sure we started)
+            shell: pidof drpcli
+            register: drpcli_pids
+            ignore_errors: true
+
+          - name: Printing the process IDs obtained
+            debug:
+              msg: "PIDS of DRPCLI: {{`{{drpcli_pids.stdout}}`}}"
+
+          - name: rerun join-up script if no pids - skip is normal
+            become: true
+            shell: "nohup ./join-up.sh >/dev/null 2>&1 &"
+            when: drpcli_pids.stdout == ""
+
+          - name: wait for joinup second time
+            pause:
+              seconds: 10
+            when: drpcli_pids.stdout == ""
+
+          - name: last chance for pids of drpcli [fail if none]
+            shell: pidof drpcli
             when: "'drpcli.service' not in services"
       EOF
 


### PR DESCRIPTION
handle intermittent failures on Ansible Join-Up script.
basically checks for pids and does a retry if missing.
also fails more obviously if the pids don't exist instead of leaving system waiting forever.

also, verify that all tags for linode are >2 letters