### PR TITLE
enhance(image-builder): Add flexiflow capabilities to Image Builder

### DIFF
--- a/image-builder/._Documentation.meta
+++ b/image-builder/._Documentation.meta
@@ -37,6 +37,63 @@ of ``cloud-init`` for image deployment customizations, etc.).
 tasks attached to the Stages to meet your use case requirements.**
 
 
+Customizing Your Image
+======================
+
+The current image builder utilizes the OS installers (eg Anaconda for RedHat/CentOS,
+Debian Installer for Debian/Ubuntu, etc...).  During the installation, the Digital
+Rebar agent (runner) is started in the Post section of these installers.  Workflow
+Stages/Tasks can be run to customize the OS image.
+
+The ``image-builder`` workflows each contain two Flexiflow Stages that will allow the
+operator to dynamically inject Tasks in to the workflow.  These tasks have access
+to the final installed filesystem via the *chroot* environment.  Tasks can install,
+customize, or alter the final image for your needs.
+
+The Tasks can be added prior to the ``image-builder-linux`` Stage which performs
+package/repo management functions, system update, etc. and after the ``image-builder-linux``
+Stage, but before the ``image-builder-capture`` Stage.  The first flexiflow injection
+lets the operator add customizations to the base OS, prior to administrative and
+cleanup tasks, while the second, allows for post-cleanup tasks for any additional
+final cleanup, or Image personalization customizations desired.
+
+To utilize the Flexiflow stages, your target machine you are building your images on
+must have the Parameter(s) ``image-builder/pre-builder-flexiflow`` and/or the
+``image-builder/poost-builder-flexiflow`` on it.   Each is an array
+list of strings that should reference Task name(s) to add, in order.
+
+These tasks will be injected dynamically in to the Workflow to allow customization,
+at the *Pre* or *Post* stage - depending on which Param values you set.
+
+An example of adding repositories that are not part of the base installer definitions,
+installing packages, and then subsequently removing the repository definitioin might
+look something like the following:
+
+  ::
+
+    image-builder/pre-builder-flexiflow:
+      - my-repository-add
+      - my-install-my-packages
+      - my-repository-remove
+    image-builder/post-builder-flexiflow:
+      - my-add-etc-issue
+
+In our theoretical example above, we have 3 tasks that will be injected in the
+*Pre* stage.  The first should add a new repository to the installed system (for
+example EPEL).  The second would install some packages that are contained in the
+example repository.  The third then removes the example repository from the
+sysmem - so the final installed system is in a clean state without those repos.
+
+After the ``image-builder-linux`` Stage/Tasks run, then the *Post* tasks will
+be injected.  In this case ``my-add-etc-issue``.  In this hypothetical task,
+the operator could add a signature to the end of ``/etc/issue`` to identify
+the image build uniquely to your organization.
+
+.. note:: The above tasks are examples, and do not actually exist, the operator
+          would have to create them as a part of a content pack or individual
+          objects added on to the DRP Endpoint.
+
+
 Tutorial Videos
 ===============
 

--- a/image-builder/._Prerequisites.meta
+++ b/image-builder/._Prerequisites.meta
@@ -1,1 +1,1 @@
-dev-library,os-other
+drp-community-content,dev-library,os-other,flexiflow

--- a/image-builder/params/image-builder-post-builder-flexiflow.yaml
+++ b/image-builder/params/image-builder-post-builder-flexiflow.yaml
@@ -1,0 +1,13 @@
+---
+Name: image-builder/post-builder-flexiflow
+Description: "flexiflow param for image-builder for post builder tasks (eg additional cleanup)"
+Documentation: ""
+Meta:
+  color: yellow
+  icon: shuffle
+  title: RackN Content
+Schema:
+  type: array
+  items:
+    type: string
+  default: []

--- a/image-builder/params/image-builder-pre-builder-flexiflow.yaml
+++ b/image-builder/params/image-builder-pre-builder-flexiflow.yaml
@@ -1,0 +1,13 @@
+---
+Name: image-builder/pre-builder-flexiflow
+Description: "flexiflow param for image-builder prior to image-builder-linux stage"
+Documentation: ""
+Meta:
+  color: yellow
+  icon: shuffle
+  title: RackN Content
+Schema:
+  type: array
+  items:
+    type: string
+  default: []

--- a/image-builder/stages/image-builder-capture.yaml
+++ b/image-builder/stages/image-builder-capture.yaml
@@ -1,0 +1,21 @@
+---
+Name: image-builder-capture
+Description: "Captures the 'gold master' image as a RootFS tarball."
+Documentation: |
+  This stage captures the built image as a RootFS tarball for deployment
+  by the ``image-deploy`` plugin as a ``tgz`` type.
+
+  Customization prior to this capture can be accomplished by setting the
+  Param ``image-builder/post-builder-flexiflow`` to a list of additional
+  Tasks to execute.
+
+Meta:
+  color: purple
+  icon: pin
+  title: Digital Rebar Image Builder
+  origin: rackn/image-builder
+Reboot: false
+Tasks:
+  - image-capture
+Templates: []
+

--- a/image-builder/stages/image-builder-linux.yaml
+++ b/image-builder/stages/image-builder-linux.yaml
@@ -18,7 +18,13 @@ Documentation: |
     2. Update all packages to the latest versions in the package repositories
     3. Install ``cloud-init`` for image bootstrap configuration
     4. Clean up the image by stripping out useless kernels, package meta files, etc.
