### PR TITLE
fix(sledgehammer): Add back increased wget timeouts.

### DIFF
--- a/content/bootenvs/discovery.yml
+++ b/content/bootenvs/discovery.yml
@@ -20,17 +20,17 @@ Meta:
   title: "Digital Rebar Community Content"
 OnlyUnknown: true
 Loaders:
-  amd64-uefi: e1a0019788acff426f7cc2eb5e5373d771716eaa/shimx64.efi
+  amd64-uefi: 737981b767d2408b6bcd76bec9244f4f1bee41b9/shimx64.efi
 OS:
   Family: "redhat"
   Name: "sledgehammer"
   SupportedArchitectures:
     amd64:
-      IsoFile: "sledgehammer-e1a0019788acff426f7cc2eb5e5373d771716eaa.amd64.tar"
-      IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/e1a0019788acff426f7cc2eb5e5373d771716eaa/sledgehammer-e1a0019788acff426f7cc2eb5e5373d771716eaa.amd64.tar"
-      Kernel: "e1a0019788acff426f7cc2eb5e5373d771716eaa/vmlinuz0"
+      IsoFile: "sledgehammer-737981b767d2408b6bcd76bec9244f4f1bee41b9.amd64.tar"
+      IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/737981b767d2408b6bcd76bec9244f4f1bee41b9/sledgehammer-737981b767d2408b6bcd76bec9244f4f1bee41b9.amd64.tar"
+      Kernel: "737981b767d2408b6bcd76bec9244f4f1bee41b9/vmlinuz0"
       Initrds:
-        - "e1a0019788acff426f7cc2eb5e5373d771716eaa/stage1.img"
+        - "737981b767d2408b6bcd76bec9244f4f1bee41b9/stage1.img"
       BootParams: >-
         rootflags=loop
         root=live:/sledgehammer.iso
@@ -228,7 +228,7 @@ Templates:
         source (tftp)/grub/discovery.cfg
       fi
   - Name: "grub-secure-discovery"
-    Path: "sledgehammer/e1a0019788acff426f7cc2eb5e5373d771716eaa/grub.cfg"
+    Path: "sledgehammer/737981b767d2408b6bcd76bec9244f4f1bee41b9/grub.cfg"
     ID: allarch-grub.tmpl
   - Name: "grub-discovery"
     Path: "grub/discovery.cfg"

--- a/content/bootenvs/sledgehammer.yml
+++ b/content/bootenvs/sledgehammer.yml
@@ -18,17 +18,17 @@ Meta:
   color: "green"
   title: "Digital Rebar Community Content"
 Loaders:
-  amd64-uefi: e1a0019788acff426f7cc2eb5e5373d771716eaa/shimx64.efi
+  amd64-uefi: 737981b767d2408b6bcd76bec9244f4f1bee41b9/shimx64.efi
 OS:
   Family: "redhat"
   Name: "sledgehammer"
   SupportedArchitectures:
     amd64:
-      IsoFile: "sledgehammer-e1a0019788acff426f7cc2eb5e5373d771716eaa.amd64.tar"
-      IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/e1a0019788acff426f7cc2eb5e5373d771716eaa/sledgehammer-e1a0019788acff426f7cc2eb5e5373d771716eaa.amd64.tar"
-      Kernel: "e1a0019788acff426f7cc2eb5e5373d771716eaa/vmlinuz0"
+      IsoFile: "sledgehammer-737981b767d2408b6bcd76bec9244f4f1bee41b9.amd64.tar"
+      IsoUrl: "http://rackn-sledgehammer.s3-website-us-west-2.amazonaws.com/sledgehammer/737981b767d2408b6bcd76bec9244f4f1bee41b9/sledgehammer-737981b767d2408b6bcd76bec9244f4f1bee41b9.amd64.tar"
+      Kernel: "737981b767d2408b6bcd76bec9244f4f1bee41b9/vmlinuz0"
       Initrds:
