### PR TITLE
enhance(drp-community-content): Add 'network-data' parser

### DIFF
--- a/content/params/network-data-output-type.yaml
+++ b/content/params/network-data-output-type.yaml
@@ -1,0 +1,32 @@
+---
+Name: "network-data-output-type"
+Description: "Defines what variable output type for 'network-data-parser.tmpl' template."
+Documentation: |
+  The template ``network-data-parser.tmpl`` parses the ``network-data`` structure in a
+  consistent manner and set of rules.  To reuse the parsing rules, include the template
+  in to other templates.  Since golang templating can't pass variables from an
+  included template in to the scope of the operating template, we must rely on the
+  scripted language Varaible definitions.
+
+  Setting this Param to one of the supported types, will tell the ``network-data-parser.tmpl``
+  to generate the correct Variable references for the targeted scripting language.
+  Supported scripted languages are:
+
+    * ``shell`` = Shell (BASH, SH, ZSH, etc)
+    * ``powershell`` = PowerShell
+    * ``python`` = Python (2 and 3 compatible)
+
+  The default value if not otherwise specified is ``shell`` (BASH, SH, etc).
+
+Schema:
+  type: string
+  enum:
+    - shell
+    - powershell
+    - python
+  default: shell
+Meta:
+  type: "value"
+  icon: "file alternate outline"
+  color: "green"
+  title: "Digital Rebar Community Content"

--- a/content/params/network-data-output-type.yaml
+++ b/content/params/network-data-output-type.yaml
@@ -12,11 +12,17 @@ Documentation: |
   to generate the correct Variable references for the targeted scripting language.
   Supported scripted languages are:
 
-    * ``shell`` = Shell (BASH, SH, ZSH, etc)
+    * ``shell`` = Shell (BASH, SH, ZSH, BusyBox, ASH, ESXi Shell, etc)
     * ``powershell`` = PowerShell
     * ``python`` = Python (2 and 3 compatible)
 
-  The default value if not otherwise specified is ``shell`` (BASH, SH, etc).
+  If the ``shell`` environment type does not support the ``declare`` function, it is
+  assumed that Arrays are not supported either.  In this case, the Associative
+  Array and related debug (if requested) statements will not be generated in the
+  template.  This is necessary to support environments like VMware ESXi BusyBox/ASH
+  shells.
+
+  The default value ``shell`` (BASH, SH, BusyBox, ASH, etc).
 
 Schema:
   type: string

--- a/content/params/network-data-parser-debug.yaml
+++ b/content/params/network-data-parser-debug.yaml
@@ -1,0 +1,17 @@
+---
+Name: "network-data-parser-debug"
+Description: "Turns on debug output in the 'network-data-parser.tmpl' template."
+Documentation: |
+  If set to boolean ``true``, will output simple Shell ``echo`` statements
+  with the parsed values from the ``network-data`` structure.  Technically,
+  the template should be complete shell/powershell/script agnostic, and use
+  of ``echo`` is Bash/SH/etc. specific statement syntax.
+
+Schema:
+  type: boolean
+  default: false
+Meta:
+  type: "enable"
+  icon: "bug"
+  color: "orange"
+  title: "Digital Rebar Community Content"

--- a/content/params/os-identity-system.yaml
+++ b/content/params/os-identity-system.yaml
@@ -1,0 +1,19 @@
+---
+Name: "os-identity/system"
+Description: "The value of the Operating System type (linux, vmware, windows)."
+Documentation: |
+  The value of the Operating System type, as discovered and set by the task
+  ``os-identity``.
+
+Meta:
+  icon: "microchip"
+  color: "blue"
+  title: "Digital Rebar Community Content"
+Schema:
+  type: "string"
+  default: ""
+  enum:
+    - ""
+    - "linux"
+    - "vmware"
+    - "windows"

--- a/content/stages/os-identity.yaml
+++ b/content/stages/os-identity.yaml
@@ -1,0 +1,14 @@
+---
+Name: "os-identity"
+Description: "A stage to set the installed Operating System identity Params."
+Documentation: |
+  This Stage sets the Operating System identity Params on the Machine
+  object.
+
+Meta:
+  icon: "key"
+  color: "blue"
+  title: "Digital Rebar Community Content"
+  feature-flags: "sane-exit-codes"
+Tasks:
+  - "os-identity"

--- a/content/tasks/os-identity.yaml
+++ b/content/tasks/os-identity.yaml
@@ -1,0 +1,19 @@
+---
+Name: "os-identity"
+Description: "A task to write the OS identity to the Machine object for later use."
+Documentation: |
+  A task to set the ``os-identity`` Param to a known value for future tasks to
+  utilize.
+Meta:
+  type: "setup"
+  icon: "wrench"
+  color: "yellow"
+  title: "Community Content"
+  feature-flags: "sane-exit-codes"
+  copyright: "RackN 2021"
+Templates:
+  - Name: "simple-params.py"
+    Path: "/tmp/simple-params.py"
+    ID: "simple-params.py.tmpl"
+  - Name: "os-identity.sh"
+    ID: "os-identity.sh.tmpl"