-    5. Perform the root filesystem tarball capture and stage it to the DRP Endpoint for use
+
+  With use of the ``image-builder/pre-builder-workflow`` Paramater on the builder
+  machine, a dynamic list of *Tasks* can be injected **BEFORE** this Stage.
+
+  With use of the ``image-builder/post-builder-flexiflow`` Parameter on the
+  builder machine, a dynamic list of *Tasks* can be injected **AFTER** this Stage,
+  but before the final image is captured.
 
 Meta:
   color: purple
@@ -31,6 +37,5 @@ Tasks:
   - image-update-packages
   - image-install-cloud-init
   - image-builder-cleanup
-  - image-capture
 Templates: []
 

--- a/image-builder/stages/image-builder-post-builder-flexiflow.yaml
+++ b/image-builder/stages/image-builder-post-builder-flexiflow.yaml
@@ -1,0 +1,36 @@
+---
+Name: image-builder-post-builder-flexiflow
+Description: Utilizes flexiflow to expand the image-builder content dynamically.
+Documentation: |
+  This stage utilizes the Flexiflow content pack to allow image builds that
+  can dynamically inject new tasks to customize the OS/image before cleanup.
+
+  To utilize this, please review the Flexiflow content for more complete details.
+  Basic usage:
+
+    * set the Param ``image-builder/post-builder-flexiflow`` as an Array of tasks to inject in place of this stage
+
+  Example:
+
+    ::
+
+      image-builder/post-builder-flexiflow:
+        - additional-cleanup
+
+  In our theoretical example above, we have 1 task.  This task is run after the
+  ``image-builder-cleanup`` task, but before the image is captured.  It allows
+  the operator to inject additional tasks post-cleanup for any additional
+  preparation of the image just prior to capturing the image.
+
+Meta:
+  color: purple
+  icon: pin
+  title: Digital Rebar Image Builder
+  origin: rackn/image-builder
+Params:
+  flexiflow/list-parameter: image-builder/post-builder-flexiflow
+Templates: []
+Tasks:
+  - flexiflow-start
+  - flexiflow-stop
+

--- a/image-builder/stages/image-builder-pre-builder-flexiflow.yaml
+++ b/image-builder/stages/image-builder-pre-builder-flexiflow.yaml
@@ -1,0 +1,39 @@
+---
+Name: image-builder-pre-builder-flexiflow
+Description: Utilizes flexiflow to expand the image-builder content dynamically.
+Documentation: |
+  This stage utilizes the Flexiflow content pack to allow image builds that
+  can dynamically inject new tasks to customize the OS/image before cleanup.
+
+  To utilize this, please review the Flexiflow content for more complete details.
+  Basic usage:
+
+    * set the Param ``image-builder/pre-builder-flexiflow`` as an Array of tasks to inject in place of this stage
+
+  Example:
+
+    ::
+
+      image-builder/pre-builder-flexiflow:
+        - repository-add
+        - install-my-packages
+        - repository-remove
+
+  In our theoretical example above, we have 3 tasks.  The first should add a new
+  repository to the installed system (for example EPEL).  The second would install
+  some packages that are contained in the example repository.  The third then
+  removes the example repository from the sysmem - so the final installed system
+  is in a clean state without those repos.
+
+Meta:
+  color: purple
+  icon: pin
+  title: Digital Rebar Image Builder
+  origin: rackn/image-builder
+Params:
+  flexiflow/list-parameter: image-builder/pre-builder-flexiflow
+Templates: []
+Tasks:
+  - flexiflow-start
+  - flexiflow-stop
+

--- a/image-builder/workflows/image-builder-centos.yaml
+++ b/image-builder/workflows/image-builder-centos.yaml
@@ -21,6 +21,9 @@ Stages:
   - centos-7-install
   - ssh-access
   - drp-agent
+  - image-builder-pre-builder-flexiflow
   - image-builder-linux
-  - finish-install
+  - image-builder-post-builder-flexiflow
+  - image-builder-capture
+  - complete-nobootenv
 

--- a/image-builder/workflows/image-builder-centos8.yaml
+++ b/image-builder/workflows/image-builder-centos8.yaml
@@ -21,6 +21,9 @@ Stages:
   - centos-8-install
   - ssh-access
   - drp-agent
+  - image-builder-pre-builder-flexiflow
   - image-builder-linux
-  - finish-install
+  - image-builder-post-builder-flexiflow
+  - image-builder-capture
+  - complete-nobootenv
 

--- a/image-builder/workflows/image-builder-rhel.yaml
+++ b/image-builder/workflows/image-builder-rhel.yaml
@@ -22,5 +22,9 @@ Stages:
   - redhat-subscription-register
   - ssh-access
   - drp-agent
+  - image-builder-pre-builder-flexiflow
   - image-builder-linux
-  - finish-install
+  - image-builder-post-builder-flexiflow
+  - image-builder-capture
+  - complete-nobootenv
+

--- a/image-builder/workflows/image-builder-ubuntu-bionic.yaml
+++ b/image-builder/workflows/image-builder-ubuntu-bionic.yaml
@@ -21,5 +21,9 @@ Stages:
   - ubuntu-18.04-install
   - ssh-access
   - drp-agent
+  - image-builder-pre-builder-flexiflow
   - image-builder-linux
-  - finish-install
+  - image-builder-post-builder-flexiflow
+  - image-builder-capture
+  - complete-nobootenv
+


### PR DESCRIPTION
- adds two _Flexiflow_ Task injection points in to the workflows
- moves the capture process to it's own stage, to allow _Flexiflow_ injection after cleanup, but before capture
- adds _Flexiflow_ stages in the following places :
  * prior to the `image-builder-linux` stage customizations
  * after the `image-builder-linux` stage, and before the `image-builder-capture` stage