### PR TITLE
fix(vmware-lib): OVFTool without datastore defined caused invalid cmd generation

### DIFF
--- a/vmware-lib/content/tasks/ovftool-deploy.yaml
+++ b/vmware-lib/content/tasks/ovftool-deploy.yaml
@@ -108,7 +108,7 @@ Templates:
         {{- range $idx, $element := $netmap }}
         {{ $netkey := get $element "Name" }}{{ $netval := get $element "Network" }}--net:"{{ $netkey }}"="{{ $netval }}" \\
         {{- end }}
-        {{ if ( .Param "govc/datastore" ) }}--datastore="{{ .ParamExpand "govc/datastore" }}" \\{{ else }}{{ end }}
+        {{ if ( .Param "govc/datastore" ) }}--datastore="{{ .ParamExpand "govc/datastore" }}"{{ else }}{{ end }} \\
         {{ .ParamExpand "govc/ova-location" }} \\
         'vi://
               {{- .Param "govc/username" -}}:{{- .Param "govc/password" -}}


### PR DESCRIPTION

If no datastore is specified, then the command output that is generated had an empty line without a backslash continuation.  This fixes that condition.