--- a/content/templates/network-data-parser.tmpl
+++ b/content/templates/network-data-parser.tmpl
@@ -125,44 +125,22 @@
 {{ $_ := set $NETDATA "dns_servers" ( trim $dsrvr ) -}}
 {{ $_ := set $NETDATA "ntp_servers" ( trim $nsrvr ) -}}
 
-{{- /* GENERATE appropriate shell/python/powershell variable definitions */ -}}
+{{- /* GENERATE shell (basic/advanced)/python/powershell variable definitions */ -}}
 
 {{- if eq $output  "shell" }}
-{{- /* *********************************** SHELL ********************************** */ -}}
+{{- /* ******************************  SHELL BASIC  ****************************** */ -}}
 ###
-#  Shell (BASH, SH, ZSH, etc) variable definitions of network-data structure
-###
-{{ range $key, $val := $NETDATA -}}
-_nd_{{ $key }}='{{ $val }}'
-{{ end -}}
-{{ if or ( eq .Env.OS.Family "vmware" ) (eq ( .Param "os-identity/system" ) "vmware" ) -}}
-###
-#  >>> VMware ESXi does not support associative arrays, no array rendered for use
-#  >>> since 'Env.Os.Family' returned 'vmware'
-#
-#  >>> use the 'fetch_nd_var()' function to get values (eg 'fetch_nd_var address')
-###
-{{ else -}}
-###
-#  Shell (sh/bash/zsh/etc) associative array (VMware ESXi busybox shell does not
-#  support this format)
-###
-declare -A _nd_data
-{{ range $key, $val := $NETDATA -}}
-  _nd_data[{{ $key }}]='{{ $val }}'
-{{ end -}} {{- /* end range $NETDATA */ -}}
-{{ end -}} {{- /* end if eq .Env.OS.Family */ -}}
-###
-#  Given a network-data key name as ARGv1, fetch the value from the associtive
-#  array if it exists.  If not, then get the value from the individual variables;
-#  for OSes (ESXi, etc) that do not support array variable types.
+#  Given a network-data key name as ARGv1, fetch the value from the associative
+#  array if exists (eg. 'declare' function found in shell environment).  If not
+#  then get the value from the individual variables; for OSes (ESXi, etc) that
+#  do not support array variable types.
 #
 #  example getting MTU value, assuming it's set to '9000':
 #    usage:  fetch_nd_var mtu
 #  returns:  9000
 #
-#  First searches _nd_data[mtu] if _nd_data exists.  Otherwise, returns the value
-#  from the variable _nd_mtu.
+#  First searches _nd_data[mtu] if the _nd_data array exists.  Otherwise,
+#  returns the value from the variable _nd_mtu.
 #
 #  Returns an empty string if the key has not been assigned any value.
 ###
@@ -180,30 +158,64 @@ fetch_nd_var() {
     echo "$_val"
   fi
 }
+
+###
+#  shell basic (BASH, SH, ZSH, etc) variable definitions of network-data structure
+#  No rendered associative arrays for shells like BusyBox/Ash that do not support
+#  them (eg. VMware ESXi).
+###
+{{ range $key, $val := $NETDATA -}}
+_nd_{{ $key }}='{{ $val }}'
+{{ end -}}
+
 {{ if $debug -}}
 ###
-#  enabled Shell debug output because 'network-data-parser-debug' is true
+#  enabled Shell debug output because 'network-data-parser-debug' is 'true'
 ###
 echo ""
-echo "DEBUG: 'network-data' parsing resulted in the following assignments:"
+echo "DEBUG: shell basic - 'network-data' resulted in the following assignments:"
 echo ""
 {{ range $key, $val := $NETDATA -}}
 printf ">>> %18s :: %s\n" "{{ $key }}" "$_nd_{{ $key }}"
 {{ end -}}
-{{ if or ( eq .Env.OS.Family "vmware" ) (eq ( .Param "os-identity/system" ) "vmware" ) -}}
-###
-#  In ESXi environment - no associative arrays were built, so no dump of them
-###
-{{ else -}}
-###
-#  Dump the associative array values
-###
-echo ""
-echo "DEBUG: dump of the _nd_data associative array:"
-echo ""
-for KEY in "${!_nd_data[@]}"; do printf ">>> %18s = '%s'\n" "[$KEY]" "${_nd_data[$KEY]}" ; done
-{{ end -}} {{- /* end if .Env.OS.Family or os-identity/system */ -}}
 {{ end -}} {{- /* end if $debug */ -}}
