### PR TITLE
bug(task-library): fix overly restrictive regex in Terraform version check

### DIFF
--- a/task-library/tasks/terraform-apply.yaml
+++ b/task-library/tasks/terraform-apply.yaml
@@ -127,10 +127,12 @@ Templates:
 
       ## this is a sad hack required by Terraform deprecation
       tfver=$(terraform -v)
-      tf13reg="Terraform v0\.1[3-9]\.0"
+      tf13reg="Terraform v0\.1[3-9]\."
       if [[ $tfver =~ $tf13reg ]]; then
         echo "=== FORCE v0.13 UPGRADE ===="
         terraform 0.13upgrade -yes -no-color .
+      else
+        echo "=== NO v0.13 UPGRADE was $tfver ==== "
       fi
 
       echo "=== INIT $(terraform version) ===="


### PR DESCRIPTION
When they came out with 0.13.1 it exposed my overly optimistic regex