### PR TITLE
refactor(cloud-wrapper): point contexts to latest instead of date version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ bundle.yaml
 bundle.json
 rel_notes
 rebar-catalog
+integrations/docker-context/*.tar.gz

--- a/cloud-wrappers/contexts/ansible.yaml
+++ b/cloud-wrappers/contexts/ansible.yaml
@@ -14,4 +14,4 @@ Meta:
   color: "blue"
   title: "RackN Content"
   Dockerpull: "digitalrebar/context-ansible"
-  Imagepull: "http://get.rebar.digital/containers/20200210/terraform.tar"
+  Imagepull: "http://get.rebar.digital/containers/latest/ansible.tar.gz"

--- a/cloud-wrappers/contexts/terraform.yaml
+++ b/cloud-wrappers/contexts/terraform.yaml
@@ -14,4 +14,4 @@ Meta:
   color: "blue"
   title: "RackN Content"
   Dockerpull: "digitalrebar/context-terraform"
-  Imagepull: "http://get.rebar.digital/containers/20200210/terraform.tar"
+  Imagepull: "http://get.rebar.digital/containers/latest/terraform.tar.gz"

--- a/integrations/docker-context/test-build.sh
+++ b/integrations/docker-context/test-build.sh
@@ -13,9 +13,13 @@ for f in $files; do
 	docker rmi digitalrebar-$f || true
 	echo "Building $f"
 	docker build -f $f -t digitalrebar-$f .
+	t=$(echo $f | sed 's/-dockerfile//g')
+	docker save digitalrebar-$f > $t.tar
+	gzip -f $t.tar
+	echo "  created $t.tar.gz"
 done
 
 echo "Checking Docker Images"
 docker images digitalrebar-*
 
-echo "done"
+echo "done - reminder, you may want to upload images to s3"

--- a/task-library/tasks/bootstrap-contexts.yaml
+++ b/task-library/tasks/bootstrap-contexts.yaml
@@ -164,6 +164,12 @@ Templates:
           fi
         else
           echo "  Found $container_sum in files/contexts/docker-context, skipping upload"
+          if podman images | grep -q localhost/$image ; then
+            echo   "  localhost/$image is installed, removing to ensure correct download"
+            podman rmi localhost/$image
+          else
+            echo   "  localhost/$image does NOT exist locally, no action"
+          fi
         fi
         i=$(($i + 1))
       done

--- a/task-library/tasks/dr-server-install.yaml
+++ b/task-library/tasks/dr-server-install.yaml
@@ -99,7 +99,7 @@ Templates:
 
           - name: "run install.sh script install mode"
             become: true
-            shell: "./install.sh --startup --drp-id={{`{{drpid}}`}} --systemd --zip-file=dr-provision.zip --no-content --start-runner --drp-password={{ .Param "dr-server/initial-password" }} --drp-user={{ .Param "dr-server/initial-user" }} --initial-contents=\"./rackn-license.json\" install"
+            shell: "./install.sh --startup --drp-id={{`{{drpid}}`}} --no-content --systemd --bootstrap --zip-file=dr-provision.zip --no-content --start-runner --drp-password={{ .Param "dr-server/initial-password" }} --drp-user={{ .Param "dr-server/initial-user" }} --initial-contents=\"./rackn-license.json\" install"
             when: services["dr-provision.service"] is not defined
             register: shell_result1
 
@@ -108,34 +108,38 @@ Templates:
               var: shell_result1.stdout_lines
             when: services["dr-provision.service"] is not defined
 
-          - name: "upgrading... Stop dr-provision service cron"
-            service:
-              name: dr-provision
-              state: stopped
-            when: services["dr-provision.service"] is defined
+          - name: "change rocketskates password"
+            shell: "drpcli -P {{ .Param "dr-server/initial-password" }} -U {{ .Param "dr-server/initial-user" }} users password rocketskates {{ .Param "dr-server/initial-password" }}"
+            ignore_errors: true
+            when: services["dr-provision.service"] is not defined
 
-          - name: "run install.sh script upgrade mode"
+          - name: "upgrading.... via drpcli system upgrade"
             become: true
-            shell: "./install.sh --startup --drp-id={{`{{drpid}}`}} --systemd --zip-file=dr-provision.zip --start-runner upgrade"
+            shell: "drpcli -P {{ .Param "dr-server/initial-password" }} -U {{ .Param "dr-server/initial-user" }} system upgrade dr-provision.zip"
             when: services["dr-provision.service"] is defined
+            ignore_errors: true
             register: shell_result2
 
-          - name: "upgrade output log"
+          - name: "upgrading... output log"
             debug: 
               var: shell_result2.stdout_lines
             when: services["dr-provision.service"] is defined
 
-          - name: wait for install to complete
-            pause:
-              seconds: 10
+          - name: "make sure license is uploaded"
+            shell: "drpcli -P {{ .Param "dr-server/initial-password" }} -U {{ .Param "dr-server/initial-user" }} contents upload rackn-license.json"
+            ignore_errors: true
+
+          - name: "retrieve version of dr-provision"
+            shell: "drpcli  -P {{ .Param "dr-server/initial-password" }} -U {{ .Param "dr-server/initial-user" }} info get | jq .version"
+            register: drp_version
+
+          - name: "version of dr-provision"
+            debug:
+              var: drp_version.stdout_lines
 
           - name: check for dr-provision pids (makes sure we started)
             shell: pidof dr-provision
             register: drprovision_pids
-            ignore_errors: true
-
-          - name: "make sure license is uploaded"
-            shell: "drpcli contents upload rackn-license.json"
             ignore_errors: true
 
           - name: Printing the process IDs obtained


### PR DESCRIPTION
fix paths for cloud-wrap (ansible was pulling terraform!) and safer upgrades for dr-server-install

fix(task-lib): helpful safety removes existing contexts
refactor(task-lib): use drpcli upgrade instead of install upgrade
fix(task-lib): ignore system ugprade error, get version