+
+###
+#  if 'declare' is not available, the shell doesn't support Array types
+###
+if ! type declare > /dev/null 2>&1
+then
+  ###
+  #  This shell does not support 'declare', which indicates it also does
+  #  not support Array type variables.  No associative array or related
+  #  debugging statements will be generated.
+  ###
+  echo ">>>"
+  echo ">>> No array support detected, no associative arrays or debug generated."
+  echo ">>>"
+else
+  ###
+  #  shell advanced (sh/bash/zsh/etc) associative array (VMware ESXi busybox
+  #  shell does not support this format)
+  ###
+  declare -A _nd_data
+{{ range $key, $val := $NETDATA -}}
+  {{ "  " }}_nd_data[{{ $key }}]='{{ $val }}'
+{{ end -}}
+
+{{ if $debug }}
+  ###
+  #  shell-advanced: Dump the associative array values
+  ###
+  echo ""
+  echo "DEBUG: shell-advanced - dump of the _nd_data associative array:"
+  echo ""
+  for KEY in "${!_nd_data[@]}"
+  do
+    printf ">>> %22s = '%s'\n" "_nd_data[$KEY]" "${_nd_data[$KEY]}"
+  done
+{{ end -}} {{- /* end if $debug */ -}}
+fi # end ! type declare
 
 {{ else if eq $output "python" -}}
 {{- /* ********************************   PYTHON   ******************************** */ -}}
@@ -213,6 +225,7 @@ for KEY in "${!_nd_data[@]}"; do printf ">>> %18s = '%s'\n" "[$KEY]" "${_nd_data
 {{ range $key, $val := $NETDATA -}}
 _nd_{{ $key }} = '{{ $val }}'
 {{ end -}}
+
 ###
 #  Python dict format of network-data structure
 ###
@@ -222,11 +235,12 @@ _nd_data = {
 {{ end -}}
 }
 {{ if $debug -}}
+
 ###
 #  enabled Python debug output because 'network-data-parser-debug' is true
 ###
 print()
-print("DEBUG: 'network-data' parsing resulted in the following assignments:")
+print("DEBUG: python - 'network-data' resulted in the following assignments:")
 print()
 {{ range $key, $val := $NETDATA -}}
 print(">>> %18s :: %s" % ("{{ $key }}", _nd_{{ $key }}))
@@ -246,6 +260,7 @@ for key, value in _nd_data.items():
 {{ range $key, $val := $NETDATA -}}
 _nd_{{ $key }} = '{{ $val }}'
 {{ end -}}
+
 ###
 #  Powershell hash table for network data
 ###
@@ -255,25 +270,25 @@ $_nd_data = @{
 {{ end -}}
 }
 {{ if $debug -}}
+
 ###
 #  enabled Powershell debug output because 'network-data-parser-debug' is true
 ###
 Write-Output ""
-Write-Output "DEBUG: 'network-data' parsing resulted in the following assignments:"
+Write-Output "DEBUG: powershell - 'network-data' resulted in the following assignments:"
 Write-Output ""
 {{ range $key, $val := $NETDATA -}}
 Write-Output ">>> {{ $key }} :: $_nd_{{ $key }}"
 {{ end -}}
 Write-Output ""
-Write-Output "DEBUG: dump of the _nd_data Powershell hash:"
+Write-Output "DEBUG: powershell - dump of the _nd_data Powershell hash:"
 Write-Output ""
 $_nd_data | Format-Table
 {{ end -}}
 
 {{ else -}}
 ####
-####  FATAL: 'network-data-output-type' unsupported value '{{ .Param "network-data-output-type" }}'
-####
+####  FATAL: 'network-data-output-type' unsupported value '{{ $output }}'
 ####
 {{ end -}} {{- /* end if .Param network-data */ -}}
 

