### PR TITLE
refactor(task-library): update docker-contexts to use v4.5 cli

### DIFF
--- a/integrations/docker-context/ansible-dockerfile
+++ b/integrations/docker-context/ansible-dockerfile
@@ -28,11 +28,8 @@ RUN pip3 install --no-cache-dir --upgrade yq
 RUN pip3 install --no-cache-dir --upgrade mitogen boto3
 # Linode
 RUN pip3 install --no-cache-dir --upgrade linode-api4
-RUN curl -o drpcli440 https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.4.0/amd64/linux/drpcli && \
-    chmod 755 drpcli440 && \
-    ./drpcli440 catalog item download drpcli to /usr/bin/drpcli && \
+RUN curl -o /usr/bin/drpcli https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.5.0/amd64/linux/drpcli && \
     chmod 755 /usr/bin/drpcli && \
-    rm drpcli440 && \
     ln -s /usr/bin/drpcli /usr/bin/jq && \
     ln -s /usr/bin/drpcli /usr/bin/drpjq && \
     echo "Installed DRPCLI $(drpcli version)"

--- a/integrations/docker-context/runner-dockerfile
+++ b/integrations/docker-context/runner-dockerfile
@@ -1,10 +1,7 @@
 FROM alpine:latest
 RUN apk --no-cache add bash curl openssh-keygen
-RUN curl -o drpcli440 https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.4.0/amd64/linux/drpcli && \
-	chmod 755 drpcli440 && \
-	./drpcli440 catalog item download drpcli to /usr/bin/drpcli && \
-	chmod 755 /usr/bin/drpcli && \
-	rm drpcli440 && \
+RUN curl -o /usr/bin/drpcli https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.5.0/amd64/linux/drpcli && \
+    chmod 755 /usr/bin/drpcli && \
     ln -s /usr/bin/drpcli /usr/bin/jq && \
     ln -s /usr/bin/drpcli /usr/bin/drpjq && \
     echo "Installed DRPCLI $(drpcli version)"

--- a/integrations/docker-context/terraform-dockerfile
+++ b/integrations/docker-context/terraform-dockerfile
@@ -1,10 +1,7 @@
 FROM hashicorp/terraform:light
 RUN apk --no-cache add bash curl
-RUN curl -o drpcli440 https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.4.0/amd64/linux/drpcli && \
-	chmod 755 drpcli440 && \
-	./drpcli440 catalog item download drpcli to /usr/bin/drpcli && \
-	chmod 755 /usr/bin/drpcli && \
-	rm drpcli440 && \
+RUN curl -o /usr/bin/drpcli https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.5.0/amd64/linux/drpcli && \
+    chmod 755 /usr/bin/drpcli && \
     ln -s /usr/bin/drpcli /usr/bin/jq && \
     ln -s /usr/bin/drpcli /usr/bin/drpjq && \
     echo "Installed DRPCLI $(drpcli version)"

--- a/integrations/docker-context/test-build.sh
+++ b/integrations/docker-context/test-build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# RackN Copyright 2019
+# Build Manager Demo
+
+set -e
+
+echo "Testing Container Build Process"
+
+files="$(ls *-dockerfile)"
+
+for f in $files; do
+	echo "Removing $f from docker images"
+	docker rmi digitalrebar-$f || true
+	echo "Building $f"
+	docker build -f $f -t digitalrebar-$f .
+done
+
+echo "Checking Docker Images"
+docker images digitalrebar-*
+
+echo "done"


### PR DESCRIPTION
update the containers to use v4.5 CLI
removed the broken code that was supposed to pull latest but was not - we'll bump the CLI version via patch instead.

also, added a short test script that can be used to build the containers locally to test that they all work.