### PR TITLE
feat(content): security flag overrides debug to protect sensitive data

### DIFF
--- a/content/params/security-debug-block.yaml
+++ b/content/params/security-debug-block.yaml
@@ -1,0 +1,24 @@
+---
+Name: "security/debug-block"
+Description: "Blocks rs-debug-enable from being turned on."
+Documentation: |
+  Since rs-debug-enable may expose sensitive information,
+  setting ANY value in this Param will block places where
+  rs-debug-enable can be set in common libraries.
+
+  If true, it will
+    1. set RS_DEBUG_ENABLE=false in setup.tmpl
+    2. attempt to set rs-debug-enable:false on the machine if it was set true
+  
+  If false, it will not set RS_DEBUG_ENABLE at all or change machine values
+
+  Design note: use of this variable is exists or not exists
+  because we do not want potential users to be able to override
+  a true value with a false value anywhere in the resolution chain.
+Schema:
+  type: "boolean"
+Meta:
+  type: "security"
+  icon: "spy"
+  color: "green"
+  title: "Digital Rebar Community Content"

--- a/content/templates/setup.tmpl
+++ b/content/templates/setup.tmpl
@@ -17,26 +17,34 @@
 
 set -e
 
-function xiterr() { [[ $1 =~ ^[0-9]+$ ]] && { XIT=$1; shift; } || XIT=1; echo "FATAL: $*";  __exit $XIT; }
-
-###
-#  if we want debugging of our scripts, set the Param to true
-#  also set shell variable for script reuse if desired for further
-#  debugging
-###
-{{ if .ParamExists "rs-debug-enable" }}
-{{ if eq (.Param "rs-debug-enable") true }}
-# use in shell as: [[ $RS_DEBUG_ENABLE ]] && echo "debugging"
-RS_DEBUG_ENABLE="{{.Param "rs-debug-enable"}}"
-set -x
-{{ end }}
-{{ end }}
-
 # We pretty much always need these parameters set, but
 # don't overwrite them if they already exist.
 [[ $RS_TOKEN ]] || export RS_TOKEN="{{.GenerateInfiniteToken}}"
 [[ $RS_ENDPOINT ]] || export RS_ENDPOINT="{{.ApiURL}}"
 [[ $RS_UUID ]] || export RS_UUID="{{.Machine.UUID}}"
+
+###
+#  if we want debugging of our scripts, set the Param to true
+#  also set shell variable for script reuse if desired for further
+#  debugging
+#  for security, this can be disabled universally by setting security/debug-block
+###
+{{ if .ParamExists "rs-debug-enable" }}
+  {{ if .Param "rs-debug-enable" }}
+    {{ if .ParamExists "security/debug-block"}}
+      {{ if .Param "security/debug-block" }}
+      echo "NOTE: secury/debug-block enabled: overriding rs-debug-enable on machine"
+      drpcli machines set $RS_UUID param rs-debug-enable to false > /dev/null
+      {{ end }}
+    {{ else }}
+      # use in shell as: [[ $RS_DEBUG_ENABLE ]] && echo "debugging"
+      RS_DEBUG_ENABLE="{{.Param "rs-debug-enable"}}"
+      set -x
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+function xiterr() { [[ $1 =~ ^[0-9]+$ ]] && { XIT=$1; shift; } || XIT=1; echo "FATAL: $*";  __exit $XIT; }
 
 function fixup_path() {
   local _add_path


### PR DESCRIPTION
From reviewing our terraform, ansiblie and kubernetes content, I realized that an operator could add code to enable the rs-debug-enable flag and potentially show sensitive information in the job logs.

This provides a security/* param that can override that behavior for administrators that want to block it.