--- a/content/templates/network-data-parser.tmpl
+++ b/content/templates/network-data-parser.tmpl
@@ -1,0 +1,238 @@
+{{/* ***********************************************************************
+      This template parses the 'network-data' structure and builds up
+      Variables and a data structure for Shell, Python, or Powershell.
+      The output is determined by the value of the Param 'network-data-
+      output-type' which defaults to "shell".
+
+      Shell output type is also written in VMware ESXi busybox shell
+      compatible format, which means the ASsociative Array will NOT be
+      written if OS.Env.Family is set to "vmware" when the template is
+      rendered.
+
+      The following rules are observed in parsing the 'network-data'
+      structure.  For each processing step, and values found in previous
+      steps will be replaced.  This creates an "order of precedence" in the
+      processing as follows:
+
+        * DNS and NTP server info will be evaluated in "all" tag first
+        * the tagged "prov" entries will be parsed
+        * the tagged "prod" entries will be parsed
+        * the tag defined in the 'network-data-tag' Param will be parsed
+
+      In all cases, the values found and processed will be converted to
+      string type values.  The DNS and NTP servers data will be parsed
+      and added as a space separate String from the found values.
+
+      Routes entries ('routes') will NOT be parsed and handled by this
+      template.  See the 'netowork-manage-routes' task in the DRP
+      Community Content pack for handling route parsing rules.
+
+      The below Variable definitions define what is available for
+      subsequent templates to consume.
+
+      The supported keys in the network-data structure will be set to empty
+      string if no data is found.
+
+      No error checking is provided for situations (eg) where dhcp
+      is set to "true", but IP address, netmask, and default GW were
+      provided.  Operator must apply appropriate logic as needed.
+
+************************************************************************* */ -}}
+
+{{- /* all type values are Strings, DNS and NTP is space separated values */ -}}
+{{- $name        := "" }} {{- /* the name field value for $tag            */ -}}
+{{- $tag         := "" }} {{- /* the final tag that data originates from  */ -}}
+{{- $dns         := "" }} {{- /* array - DNS server addresses             */ -}}
+{{- $ntp         := "" }} {{- /* array - NTP server addresses             */ -}}
+{{- $dhcp        := "" }} {{- /* true/false if DHCP is defined            */ -}}
+{{- $address     := "" }} {{- /* the IP address                           */ -}}
+{{- $netmask     := "" }} {{- /* dotted quad netmask; eg '255.255.255.0'  */ -}}
+{{- $cidr        := "" }} {{- /* the CIDR bits of netmask; eg '24'        */ -}}
+{{- $gateway     := "" }} {{- /* the default gateway                      */ -}}
+{{- $vlan        := "" }} {{- /* the VLAN tag for the network             */ -}}
+{{- $mtu         := "" }} {{- /* the packet frame size                    */ -}}
+{{- $interface   := "" }} {{- /* network interface name in the target OS  */ -}}
+
+{{- $NETDATA := dict }}
+{{- $_ := set $NETDATA "name" "" }}
+{{- $_ := set $NETDATA "tag" "" }}
+{{- $_ := set $NETDATA "dns_servers" "" }}
+{{- $_ := set $NETDATA "ntp_servers" "" }}
+{{- $_ := set $NETDATA "dhcp" "" }}
+{{- $_ := set $NETDATA "address" "" }}
+{{- $_ := set $NETDATA "netmask" "" }}
+{{- $_ := set $NETDATA "cidr" "" }}
+{{- $_ := set $NETDATA "gateway" "" }}
+{{- $_ := set $NETDATA "vlan" "" }}
+{{- $_ := set $NETDATA "mtu" "" }}
+{{- $_ := set $NETDATA "interface" "" }}
+
+{{- if .ParamExists "network-data" -}}
+  {{ $nd := .ComposeParam "network-data" -}}
+  {{ if hasKey $nd "prov" }}{{ $tag = "prov" }}{{ end -}}
+  {{ if hasKey $nd "prod" }}{{ $tag = "prod" }}{{ end -}}
+  {{ if .Param "network-data-tag" }}{{ $tag = ( .ParamExpand "network-data-tag" ) }}{{ end -}}
+
+  {{ if hasKey $nd "all" -}}
+    {{ $all := ( get $nd "all" ) -}}
+    {{ if hasKey $all "dns-servers" }}{{ $dns = (get $all "dns-servers" ) }}{{ end -}}
+    {{ if hasKey $all "ntp-servers" }}{{ $ntp = (get $all "ntp-servers" ) }}{{ end -}}
+  {{ end -}}
+
+  {{ if hasKey $nd $tag -}}
+  {{ $data := ( get $nd $tag ) -}}
+
+  {{ if ( hasKey $data "dhcp" ) -}}
+    {{ $_dyn := ( ( get $data "dhcp" ) | toString ) -}}
+    {{ if or ( eq ( lower $_dyn ) "yes" ) ( eq ( lower $_dyn ) "on" ) ( eq ( lower $_dyn ) "true" ) -}}
+      {{ $_ := set $NETDATA "dhcp" "true" -}}
+    {{ end -}}
+  {{ end -}}
+
+  {{ if and (hasKey $data "address") (hasKey $data "netmask") -}}
+    {{ $_ := set $NETDATA "address" ( trim ( get $data "address" ) ) -}}
+    {{ $_ := set $NETDATA "netmask" ( trim ( get $data "netmask" ) ) -}}
+    {{ $_ := set $NETDATA "cidr" ( .NetmaskToCIDR  ( get $data "netmask" ) ) -}}
+  {{ end -}}
+  {{ if hasKey $data "gateway" }}{{ $_ := set $NETDATA "gateway" ( trim ( get $data "gateway" ) ) }}{{ end -}}
+  {{ if hasKey $data "vlan" }}{{ $_ := set $NETDATA "vlan" ( trim ( ( get $data "vlan" ) | toString ) ) }}{{ end -}}
+  {{ if hasKey $data "mtu" }}{{ $_ := set $NETDATA "mtu" ( trim ( ( get $data "mtu" ) | toString ) ) }}{{ end -}}
+  {{ if hasKey $data "interface" }}{{ $_ := set $NETDATA "interface" ( trim ( get $data "interface" ) ) }}{{ end -}}
+  {{ if hasKey $data "dns-servers" }}{{ $dns = ( get $data "dns-servers" ) }}{{ end -}}
+  {{ if hasKey $data "ntp-servers" }}{{ $ntp = ( get $data "ntp-servers" ) }}{{ end -}}
+
+  {{ end -}}{{- /* hasKey $tag */ -}}
+
+{{ else -}} {{- /* if ParamExists network-data */ -}}
+            {{- /* no network-data Param was found */ -}}
+{{ end -}}  {{- /* if ParamExists network-data */ -}}
+
+{{ $output := ( .Param "network-data-output-type") -}}
+{{ $debug := ( .Param "network-data-parser-debug") -}}
+
+{{ $_p := "" -}}
+{{ $dsrvr := "" -}}
+{{ $nsrvr := "" -}}
+{{ if eq $output "powershell" -}}{{ $_p ="$" }}{{ end -}}
+{{ if $dns }}{{ range $_d := $dns }}{{ $dsrvr = ( cat $_d $dsrvr ) }}{{ end }}{{ end -}}
+{{ if $ntp }}{{ range $_n := $ntp }}{{ $nsrvr = ( cat $_n $nsrvr ) }}{{ end }}{{ end -}}
+{{ $dsrvr = trim $dsrvr -}}
+{{ $_ := set $NETDATA "dns_servers" ( trim $dsrvr ) -}}
+{{ $_ := set $NETDATA "ntp_servers" ( trim $nsrvr ) -}}
+
+{{- /* GENERATE appropriate shell/python/powershell variable definitions */ -}}
+
+{{- if eq $output  "shell" }}
+{{- /* *********************************** SHELL ********************************** */ -}}
+###
+#  Shell (BASH, SH, ZSH, etc) variable definitions of network-data structure
+###
+{{ range $key, $val := $NETDATA -}}
+_nd_{{ $key }}='{{ $val }}'
+{{ end -}}
+{{ if eq .Env.OS.Family "vmware" -}}
+###
+#  >>> VMware ESXi does not support associative arrays, no array rendered for use
+#  >>> since 'Env.Os.Family' returned 'vmware'
+###
+{{ else -}}
+###
+#  Shell (sh/bash/zsh/etc) associative array (VMware ESXi busybox shell does not
+#  support this format)
+###
+declare -A _nd_data
+{{ range $key, $val := $NETDATA -}}
+  _nd_data[{{ $key }}]='{{ $val }}'
+{{ end -}}
+{{ end -}}
+{{ if $debug -}}
+###
+#  enabled Shell debug output because 'network-data-parser-debug' is true
+###
+echo ""
+echo "DEBUG: 'network-data' parsing resulted in the following assignments:"
+echo ""
+{{ range $key, $val := $NETDATA -}}
+printf ">>> %18s :: %s\n" "{{ $key }}" "$_nd_{{ $key }}"
+{{ end -}}
+###
+#  Dump the associative array values
+###
+echo ""
+echo "DEBUG: dump of the _nd_data associative array:"
+echo ""
+for KEY in "${!_nd_data[@]}"; do printf ">>> %18s = '%s'\n" "[$KEY]" "${_nd_data[$KEY]}" ; done
+{{ end -}}
+
+{{ else if eq $output "python" -}}
+{{- /* ********************************   PYTHON   ******************************** */ -}}
+###
+#  Python parsed variable definitions of the network-data structure
+###
+{{ range $key, $val := $NETDATA -}}
+_nd_{{ $key }} = '{{ $val }}'
+{{ end -}}
+###
+#  Python dict format of network-data structure
+###
+_nd_data = {
+{{ range $key, $val := $NETDATA -}}
+  "{{ $key }}": "{{ $val }}",
+{{ end -}}
+}
+{{ if $debug -}}
+###
+#  enabled Python debug output because 'network-data-parser-debug' is true
+###
+print()
+print("DEBUG: 'network-data' parsing resulted in the following assignments:")
+print()
+{{ range $key, $val := $NETDATA -}}
+print(">>> %18s :: %s" % ("{{ $key }}", _nd_{{ $key }}))
+{{ end -}}
+print()
+print("DEBUG: dump of the _nd_data Python dict:")
+print()
+for key, value in _nd_data.items():
+    print(">>> %18s :: %s" % (key, value))
+{{ end -}}
+
+{{ else if eq $output "powershell" -}}
+{{- /* ******************************** POWERSHELL ******************************** */ -}}
+###
+#  Powershell network data information
+###
+{{ range $key, $val := $NETDATA -}}
+_nd_{{ $key }} = '{{ $val }}'
+{{ end -}}
+###
+#  Powershell hash table for network data
+###
+$_nd_data = @{
+{{ range $key, $val := $NETDATA -}}
+  {{ $key }} = '{{ $val }}';
+{{ end -}}
+}
+{{ if $debug -}}
+###
+#  enabled Powershell debug output because 'network-data-parser-debug' is true
+###
+Write-Output ""
+Write-Output "DEBUG: 'network-data' parsing resulted in the following assignments:"
+Write-Output ""
+{{ range $key, $val := $NETDATA -}}
+Write-Output ">>> {{ $key }} :: $_nd_{{ $key }}"
+{{ end -}}
+Write-Output ""
+Write-Output "DEBUG: dump of the _nd_data Powershell hash:"
+Write-Output ""
+$_nd_data | Format-Table
+{{ end -}}
+
+{{ else -}}
+####
+####  FATAL: 'network-data-output-type' unsupported value '{{ .Param "network-data-output-type" }}'
+####
+####
+{{ end -}} {{- /* end if .Param network-data */ -}}
+