-        - "e1a0019788acff426f7cc2eb5e5373d771716eaa/stage1.img"
+        - "737981b767d2408b6bcd76bec9244f4f1bee41b9/stage1.img"
       BootParams: >-
         rootflags=loop
         root=live:/sledgehammer.iso
@@ -196,10 +196,10 @@ Templates:
     Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'
   - ID: "default-grub.tmpl"
     Name: "grub-secure"
-    Path: "sledgehammer/e1a0019788acff426f7cc2eb5e5373d771716eaa/grub.cfg-{{.Machine.HexAddress}}"
+    Path: "sledgehammer/737981b767d2408b6bcd76bec9244f4f1bee41b9/grub.cfg-{{.Machine.HexAddress}}"
   - ID: "default-grub.tmpl"
     Name: "grub-secure-mac"
-    Path: 'sledgehammer/e1a0019788acff426f7cc2eb5e5373d771716eaa/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
+    Path: 'sledgehammer/737981b767d2408b6bcd76bec9244f4f1bee41b9/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
   - ID: drp-agent-cfg.yaml.tmpl
     Name: agent-cfg
     Path: "{{.Machine.Path}}/agent-cfg.yml"

--- a/content/profiles/sledgehammer-0b8f38aeecc5a40f915758d9af47102fee6fb83e.yaml
+++ b/content/profiles/sledgehammer-0b8f38aeecc5a40f915758d9af47102fee6fb83e.yaml
@@ -1,0 +1,38 @@
+---
+Name: sledgehammer-0b8f38aeecc5a40f915758d9af47102fee6fb83e
+Description: 'Bootenv override for sledgehammer amd64 (CentOS 8)'
+Params:
+  bootenv-customize:
+    discovery:
+      Loaders:
+        'amd64-uefi': 0b8f38aeecc5a40f915758d9af47102fee6fb83e/shimx64.efi
+      OS:
+        Name: sledgehammer
+        SupportedArchitectures:
+          'amd64':
+            IsoFile: sledgehammer-0b8f38aeecc5a40f915758d9af47102fee6fb83e.amd64.tar
+            Kernel: 0b8f38aeecc5a40f915758d9af47102fee6fb83e/vmlinuz0
+            Initrds:
+              - 0b8f38aeecc5a40f915758d9af47102fee6fb83e/stage1.img
+      Templates:
+        - Name: grub-secure-discovery
+          Path: sledgehammer/0b8f38aeecc5a40f915758d9af47102fee6fb83e/grub.cfg
+          ID: allarch-grub.tmpl
+    sledgehammer:
+      Loaders:
+        'amd64-uefi': 0b8f38aeecc5a40f915758d9af47102fee6fb83e/shimx64.efi
+      OS:
+        Name: sledgehammer
+        SupportedArchitectures:
+          'amd64':
+            IsoFile: sledgehammer-0b8f38aeecc5a40f915758d9af47102fee6fb83e.amd64.tar
+            Kernel: 0b8f38aeecc5a40f915758d9af47102fee6fb83e/vmlinuz0
+            Initrds:
+              - 0b8f38aeecc5a40f915758d9af47102fee6fb83e/stage1.img
+      Templates:
+        - Name: grub-secure
+          Path: 'sledgehammer/0b8f38aeecc5a40f915758d9af47102fee6fb83e/grub.cfg-{{.Machine.HexAddress}}'
+          ID: default-grub.tmpl
+        - Name: grub-secure-mac
+          Path: 'sledgehammer/0b8f38aeecc5a40f915758d9af47102fee6fb83e/grub.cfg-{{.Machine.MacAddr "pxelinux"}}'
+          ID: default-grub.tmpl


### PR DESCRIPTION
This adds the increased timeouts for wget back to the sledgehammer
stage 1 initramfs.

It also adds an override for a centos 8 based Sledgehammer.  This will
become the default version of Sledgehammer in a future release of
Rebar.