### PR TITLE
fix(debian-10): Fix Debian Buster BootEnv for netcfg

### DIFF
--- a/content/bootenvs/debian-10.yml
+++ b/content/bootenvs/debian-10.yml
@@ -35,6 +35,7 @@ OS:
         hw-detect/load_firmware=true
         rw
         quiet
+        {{.Param "debian-buster-netcfg"}}
         {{.Param "kernel-options"}}
         {{.Param "kernel-console"}}
 RequiredParams:

--- a/content/params/debian-buster-netcfg.yaml
+++ b/content/params/debian-buster-netcfg.yaml
@@ -1,0 +1,36 @@
+---
+Name: "debian-buster-netcfg"
+Description: "Specifies how Debian 10 (buster) configures the Debian Installer network"
+Documentation: |
+  It appears that in Debian 10 (Buster) - the use of any *preseed* directives to
+  configure the network is hard coded to *auto* (DHCP) for single NIC hosts.  Multiple
+  NIC hosts will stop and ask the operator what NIC to use for installation.
+
+  This occurs regarldess of any *preseed* directives.  The only apparent way to
+  configure Debian 10 interfaces at installation are to pass the *netcfg/...*
+  values on the Kernel command line.
+
+  This Param specifies that the network interface should be chosen automatically,
+  regardless of the number of NICs in the system; with the default value set to:
+
+    * ``netcfg/choose_interface=auto``
+
+  If you replace *auto* with the name of the Network Interface, then the installer
+  will use your explicitly set NIC.
+
+  For static IP assignment or, explicit NIC selection requirements, you will have
+  to set this Param on the Machine object, the *preseed* directives are ignored.
+
+  An example to explicitly set a Static IP assignment for the installer is as
+  follows:
+
+    * ``netcfg/get_ipaddress=192.168.1.10 netcfg/get_netmask=255.255.255.0 netcfg/get_gateway=192.168.1.1 netcfg/get_nameservers=1.1.1.1,1.0.0.1 netcfg/choose_interface=eth0 netcfg/disable_autoconfig=true``
+
+Schema:
+  type: "string"
+  default: "netcfg/choose_interface=auto"
+
+Meta:
+  icon: "bullseye"
+  color: "blue"
+  title: "Digital Rebar Community Content"


### PR DESCRIPTION
Debian 10 (Buster) _preseed_ completely ignores any of the `netcfg/*` configuration stanzas.  Some conventional wisdom says to set the Kernel arguments with `priority=high` or `priority=critical`.  Neither of these worked.  After a dozen different suggested methods, the only one that seems to work is explicitly set the `netcfg/*` values on the Kernel argument/options.

It has worked in the past because by default, a single NIC system will revert to DHCP for network configuration.  If the system has multiple NICs in it, then the current _bootenv_ would fail to autoselect, and prompt the operator to specify which NIC to use for the installer network interface.

This PR:
- Adds new Param exclusively for Debian 10 (Buster) named `debian-buster-netcfg`, with default to auto config NIC
- Sets that param to a default value of `netcfg/choose_interface=auto`
- Specifies some alternative options/settings in the Param documentation
- Modifies the `debian-10-install` _bootenv_ to use the `debian-buster-netcfg` value

This has been tested to work correctly on single NIC and multi-NIC systems.
