### PR TITLE
enhance(drp-community-content): Add 'network-manage-routes task

### DIFF
--- a/content/._RequiredFeatures.meta
+++ b/content/._RequiredFeatures.meta
@@ -1,1 +1,1 @@
-sane-exit-codes, job-exit-states, fsm-runner, workflows, default-workflow, http-range-header, roles, tenants, sprig, multiarch, overridable-bootloaders, centos-8
+sane-exit-codes, job-exit-states, fsm-runner, workflows, default-workflow, http-range-header, roles, tenants, sprig, multiarch, overridable-bootloaders, centos-8, virtual-media-boot

--- a/content/params/network-data-tag.yaml
+++ b/content/params/network-data-tag.yaml
@@ -1,0 +1,18 @@
+---
+Name: network-data-tag
+Description: Defines the named object to select a data structure from the network-data Param.
+Documentation: |
+  This Param sets the named object tag which should be selected from the
+  ``network-data`` Param structure.  This defines which data structure will be
+  used when appropriate tasks/templates are applying network configuration values.
+
+  .. note:: This Param structure will be replaced with a new tagging method defined in
+            *Universal Workflow*.
+
+Meta:
+  color: blue
+  icon: list alternate outline
+  title: Digital Rebar
+Schema:
+  type: string
+  default: ""

--- a/content/params/network-manage-routes-command.yaml
+++ b/content/params/network-manage-routes-command.yaml
@@ -1,0 +1,21 @@
+---
+Name: network-manage-routes-command
+Description: Defines if an add or remove network route action should be taken. (default is add)
+Documentation: |
+  The ``network-manage-routes`` task can either add or remove routes.  This param
+  defines which action for that Task to take.  By default, the task will add routes,
+  unless this param is set on the machine with the value ``remove``.
+
+  The only allowed values are ``add`` or ``remove``; with the default set to add.
+
+Meta:
+  color: blue
+  icon: list
+  title: Digital Rebar
+Schema:
+  default: add
+  type: string
+  enum:
+    - add
+    - remove
+

--- a/content/stages/network-manage-routes.yaml
+++ b/content/stages/network-manage-routes.yaml
@@ -1,0 +1,54 @@
+---
+Name: "network-manage-routes"
+Description: "Stage to set additional routes based on 'network-data' values. (Linux/ESXi/Darwin)"
+Documentation: |
+  This stage uses the ``network-data`` structure to set or remove any routes specified
+  based on the reference tag named in ``network-data-tag`` Param setting.
+
+  The action of add or remove is controlled by the Param ``network-manage-routes-command``, which
+  defaults to adding routes to a system.
+
+  An example of ``network-data`` Param values known to work with this Stage are as follows
+  (the Param ``network-data-tag`` would be set to ``myroutes`` in this example):
+
+  in YAML format:
+    ::
+
+      network-data:
+        myroutes:
+          routes:
+          - gateway: 192.168.100.1
+            netmask: 255.255.255.0
+            network: 10.10.10.0
+          - gateway: 172.17.92.254
+            netmask: 255.255.255.0
+            network: 10.20.20.0
+
+  in JSON Format:
+
+    ::
+
+      {
+        "myroutes": {
+          "routes": [
+            { "gateway": "192.168.100.1", "netmask": "255.255.255.0", "network": "10.10.10.0" },
+            { "gateway": "172.17.92.254", "netmask": "255.255.255.0", "network": "10.20.20.0" }
+          ]
+        }
+      }
+
+  .. note:: The ``network-data`` structure is used for other network plumbing purposes too.  This
+            example only shows valid syntax for adding routes.  Additional stanzas are likely to
+            appear in a valid data structure.  See the documentation on the Param for more details.
+
+Meta:
+  color: "blue"
+  icon: "list alternate outline"
+  title: "RackN Content"
+RequiredParams:
+  - network-data
+  - network-data-tag
+OptionalParams:
+  - network-manage-routes-command
+Tasks:
+  - network-manage-routes