--- a/content/templates/network-data-parser.tmpl
+++ b/content/templates/network-data-parser.tmpl
@@ -23,6 +23,11 @@
       string type values.  The DNS and NTP servers data will be parsed
       and added as a space separate String from the found values.
 
+      The dns_servers and ntp_servers are not returned in any array type
+      as some OSes that we support (namely VMware ESXi) shell does not
+      support any array types; and much more primitive constructs need
+      to be used to support them.
+
       Routes entries ('routes') will NOT be parsed and handled by this
       template.  See the 'netowork-manage-routes' task in the DRP
       Community Content pack for handling route parsing rules.
@@ -134,6 +139,8 @@ _nd_{{ $key }}='{{ $val }}'
 ###
 #  >>> VMware ESXi does not support associative arrays, no array rendered for use
 #  >>> since 'Env.Os.Family' returned 'vmware'
+#
+#  >>> use the 'fetch_nd_var()' function to get values (eg 'fetch_nd_var address')
 ###
 {{ else -}}
 ###
@@ -143,8 +150,34 @@ _nd_{{ $key }}='{{ $val }}'
 declare -A _nd_data
 {{ range $key, $val := $NETDATA -}}
   _nd_data[{{ $key }}]='{{ $val }}'
-{{ end -}}
-{{ end -}}
+{{ end -}} {{- /* end range $NETDATA */ -}}
+{{ end -}} {{- /* end if eq .Env.OS.Family */ -}}
+###
+#  Given a network-data key name as ARGv1, fetch the value from the associtive
+#  array if it exists.  If not, then get the value from the individual variables;
+#  for OSes (ESXi, etc) that do not support array variable types.
+#
+#  example getting MTU value, assuming it's set to '9000':
+#    usage:  fetch_nd_var mtu
+#  returns:  9000
+#
+#  First searches _nd_data[mtu] if _nd_data exists.  Otherwise, returns the value
+#  from the variable _nd_mtu.
+#
+#  Returns an empty string if the key has not been assigned any value.
+###
+fetch_nd_var() {
+  local _key="$1"
+  local _val=""
+
+  if [[ -n "$_nd_data" ]]
+  then
+    echo "$_nd_data[$_key]"
+  else
+    eval _val="\$_nd_${_key}"
+    echo "$_val"
+  fi
+}
 {{ if $debug -}}
 ###
 #  enabled Shell debug output because 'network-data-parser-debug' is true

