### PR TITLE
fix(classify): Fix typos in function names

### DIFF
--- a/classify/templates/classify-base-actions.sh.tmpl
+++ b/classify/templates/classify-base-actions.sh.tmpl
@@ -10,7 +10,7 @@ function cl_set_parameter() {
   drpcli machines set $RS_UUID param "$_parameter" to "$_value" >/dev/null
 }
 
-function set_paramater() {
+function set_parameter() {
   cl_set_parameter "$1" "$2"
 }
 

--- a/classify/templates/classify-base-tests.sh.tmpl
+++ b/classify/templates/classify-base-tests.sh.tmpl
@@ -68,8 +68,8 @@ function get_my_mac() {
   MY_MAC_ADDR="$_macaddr"
 }
 
-function get_my_mac() {
-  cl_get_my_mac
+function cl_get_my_mac() {
+  get_my_mac
 }
 
 # extends Classifier to check if 'inventory-data' field matches value


### PR DESCRIPTION
Fix several typos in classify function names.