### PR TITLE
fix(contexts-runners): update pull to use v44 DRPCLI

### DIFF
--- a/integrations/docker-context/ansible-dockerfile
+++ b/integrations/docker-context/ansible-dockerfile
@@ -28,11 +28,11 @@ RUN pip3 install --no-cache-dir --upgrade yq
 RUN pip3 install --no-cache-dir --upgrade mitogen boto3
 # Linode
 RUN pip3 install --no-cache-dir --upgrade linode-api4
-RUN curl -o drpcli420 https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.2.0/amd64/linux/drpcli && \
-    chmod 755 drpcli420 && \
-    ./drpcli420 catalog item download drpcli to /usr/bin/drpcli && \
+RUN curl -o drpcli440 https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.4.0/amd64/linux/drpcli && \
+    chmod 755 drpcli440 && \
+    ./drpcli440 catalog item download drpcli to /usr/bin/drpcli && \
     chmod 755 /usr/bin/drpcli && \
-    rm drpcli420 && \
+    rm drpcli440 && \
     ln -s /usr/bin/drpcli /usr/bin/jq && \
     ln -s /usr/bin/drpcli /usr/bin/drpjq && \
     echo "Installed DRPCLI $(drpcli version)"

--- a/integrations/docker-context/runner-dockerfile
+++ b/integrations/docker-context/runner-dockerfile
@@ -1,10 +1,10 @@
 FROM alpine:latest
 RUN apk --no-cache add bash curl openssh-keygen
-RUN curl -o drpcli420 https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.2.0/amd64/linux/drpcli && \
-	chmod 755 drpcli420 && \
-	./drpcli420 catalog item download drpcli to /usr/bin/drpcli && \
+RUN curl -o drpcli440 https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.4.0/amd64/linux/drpcli && \
+	chmod 755 drpcli440 && \
+	./drpcli440 catalog item download drpcli to /usr/bin/drpcli && \
 	chmod 755 /usr/bin/drpcli && \
-	rm drpcli420 && \
+	rm drpcli440 && \
     ln -s /usr/bin/drpcli /usr/bin/jq && \
     ln -s /usr/bin/drpcli /usr/bin/drpjq && \
     echo "Installed DRPCLI $(drpcli version)"

--- a/integrations/docker-context/terraform-dockerfile
+++ b/integrations/docker-context/terraform-dockerfile
@@ -1,10 +1,10 @@
 FROM hashicorp/terraform:light
 RUN apk --no-cache add bash curl
-RUN curl -o drpcli420 https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.2.0/amd64/linux/drpcli && \
-	chmod 755 drpcli420 && \
-	./drpcli420 catalog item download drpcli to /usr/bin/drpcli && \
+RUN curl -o drpcli440 https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.4.0/amd64/linux/drpcli && \
+	chmod 755 drpcli440 && \
+	./drpcli440 catalog item download drpcli to /usr/bin/drpcli && \
 	chmod 755 /usr/bin/drpcli && \
-	rm drpcli420 && \
+	rm drpcli440 && \
     ln -s /usr/bin/drpcli /usr/bin/jq && \
     ln -s /usr/bin/drpcli /usr/bin/drpjq && \
     echo "Installed DRPCLI $(drpcli version)"


### PR DESCRIPTION
needed the pooling CLI calls in the runner.