### PR TITLE
refactor(cloud-wrappers): switch to using builtin drpcli-runner for tip

### DIFF
--- a/cloud-wrappers/._Prerequisites.meta
+++ b/cloud-wrappers/._Prerequisites.meta
@@ -1,1 +1,1 @@
-drp-community-content:>=4.4.0,task-library,rackn-license
+drp-community-content:>=4.6.0,task-library:>=4.6.0,docker-context:>=4.6.0,rackn-license

--- a/cloud-wrappers/contexts/ansible.yaml
+++ b/cloud-wrappers/contexts/ansible.yaml
@@ -14,3 +14,4 @@ Meta:
   color: "blue"
   title: "RackN Content"
   Dockerpull: "digitalrebar/context-ansible"
+  Imagepull: "http://get.rebar.digital/containers/20200210/terraform.tar"

--- a/cloud-wrappers/contexts/terraform.yaml
+++ b/cloud-wrappers/contexts/terraform.yaml
@@ -14,3 +14,4 @@ Meta:
   color: "blue"
   title: "RackN Content"
   Dockerpull: "digitalrebar/context-terraform"
+  Imagepull: "http://get.rebar.digital/containers/20200210/terraform.tar"

--- a/cloud-wrappers/stages/cloud-decommission.yaml
+++ b/cloud-wrappers/stages/cloud-decommission.yaml
@@ -3,13 +3,13 @@ Name: "cloud-decommission"
 Description: "Destroy Cloud Instance with Terraform Context"
 Params:
   terraform/plan-action: "destroy"
-  context/name: "runner"
+  context/name: "drpcli-runner"
 BootEnv: "sledgehammer"
 Tasks:
   - "context:terraform"
   - "cloud-validate"
   - "terraform-apply"
-  - "context:runner"
+  - "context:drpcli-runner"
   - "cloud-cleanup"
   - "context-set"
 Meta:

--- a/cloud-wrappers/stages/cloud-provision.yaml
+++ b/cloud-wrappers/stages/cloud-provision.yaml
@@ -5,7 +5,7 @@ Params:
   terraform/plan-action: "apply"
 BootEnv: "sledgehammer"
 Tasks:
-  - "context:runner"
+  - "context:drpcli-runner"
   - "cloud-validate"
   - "rsa-key-create"
   - "context:terraform"

--- a/task-library/tasks/bootstrap-contexts.yaml
+++ b/task-library/tasks/bootstrap-contexts.yaml
@@ -40,22 +40,6 @@ ExtraClaims:
     specific: "rackn-license"
 Templates:
   - Contents: |-
-      {
-        "Name": "runner",
-        "Description": "DEPRECATED! SWITCH TO drpcli-runner",
-        "Documentation": "Very minimal container to run the DRPCLI as a starting or idle point for Machines. This provides a very low overhead system to start or complete workflows so that tasks can continue to execute even if the target machine is not available (or never exists).",
-        "Engine": "docker-context",
-        "Image": "digitalrebar-context-runner",
-        "Meta": {
-          "icon": "cube",
-          "color": "red",
-          "copyright": "RackN 2020",
-          "Dockerpull": "digitalrebar/context-runner"
-        }
-      }
-    Name: "runner-context"
-    Path: "runner.json"
-  - Contents: |-
       #!/bin/bash
       # RackN Copyright 2020
 
@@ -106,7 +90,7 @@ Templates:
       echo "Podman installed successfully"
 
       echo "Install Docker-Context"
-      pv="stable"
+      pv="tip"
       if drpcli plugin_providers exists docker-context; then
         pv="$(drpcli plugin_providers show docker-context | jq .Version -r)"
         echo "Plugin Exists at version $pv"
@@ -115,12 +99,11 @@ Templates:
         drpcli catalog item install docker-context --version=$pv
       fi
 
-      echo "Create Runner Context if missing (requires license)"
-      if drpcli contexts exists runner ; then
-        echo "  runner context exists, no action"
+      if drpcli contexts exists drpcli-runner ; then
+        echo "Built-In Runner Detected"
       else
-        echo "  runner context missing, creating"
-        drpcli contexts create runner.json
+        echo "ERROR: this process requires the built-in runner context"
+        exit 1
       fi
 
       echo "Check which files are uploaded (error = none)"


### PR DESCRIPTION
Part of the docker-context refactor to have drpcli-runner as a built in context.
This changes cloudwapper and the context bootstrap to rely on that runner instead