--- a/content/templates/network-data-parser.tmpl
+++ b/content/templates/network-data-parser.tmpl
@@ -135,7 +135,7 @@
 {{ range $key, $val := $NETDATA -}}
 _nd_{{ $key }}='{{ $val }}'
 {{ end -}}
-{{ if eq .Env.OS.Family "vmware" -}}
+{{ if or ( eq .Env.OS.Family "vmware" ) (eq ( .Param "os-identity/system" ) "vmware" ) -}}
 ###
 #  >>> VMware ESXi does not support associative arrays, no array rendered for use
 #  >>> since 'Env.Os.Family' returned 'vmware'
@@ -167,12 +167,14 @@ declare -A _nd_data
 #  Returns an empty string if the key has not been assigned any value.
 ###
 fetch_nd_var() {
-  local _key="$1"
+  # xform dash to underscore because network-data uses dash, and shell vars
+  # use underscore
+  local _key="$(echo $1 | sed 's/-/_/g')"
   local _val=""
 
   if [[ -n "$_nd_data" ]]
   then
-    echo "$_nd_data[$_key]"
+    echo "${_nd_data[$_key]}"
   else
     eval _val="\$_nd_${_key}"
     echo "$_val"
@@ -188,6 +190,11 @@ echo ""
 {{ range $key, $val := $NETDATA -}}
 printf ">>> %18s :: %s\n" "{{ $key }}" "$_nd_{{ $key }}"
 {{ end -}}
+{{ if or ( eq .Env.OS.Family "vmware" ) (eq ( .Param "os-identity/system" ) "vmware" ) -}}
+###
+#  In ESXi environment - no associative arrays were built, so no dump of them
+###
+{{ else -}}
 ###
 #  Dump the associative array values
 ###
@@ -195,7 +202,8 @@ echo ""
 echo "DEBUG: dump of the _nd_data associative array:"
 echo ""
 for KEY in "${!_nd_data[@]}"; do printf ">>> %18s = '%s'\n" "[$KEY]" "${_nd_data[$KEY]}" ; done
-{{ end -}}
+{{ end -}} {{- /* end if .Env.OS.Family or os-identity/system */ -}}
+{{ end -}} {{- /* end if $debug */ -}}
 
 {{ else if eq $output "python" -}}
 {{- /* ********************************   PYTHON   ******************************** */ -}}

--- a/content/templates/os-identity.sh.tmpl
+++ b/content/templates/os-identity.sh.tmpl
@@ -1,0 +1,83 @@
+#!/usr/bin/env sh
+# Get the OS identity and write it to the Machine param 'os-identity'
+
+###
+#  Utilizes uname to get basic OS information.  Writes to the machine object.
+#  For ESXi - the 'simple-params.py' python helper must be rendered to the normal
+#  (/tmp/simple-params.py or alternatively as /tmp/esxi-params.py) location.
+#
+#  Because this may be executed in the limited VMware ESXi shell, we can not use
+#  the "setup.tmpl".  Generate our own UUID and Token.
+#
+#  Future enhancements may provide additional Param values to identify the OS
+#  environment more specifically.
+###
+
+{{ if eq (.Param "rs-debug-enable") true }}set -x{{ end }}
+set -e
+
+SYS=$(uname -s)
+export RS_ENDPOINT='{{ .ApiURL }}'
+export RS_UUID='{{ .Machine.UUID }}'
+export RS_TOKEN='{{ .GenerateInfiniteToken }}'
+
+update_via_python() {
+  local _param="$1"
+  shift
+  local _ident="$*"
+  local _get=""
+
+  if [[ -r "/tmp/simple-params.py" ]]
+  then
+    PY=/tmp/simple-params.py
+  elif [[ -r "/tmp/esxi-params.py" ]]
+  then
+    PY=/tmp/esxi-params.py
+  else
+    xiterr 1 "Required /tmp/simple-params.py or /tmp/esxi-params.py not available."
+  fi
+
+  _get=$(python3 $PY get "$_param")
+  [[ "$_get" != "null" ]] && python3 $PY remove "$_param"
+  python3 $PY add "$_param" "$_ident"
+
+  _get=$(python3 $PY get "$_param")
+  [[ "$_get" != "null" ]] && echo "Successfully wrote '$_param' as value '$_ident'."
+}
+
+update_via_drpcli() {
+  local _param="$1"
+  shift
+  local _ident="$*"
+
+  which drpcli > /dev/null 2>&1 || xiterr 1 "Unable to find 'drpcli' binary to use in PATH ('$PATH')."
+
+  _get=$(drpcli machines get $RS_UUID param "$_param" | sed 's/"//g')
+  [[ "$_get" != "null" ]] && drpcli machines remove $RS_UUID param "$_param"
+  drpcli machines add $RS_UUID param "$_param" to "$_ident" > /dev/null
+
+  _get=$(drpcli machines get $RS_UUID param "$_param" | sed 's/"//g')
+  [[ "$_get" != "null" ]] && echo "Successfully wrote '$_param' as value '$_ident'."
+}
+
+update_values() {
+  local _key="$1"
+  shift 1
+  local _val="$*"
+
+  case $SYS in
+    VMkernel) update_via_python "os-identity/$_key" "vmware"  ;;
+    Linux)    update_via_drpcli "os-identity/$_key" "linux"  ;;
+    *)  xiterr 1 "Unsupported system ('$SYS') as reported by 'uname -s'." ;;
+  esac
+}
+
+echo ">>> Beginning 'os-identity' check process."
+
+# someday, this might do more than just "system" type
+update_values system "$SYS"
+
+echo ">>> Done."
+
+rm -f $PY
+exit 0