--- a/content/tasks/network-manage-routes.yaml
+++ b/content/tasks/network-manage-routes.yaml
@@ -1,0 +1,161 @@
+---
+Name: "network-manage-routes"
+Description: "Set/Remove routes based on 'network-data' Param values. (Linux/ESXi/Darwin)"
+Documentation: |
+  Configure the system to add or remove additional Route statements provided in the
+  ``network-data`` Param.  The ``network-manage-routes-command`` should be set to one
+  of ``add`` or ``delete`` to define which action to take.
+
+  If a route exists already, and the ``add`` action has been set (the default), then
+  the route will first be removed, then re-added.
+
+  In addition to ``network-data``, the ``network-data-tag`` must be specified to
+  select the correct set of configuration data references found in ``network-data``.
+
+  This task is designed to work on Linux (via ``ip2`` suite of commands), ESXi,
+  and MacOS X (Darwin).  As such, it uses ``sh`` since VMware vSphere ESXi
+  appliances do not have a proper BASH shell (they use a modified busybox shell).
+
+Meta:
+  icon: "cloud"
+  color: "yellow"
+  title: "Digital Rebar"
+RequiredParams:
+  - "network-data"
+  - "network-data-tag"
+  - "network-manage-routes-command"
+Templates:
+  - Name: "network-manage-routes.sh"
+    Contents: |
+      #!/usr/bin/env sh
+      # Set additional network routes from 'network-data' Param
+
+      ###
+      #  NOTE - must use 'sh' for ESXi as 'bash' is not available, the shell
+      #         constructs here must be compatible with ESXi busybox shell.
+      #
+      #       - needs support added for routes via Device (interfaces)
+      ###
+
+      echo ""
+
+      xiterr() { [[ $1 =~ ^[0-9]+$ ]] && { XIT=$1; shift; } || XIT=1; printf "FATAL: $*\n"; exit $XIT; }
+      {{ if eq (.Param "rs-debug-enable") true }}set -x{{ end }}
+      set -e
+
+      ### begin convert_ipv4_netmask_to_cidr_prefix.sh.tmpl
+      {{ template "convert_ipv4_netmask_to_cidr_prefix.sh.tmpl" . }}
+
+      ### begin network-manage-routes.sh
+      #
+      verify_and_remove() {
+        echo ">>> Checking if route exists on system."
+        if eval $CHK
+        then
+          echo "Route '$CIDR' via gateway '$GW' exists on system.  Removing."
+          echo ">>> Remove with CMD:  $REM"
+          eval $REM
+        else
+          echo ">>> No existing route found.  No remove action performed."
+        fi
+      }
+
+      {{ $tag := ( .Param "network-data-tag" ) -}}
+      TAG="{{ $tag }}"
+      [[ -z "$TAG" ]] && xiterr 1 "Required 'network-data-tag' not specified." || true
+
+      ACTION="{{ .Param "network-manage-routes-command" }}"
+
+      echo ">>> Processing network-data tag '$TAG' values ..."
+
+      {{ if .ParamExists "network-data" -}}
+      {{ $netdata := .ComposeParam "network-data" -}}
+
+      {{ if ( hasKey $netdata $tag ) -}}
+      {{ $tagdata := ( get $netdata $tag ) -}}
+      {{ range $rkey, $route := ( get $tagdata "routes" ) -}}
+      # initialize variables to empty value for iterative range loops
+      VER="" NW="" NM="" BITS="" CIDR="" GW=""
+
+      # ESXi route command requires explicit IPv4 or IPv6 callout - it's not smart
+      # enough to figure it out on it's own
+      VER="{{ if ( contains ":" ( get $route "network" ) ) }}ipv6{{ else }}ipv4{{ end }}"
+
+      {{ if and ( get $route "network" ) ( get $route "netmask" ) -}}
+      NW="{{ get $route "network" }}"
+      NM="{{ get $route "netmask" }}"
+
+      #BITS="$(convert_ipv4_netmask_to_cidr_prefix $NM)"
+      # requires DRP version v4.6.0 with the Feature Flag "virtual-media-boot"
+      BITS="{{ $.NetmaskToCIDR (get $route "netmask" ) }}"
+      CIDR="$NW/$BITS"
+      {{ else -}}
+      xiterr 1 "No required network and/or netmask specified in 'routes' section for '$TAG'."
+      {{ end -}}
+
+      {{ if ( get $route "gateway" ) -}}
+      GW={{ get $route "gateway" }}
+      {{ else -}}
+      xiterr 1 "No required gateway defined in 'routes' section for '$TAG'."
+      {{ end -}}
+
+      ###
+      #  Set our add, remove, and check commands for different system platforms.
+      ###
+      SYS=$(uname -s)
+      case $SYS in
+        VMkernel) ADD="esxcli network ip route $VER add --network=$CIDR --gateway=$GW"
+                  REM="esxcli network ip route $VER remove --network=$CIDR --gateway=$GW"
+                  CHK="esxcli network ip route $VER list | egrep -q \"${NW}.*${NM}\""
+        ;;
+        Linux)    ADD="ip route add $CIDR via $GW"
+                  REM="ip route del $CIDR via $GW"
+                  CHK="ip route list | grep -q \"$CIDR via $GW\""
+        ;;
+        Darwin)   ADD="sudo route -n add -net $CIDR $GW"
+                  # allow MacOS X to fail without causing task to error out
+                  REM="sudo route -n delete -net $CIDR $GW || true"
+                  # thank you MacOS X for converting network info to shorthand
+                  # they change "10.10.10.0/24" to "10.10.10/24" in routing tables
+                  # "echo" will always succeed, so we'll always try to remove the route
+                  CHK="echo"
+        ;;
+        *)        xiterr 1 "unsupported OS ('$SYS') for adding routes" ;;
+      esac
+
+      echo ""
+      echo "===================== setting route ====================="
+      echo ""
+      echo " requested action:  $ACTION"
+      echo "     machine type:  $SYS"
+      echo "IP protocol suite:  $VER  (*)"
+      echo "          Network:  $NW"
+      echo "          Netmask:  $NM"
+      echo "        CIDR bits:  $BITS"
+      echo "    CIDR notation:  $CIDR"
+      echo "  Network Gateway:  $GW"
+      echo ""
+      echo "===================== setting route ====================="
+      echo ""
+      echo "NOTE: (*) determined dynamically if Network has colon in it (IPv6) or not (IPv4)."
+      echo ""
+
+      # "remove" handled in above, so we don't need to specify it in 'case' statement
+      case "$ACTION" in
+        remove) verify_and_remove ;;
+        add)
+          verify_and_remove
+          echo ">>> Add with CMD:  $ADD"
+          eval $ADD
+          echo ""
+        ;;
+      esac
+      {{ end -}}
+
+      {{ else -}}
+      xiterr 1 "No data with tag of '$TAG' found in 'network-data' structure Param."
+      {{ end -}}
+
+      {{ else -}}
+      xiterr 1 "Required Param 'network-data' structure not provided."
+      {{ end -}}

