### PR TITLE
ferature(task-library): ansible-playbooks-local can use templates

### DIFF
--- a/task-library/params/ansible-playbooks.yaml
+++ b/task-library/params/ansible-playbooks.yaml
@@ -7,18 +7,22 @@ Documentation: |
   Runs the provided playbooks in order from the json array.  The array contains structured
   objects with further details about the ansible-playbook action.
 
-  Each playbook MUST be stored in a git location accessible from the machine running the task.
+  Each playbook MUST be stored in either
+  1. a git location accessible from the machine running the task.
+  1. a DRP template accessible to the running DRP
 
   The following properties are included in each array entry:
 
   * playbook (required): name of the playbooks passed into ansible-playbook cli
   * name (required): determines the target of the git clone
-  * repo (required): path related to machine where the playbook can be clone from
+  * either (required, mutually exclusive):
+    * repo: path related to machine where the playbook can be git cloned from
+    * template: name of a DRP template containing a localhost ansible playbook
   * path (optional): if playbooks are nested into a single repo, move into that playbook
   * commit (optional): commit used to checkout a specific commit tag from the git history
   * data (optionalm boolean): if true, use items provided in args
   * args (optional): additional arguments to be passed into the ansible-playbook cli
-  * verbosity (optional, boolean): if true, captures additional output from ansiblie.
+  * verbosity (optional, boolean): if false, suppresses output from ansiblie using no_log.
 
   For example
 
@@ -34,12 +38,27 @@ Documentation: |
           "data": false,
           "args": "",
           "verbosity": true
+        },
+        {
+          "playbook": "test",
+          "name": "test",
+          "template": "ansible-playbooks-test-playbook.yaml.tmpl",
+          "path": "",
+          "commit": "",
+          "data": false,
+          "args": "",
+          "verbosity": true
         }
       ]
 
 Schema:
   type: "array"
-  default: []
+  default:
+  - playbook: test
+    name: test
+    template: "ansible-playbooks-test-playbook.yaml.tmpl"
+    data: false
+    verbosity: true
   items:
     properties:
       name:

--- a/task-library/tasks/ansible-inventory.yaml
+++ b/task-library/tasks/ansible-inventory.yaml
@@ -21,7 +21,10 @@ Templates:
     {{template "setup.tmpl" .}}
 
     if ! which ansible 2>/dev/null >/dev/null ; then
+        echo "installing ansible..."
         install ansible
+    else
+        echo "ansible installed, no action take"
     fi
 
     ansible -m setup -o 127.0.0.1 2>/dev/null | sed "s/127.0.0.1 | SUCCESS => //g" > ansible.json

--- a/task-library/tasks/ansible-playbooks-local.yaml
+++ b/task-library/tasks/ansible-playbooks-local.yaml
@@ -35,44 +35,60 @@ Templates:
     {{template "setup.tmpl" .}}
     [[ $RS_UUID ]] && export RS_UUID="{{.Machine.UUID}}"
 
-    echo "Running Git-based ansible playbooks"
+    if ! which ansible 2>/dev/null >/dev/null ; then
+        echo "Installing ansible..."
+        install ansible
+    else
+        echo "Ansible installed, no action required"
+    fi
+
+    echo "Running local ansible/playbooks"
     {{range $index, $playbook := .Param "ansible/playbooks"}}
-        NAME={{$playbook.name}}
-        REPO={{$playbook.repo}}
-        DIR={{$playbook.path}}
-        PB={{$playbook.playbook}}
-        L=$(mktemp "./$F.$$.XXXXXXXX.log")
+
+        echo "======== Item {{$index}} of ansible/playbooks ========="
+        NAME="{{if $playbook.name}}{{$playbook.name}}{{else}}playbook{{$index}}{{end}}"
+        DIR="/{{if $playbook.path}}{{$playbook.path}}{{else}}{{end}}"
+        PB="{{if $playbook.playbook}}{{$playbook.playbook}}{{else}}playbook{{$index}}.yaml{{end}}"
+
+        {{if $playbook.template }}
+          echo "  Creating playbook ${NAME}/${PB} from DRP template: {{$playbook.template}}"
+          mkdir ${NAME}
+          tee ${NAME}/${PB} >/dev/null << EOF
+    {{$.CallTemplate $playbook.template $}}
+    EOF
+        {{else}}
+          {{ if not $playbook.repo}}
+            echo "ERROR: template or repo must be defined!"
+            exit 1
+          {{else}}
+            echo "  Cloning the git repo: {{$playbook.repo}}"
+            git clone "{{$playbook.repo}}" "$NAME"
+            {{if not $playbook.commit }}
+              echo "  No commit requsted, using default commit"
+            {{else}}
+              echo "  Checking out {{$playbook.commit}}"
+              git checkout {{$playbook.commit}}
+            {{end}}
+          {{end}}
+        {{end}}
 
         {{if not $playbook.data }}
+            echo "  No special args requsted"
             ARGS=""
         {{else}}
+            echo "  Using args: {{$playbook.args}}"
             ARGS="{{$playbook.args}}"
         {{end}}
 
-        echo "Getting the git repo: $REPO"
-        git clone "$REPO" "$NAME"
-
-        {{if not $playbook.commit }}
-        echo "No commit"
-        {{else}}
-        git checkout {{$playbook.commit}}
-        {{end}}
-
-        echo "Running the playbook, $PB, from $DIR"
-        echo "Setting log file to:  '$L'"
-        cd "$NAME/$DIR"
-        {{if not $playbook.verbosity }}
-        echo "ansible-playbook $ARGS \"$PB\" | tee -a \"$L\""
-        ansible-playbook $ARGS "$PB" 2>&1 | tee -a "$L"
-        {{else}}
-        echo "ansible-playbook $ARGS {{$playbook.verbosity}} \"$PB\" | tee -a \"$L\""
-        ansible-playbook $ARGS {{$playbook.verbosity}} "$PB" 2>&1 | tee -a "$L"
-        {{end}}
+        cd "${NAME}${DIR}"
+        echo "  Running the playbook $PB in $(pwd)"
+        ansible-playbook -i localhost, $ARGS {{if not $playbook.verbosity}}no_log: True{{end}} "$PB"
         cd -
 
-        rm -rf $NAME $L
     {{else}}
         echo "NOTE: No ansible/playbooks defined."
     {{end}}
+    echo "======== End of Loop ========="
 
+    echo "done"
     exit 0

--- a/task-library/templates/ansible-playbooks-test-playbook.yaml.tmpl
+++ b/task-library/templates/ansible-playbooks-test-playbook.yaml.tmpl
@@ -1,0 +1,19 @@
+---
+### playbook is used to prove that local ansible is working
+- hosts: all
+  connection: local
+  gather_facts: false
+  user: "{{ .Param "rsa/key-user" }}"
+
+  vars:
+    test: "file.test"
+
+  tasks:
+    - name: "Testing ansible-playbooks-local"
+      debug:
+        msg: "Testing Ansible Variable: {{`{{ test }}`}}"
+
+    - name: "Validating access to local system"
+      file:
+        path: "{{`{{ test }}`}}"
+        state: touch


### PR DESCRIPTION
allow playbooks-local to use templates in addition to github playbooks.  adding templates in addition to git repos makes it easier to use simple Ansible plays inside of workflows without external dependencies

this change includes a DEFAULT TEMPLATE so that it's very easy and reliable to test the task without having to figure out a all the param settings!  this should make it much easier for new users to explore this task

also, cleaned up the task so that it was much more robust by adding protections for missing values and checks.