### PR TITLE
feat(content): Add access-ssh-parameters and template override

### DIFF
--- a/content/tasks/ssh-access.yaml
+++ b/content/tasks/ssh-access.yaml
@@ -6,13 +6,23 @@ Documentation: |
   and makes sure that the sshd config for PermitRootLogin is populated.
 
   Runs as part of a shell script for kickstart or net-post-install.
-  The template does nothing if access-keys, access-keys-sharedm AND access-keys-global are undefined
+
+  If the `access-ssh-template` is specified, that template is used to replace
+  the existing sshd config file.
+
+  Otherwise, the task will use the access-keys, access-keys-shared, and access-keys-global
+  parameters to define keys to inject into the authorized_keys file for root.
+
+  The access-ssh-root-mode and access-ssh-parameters will alter the sshd config file.
+  The access-ssh-parameters parameter is a general key/value map to replace config sections.
 
   Optional Parameters:
   * access-keys
   * access-keys-shared
   * access-keys-global
   * access-ssh-root-mode
+  * access-ssh-parameters
+  * access-ssh-template
 
   Parameter YAML format:
 
@@ -32,6 +42,8 @@ OptionalParams:
   - "access-keys-shared"
   - "access-keys-global"
   - "access-ssh-root-mode"
+  - "access-ssh-template"
+  - "access-ssh-parameters"
 Templates:
   - ID: "access-keys.sh.tmpl"
     Name: "Put access keys in place for root user"

--- a/content/templates/access-keys.sh.tmpl
+++ b/content/templates/access-keys.sh.tmpl
@@ -1,24 +1,6 @@
 #!/bin/bash
 #
-# This template populates the root's authorized keys file
-# and makes sure that the sshd config for PermitRootLogin is populated.
-#
-# Runs as part of a shell script for kickstart or net-post-install
-# The template does nothing if access-keys is undefined
-#
-# Required Parameters: access-keys
-# Optional Parameters: access-ssh-root-mode
-#
-# Parameter YAML format:
-#
-# access-keys:
-#   greg:  ssh-rsa key
-#   greg2:  ssh-rsa key
-# access-ssh-root-mode: "without-password|yes|no|forced-commands-only"
-#
-# Defaults:
-# access-keys - empty
-# access-ssh-root-mode - defaults to "without-password" if unspecified
+# See task definition for more information.
 #
 
 {{if or (.ParamExists "access-keys") (or (.ParamExists "access-keys-global") (.ParamExists "access-shared")) }}
@@ -43,6 +25,7 @@ cat >>$KEYS <<EOFSSHACCESS
 {{end -}}
 {{end -}}
 EOFSSHACCESS
+
 # if the we are called multiple times we get duplicate keys, lets fix that
 cat $KEYS | sort -u > $TMP_KEYS
 [[ -s "$TMP_KEYS" ]] && cp $TMP_KEYS $KEYS
@@ -50,6 +33,11 @@ cat $KEYS | sort -u > $TMP_KEYS
 chmod 600 $KEYS
 {{end}}
 
+{{if .ParamExists "access-ssh-template" }}
+cat >/etc/ssh/sshd_config <<EOFSSHCONFIG
+{{ .CallTemplate (.Param "access-ssh-template") . }}
+EOFSSHCONFIG
+{{ else }}
 echo "Updating SSHD default values"
 # This is Ubuntu-ish - so keep it - though it doesn't really work properly without the below as well.
 sed --in-place -r -e '/^#?PermitRootLogin/ s/^#//' -e '/^#?PermitRootLogin/ s/prohibit-password/{{if .ParamExists "access-ssh-root-mode"}}{{.Param "access-ssh-root-mode"}}{{else}}without-password{{end}}/' /etc/ssh/sshd_config
@@ -61,6 +49,19 @@ sed --in-place -r -e '/PermitRootLogin/ s/PermitRootLogin .*/PermitRootLogin {{i
 sed --in-place -r -e '/^#?PasswordAuthentication/ s/^#//' /etc/ssh/sshd_config
 sed --in-place -r -e '/PasswordAuthentication/ s/PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config
 {{ end }}
+{{ end }}
+
+{{if .ParamExists "access-ssh-parameters" }}
+{{ range $k, $v := .Param "access-ssh-parameters" }}
+if grep -q "{{$k}} " /etc/ssh/sshd_config ; then
+    sed --in-place -r -e '/^#?{{$k}}/ s/^#//' /etc/ssh/sshd_config
+    sed --in-place -r -e '/{{$k}}/ s/{{$k}} .*/{{$k}} {{$v}}/' /etc/ssh/sshd_config
+else
+    sed --in-place "$ a\{{$k}} {{$v}}" /etc/ssh/sshd_config
+fi
+  {{ end }}
+{{ end }}
+
 {{ end }}
 
 # Restart sshd but os badness.


### PR DESCRIPTION
These two new parameters allow for the extension of the ssh
config file.  The access-ssh-temmplate allows for complete override
with your own template.  access-ssh-parameters allows for key/value
style replacement of entries in the config file.