### PR TITLE
refactor(cloud-wrapper): use template vars and make icon selection smarter

### DIFF
--- a/cloud-wrappers/params/cloud-provider-icon.yaml
+++ b/cloud-wrappers/params/cloud-provider-icon.yaml
@@ -1,0 +1,26 @@
+---
+Name: "cloud/provider-icons"
+Description: "Cloud Provider Icons"
+Documentation: |
+  List of icons to use for Cloud Providers
+
+  Implemented clouds: aws, google, linode, azure, default
+
+  Expand this list as new types are added!
+Schema:
+  type: "object"
+  default:
+    aws: "aws"
+    azure: "microsoft"
+    default: "cloud"
+    google: "google"
+    linode: "linode"
+    digitalocean: "digital ocean"
+    
+  required:
+    - "default"
+Meta:
+  type: "value"
+  icon: "cloud"
+  color: "black"
+  title: "Digital Rebar Community Content"

--- a/cloud-wrappers/tasks/cloud-inspect.yaml
+++ b/cloud-wrappers/tasks/cloud-inspect.yaml
@@ -6,7 +6,7 @@ Documentation: |
 RequiresParams:
 
 Templates:
-  - Name: "discover-cloud-metadata"
+  - Name: "cloud-inspect"
     Contents: |
       #!/bin/bash
       # RackN Copyright 2020
@@ -15,11 +15,12 @@ Templates:
       {{template "setup.tmpl" .}}
 
       {{ if .ParamExists "cloud/provider" }}
+      {{ $cloud := (.Param "cloud/provider") }}
 
       # Ubuntu Path is different than Centos Path - fix it.
       export PATH=$PATH:/usr/bin:/usr/sbin:/bin:/sbin
 
-      {{ if eq "aws" (.Param "cloud/provider") }}
+      {{ if eq "aws" $cloud }}
       echo "============================= AWS INSPECT ============================="
       INSTANCEID=$(curl -sfL http://169.254.169.254/latest/meta-data/instance-id)
       echo "Looking for {{ .Param "cloud/provider"}} Instance ID, found \"$INSTANCEID\""
@@ -39,7 +40,7 @@ Templates:
       {{ end }}
 
 
-      {{ if eq "google" (.Param "cloud/provider") }}
+      {{ if eq "google" $cloud }}
       echo "============================= GOOGLE INSPECT ============================="
       INSTANCEID=$(curl -sfL -H "Metadata-Flavor: Google" http://metadata/computeMetadata/v1/instance/id)
       echo "Looking for {{ .Param "cloud/provider"}} Instance ID, found \"$INSTANCEID\""
@@ -62,7 +63,7 @@ Templates:
       fi
       {{ end }}
 
-      {{ if eq "linode" (.Param "cloud/provider") }}
+      {{ if eq "linode" $cloud }}
       echo "============================= LINODE INSPECT ============================="
 
         {{ if .ParamExists "terraform-var/instance_id" }}
@@ -75,7 +76,7 @@ Templates:
 
       {{ end }}
 
-      {{ if eq "azure" (.Param "cloud/provider") }}
+      {{ if eq "azure" $cloud }}
       echo "============================= LINODE INSPECT ============================="
 
         {{ if .ParamExists "terraform-var/instance_id" }}
@@ -93,9 +94,6 @@ Templates:
         drpcli machines update $RS_UUID '{"Description":"ERROR: You must define the cloud/provider!"}'
         exit 1
       {{ end }}
-
-      echo "set icon to cloud to show provisioned"
-      drpcli machines meta set $RS_UUID key icon to cloud > /dev/null
 
       echo "done"
       exit 0

--- a/cloud-wrappers/tasks/cloud-validate.yaml
+++ b/cloud-wrappers/tasks/cloud-validate.yaml
@@ -36,10 +36,11 @@ Templates:
       {{ end }}
 
       {{ if .ParamExists "cloud/provider" }}
+        {{ $cloud := .Param "cloud/provider" }}
 
         echo "We have cloud provider {{ .Param "cloud/provider"}}!  Do we have the right credentials?"
 
-        {{ if eq "aws" (.Param "cloud/provider") }}
+        {{ if eq "aws" $cloud }}
           {{ if .ParamExists "aws/secret-key" }}
             echo "  required secret-key is set"
           {{ else }}
@@ -56,7 +57,7 @@ Templates:
           {{ end }}
         {{ end }}
 
-        {{ if eq "google" (.Param "cloud/provider") }}
+        {{ if eq "google" $cloud }}
           {{ if .ParamExists "google/credential" }}
             echo "  required google/credentialis set"
           {{ else }}
@@ -73,7 +74,7 @@ Templates:
           {{ end }}
         {{ end }}
 
-        {{ if eq "linode" (.Param "cloud/provider") }}
+        {{ if eq "linode" $cloud }}
           echo "linode/token check..."
           {{ if .ParamExists "linode/token" }}
             echo "  required token is set"
@@ -94,7 +95,7 @@ Templates:
 
         {{ end }}
 
-        {{ if eq "azure" (.Param "cloud/provider") }}
+        {{ if eq "azure" $cloud }}
           {{ if .ParamExists "azure/subscription_id" }}
             echo "  required subscription_id is set"
           {{ else }}
@@ -124,6 +125,15 @@ Templates:
             exit 1
           {{ end }}
         {{ end }}
+
+        cloudicon="cloud"
+        {{ if hasKey (.Param "cloud/provider-icons") $cloud }}
+          cloudicon={{ get (.Param "cloud/provider-icons") $cloud }}
+        {{ else }}
+          cloudicon={{ get (.Param "cloud/provider-icons") "default" }}
+        {{ end }}
+        echo "set icon to $cloudicon"
+        drpcli machines meta set $RS_UUID key icon to $cloudicon > /dev/null
 
       {{ else }}
         echo "You must define which cloud is being used!"


### PR DESCRIPTION
When provisioning cloud-wrapper against multiple clouds at the same time, it would be helpful to show different Icons instead of generic "cloud" for each one.