--- a/content/templates/simple-params.py.tmpl
+++ b/content/templates/simple-params.py.tmpl
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# cheap and dirty "API" calls to DRP
+
+###
+#  USAGE Examples (assuming this template is rendered as '/tmp/simple-params.py'):
+#
+#    python3 /tmp/simple-params.py get foobar
+#      Gets the Param value named "foobar" if exists
+#      if not, returns the bare string 'null'
+#
+#    python3 /tmp/simple-params.py add foobar blatz
+#      Adds (POST) the Param "foobar" with value "blatz" as type String
+#      - ONLY supports String type values
+#
+#    python3 /tmp/simple-params.py add-raw foobar 3333
+#      Adds (POST) the Param "foobar" with a number/integer value of 3333
+#      - supports bare Number/Integer types
+#      - supports raw true / false values
+#      - supports JSON / Object structures
+#
+#    python3 /tmp/simple-params.py delete foobar
+#      Deletes (DELETE) param "foobar"
+###
+
+# please don't laugh at my miserable python ...
+
+import os, sys, urllib, urllib.request, urllib.parse, ssl, time, re
+
+args = len(sys.argv) - 1
+if args < 2:
+  print("FATAL: Requires at least 2 input arguments: 'action' 'param' ['value']")
+  print("       Where 'action' can be one of 'get', 'add', or 'delete'")
+  sys.exit("       'value' is required only for 'add'")
+
+action = sys.argv[1]
+param = sys.argv[2]
+
+try:
+  ep = os.environ['RS_ENDPOINT']
+except:
+  ep = 'https://147.75.65.75:8092'
+
+try:
+  uuid = os.environ['RS_UUID']
+except:
+    uuid = '53f8777f-d3cf-477f-880e-6b937c536784'
+
+if action == "get":
+  if args != 2:
+    sys.exit("FATAL: 'get' can only be accompanied by Param to get")
+  method = "GET"
+  value = str.encode("")
+elif action == "delete":
+  if args != 2:
+    sys.exit("FATAL: 'delete' can only be accompanied by Param to remove")
+  method = "DELETE"
+  value = str.encode("")
+elif action == "add":
+  if args != 3:
+    sys.exit('FATAL: Requires 3 argumens with "add".')
+  method = "POST"
+  # this is all wrong for JSON input
+  value = str.encode('"' + sys.argv[3] + '"')
+elif action == "add-raw":
+  if args != 3:
+    sys.exit('FATAL: Requires 3 argumens with "add-raw".')
+  method = "POST"
+  value = str.encode(sys.argv[3])
+else:
+  sys.exit("FATAL: must specify 'action' of either 'add' or 'delete' (invalid: '" + action + "').")
+
+# if VMkernel we do special things
+system = os.uname().sysname
+
+# see if we golang template rendered ourself - if not fallback
+apiurl='{{.ApiURL}}'
+if re.search(r'.ApiURL', apiurl):
+  url = ep + '/api/v3/machines/' + uuid + '/params/' + urllib.parse.quote(param)
+  auth = 'Basic cm9ja2V0c2thdGVzOnIwY2tldHNrOHRz'
+else:
+  url = '{{.ApiURL}}/api/v3/machines/{{.Machine.UUID}}/params/' + urllib.parse.quote(param)
+  auth = 'Bearer {{.GenerateInfiniteToken}}'
+
+# really chould check that firewall vib in place an ports open
+if system == "VMkernel":
+  os.system("localcli network firewall set --enabled false")
+
+# really should be using proper PATCH method here
+req = urllib.request.Request(url, method=method, data=value)
+
+req.add_header('Content-Type', 'application/json')
+req.add_header('Authorization', auth)
+
+try:
+  response = urllib.request.urlopen(req,context=ssl.SSLContext(ssl.PROTOCOL_SSLv23))
+  if action == "get":
+    print(response.read().decode("utf-8").replace('"', ''))
+except urllib.error.HTTPError as err:
+  if action == "delete":
+    if err.code == 404:
+      print("Param '" + param + "' did not exist on machine.  Ignoring and continuing.")
+  elif action == "add":
+    if err.code == 409:
+      print("FATAL: Unable to set param '" + param + "' to value '" + value.decode("utf-8") + "'.")
+  else:
+    raise
+
+if system == "VMkernel":
+  os.system("localcli network firewall set --enabled true")
+


