### PR TITLE
feat(sledge8): Update cent8 sledgehammer to use python2 by default.

### DIFF
--- a/sledgehammer-builder/bootenvs/build-sledgehammer.yaml
+++ b/sledgehammer-builder/bootenvs/build-sledgehammer.yaml
@@ -123,6 +123,7 @@ Templates:
       kernel-tools
       kexec-tools
       less
+      libssh2
       libsysfs
       linux-firmware
       lldpd
@@ -137,6 +138,7 @@ Templates:
       {{end}}
       mktemp
       ncurses
+      ncurses-compat-libs
       nfs-utils
       ntfs-3g
       ntfsprogs

--- a/sledgehammer-builder/params/sledgehammer-default-python.yaml
+++ b/sledgehammer-builder/params/sledgehammer-default-python.yaml
@@ -1,0 +1,9 @@
+---
+Name: sledgehammer/default-python
+Description: The default python to use when a script asks for '/usr/bin/python'
+Schema:
+  type: string
+  default: /usr/bin/python2
+  enum:
+    - /usr/bin/python2
+    - /usr/bin/python3

--- a/sledgehammer-builder/tasks/sledgehammer-prepare-for-image-creation.yaml
+++ b/sledgehammer-builder/tasks/sledgehammer-prepare-for-image-creation.yaml
@@ -61,3 +61,7 @@ Templates:
       {{ range (.Param "sledgehammer/enable-services") }}
       systemctl enable {{ . }}
       {{ end }}
+  - Name: set-default-python
+    Contents: |
+      #!/bin/bash
+      alternatives --set python {{ .Param "sledgehammer/default-python" }}


### PR DESCRIPTION
This also adds an extra dependency that the Dell firmware update process
requires.  Still needs testing on an HP box.