--- a/content/templates/convert_ipv4_netmask_to_cidr_prefix.sh.tmpl
+++ b/content/templates/convert_ipv4_netmask_to_cidr_prefix.sh.tmpl
@@ -1,0 +1,72 @@
+#!/usr/bin/env sh
+# Returns the CIDR Prefix (eg "24") for an IPv4 network netmask provided as ARGv1
+
+###
+#  NOTE:  Uses 'sh' intentionally; may run in ESXi environment which does not have
+#         a valid BASH shell.
+#
+#         DOES NOT support IPv6 netmask to cidr prefix notation.
+###
+
+###
+#  Expects ARGv1 of input to be a validly formed IPv4 network netmask.
+###
+convert_ipv4_netmask_to_cidr_prefix() {
+  local _nm="$1"
+
+  if [[ -z "$_nm" ]]
+  then
+    echo "FATAL: No network netmask provided as ARGv1."
+    exit 1
+  else
+    echo $_nm | grep -w -E -o '^(254|252|248|240|224|192|128)\.0\.0\.0|255\.(254|252|248|240|224|192|128|0)\.0\.0|255\.255\.(254|252|248|240|224|192|128|0)\.0|255\.255\.255\.(254|252|248|240|224|192|128|0)' > /dev/null
+    if [[ $? -ne 0 ]]
+    then
+      echo "FATAL: ARGv1 network netmask ('$_nm') is not a valid IPv4 formatted netmask"
+      exit 1
+    fi
+  fi
+
+  ###
+  #  Because ... ESXi does not have 'bc', 'atoi', or a whole lot of real tools ... this
+  #  is super ugly low tech, but works ...
+  ###
+  case "$_nm" in
+    "128.0.0.0") echo "1" ;;
+    "192.0.0.0") echo "2" ;;
+    "224.0.0.0") echo "3" ;;
+    "240.0.0.0") echo "4" ;;
+    "248.0.0.0") echo "5" ;;
+    "252.0.0.0") echo "6" ;;
+    "254.0.0.0") echo "7" ;;
+    "255.0.0.0") echo "8" ;;
+    "255.128.0.0") echo "9" ;;
+    "255.192.0.0") echo "10" ;;
+    "255.224.0.0") echo "11" ;;
+    "255.240.0.0") echo "12" ;;
+    "255.248.0.0") echo "13" ;;
+    "255.252.0.0") echo "14" ;;
+    "255.254.0.0") echo "15" ;;
+    "255.255.0.0") echo "16" ;;
+    "255.255.128.0") echo "17" ;;
+    "255.255.192.0") echo "18" ;;
+    "255.255.224.0") echo "19" ;;
+    "255.255.240.0") echo "20" ;;
+    "255.255.248.0") echo "21" ;;
+    "255.255.252.0") echo "22" ;;
+    "255.255.254.0") echo "23" ;;
+    "255.255.255.0") echo "24" ;;
+    "255.255.255.128") echo "25" ;;
+    "255.255.255.192") echo "26" ;;
+    "255.255.255.224") echo "27" ;;
+    "255.255.255.240") echo "28" ;;
+    "255.255.255.248") echo "29" ;;
+    "255.255.255.252") echo "30" ;;
+    "255.255.255.254") echo "31" ;;
+    "255.255.255.255") echo "32" ;;
+    *) echo "FATAL: invalid input netmask '$1' format."
+       exit 1
+    ;;
+  esac
+}
+


### PR DESCRIPTION
Adds new feature to DRP Community Content to allow adding or removing Routes from Linux, ESXi, or MacOS X systems in the same task.  Utilizes the new `network-data` structure to describe network details, including Routes to manipulate.  In addition, the following params control the behavior of the Task:
- `network-data-tag` - defines which structure in `network-data` to get routes from
- `network-manage-routes-command` - defines "add" or "remove" action for route manipulation

Should work with both IPv4 and IPv6 addressing, assuming the underlaying OS Route command support the syntax.  For ESXi, the Network definition is used to dynamically determine if it's an IPv4 or IPv6 route action needed, since ESXi does not know how to parse the address to determine that.