### PR DESCRIPTION
Adds template to parse the `network-data` structure and returns an execution environment specific set of Variables and complex data structures.  The environments supported are Shell (bash, sh, zsh, busybox shell, etc.).

The `network-data` structure is parsed with the following rules / order of precedence:
* values from `all` tag
* values from `prov` (provisioning) tag
* values from `prod` (production) tag
* values from the tag defined by the Param `network-data-tag`

In each environment, a variable will be created in the format of `_nd_<KEY>`; where "`<KEY>`" is the original key name found in the `network-data` structure.  For example for an IP address, the variable `_nd_address` would be created with a value.

For each executing environment, a more complex single data structure will be created as follows:
* shell type environments (except VMware) - an Associative Array
* Python - a Dict structure
* Powershell - a Hash Table structure

A simple shell function (`fetch_nd_var()`) will return the value from the `_nd_data` array if it exists, otherwise will parse the environment variable and return the value for the bare variable.  This is to support VMware ESXi's lack of array type variables in the shell.  The function is rendered and works for any shell type, regardless of array support.

By setting the `network-data-parser-debug` Param to `true`, both the bare Variables and complex data structure will be dumped to standard output via appropriate echo/print statements.  This helps with debugging parsing and output of the final values derived from the `network-data` structure.

Output has been successfully determined to produce valid Shell and Python values.  Powershell "looks" right, but has not been tested.