### PR TITLE
feat(task-library): Install dr server on aws

### DIFF
--- a/cloud-wrappers/params/aws-ami-id.yaml
+++ b/cloud-wrappers/params/aws-ami-id.yaml
@@ -5,7 +5,7 @@ Documentation: |
   Provision AWS O/S Image
 Schema:
   type: "string"
-  default: "ami-0e34e7b9ca0ace12d"
+  default: "ami-0d5d1a3aa3516231f"
 Meta:
   type: "os"
   color: "black"

--- a/cloud-wrappers/params/cloud-dmi-hypervisor.yaml
+++ b/cloud-wrappers/params/cloud-dmi-hypervisor.yaml
@@ -1,0 +1,12 @@
+---
+Name: "cloud/dmi-hypervisor"
+Description: "Cloud Hypervisor Type"
+Documentation: |
+  The DMI.Hypervisor value returned by Gohai
+Schema:
+  type: "string"
+Meta:
+  type: "id"
+  icon: "server"
+  color: "blue"
+  title: "Digital Rebar Community Content"

--- a/cloud-wrappers/stages/cloud-inspect.yaml
+++ b/cloud-wrappers/stages/cloud-inspect.yaml
@@ -1,8 +1,8 @@
 ---
 Name: "cloud-inspect"
-Description: "Stage to dynamically determine if machine is in AWS and record metadata"
+Description: "Collect cloud metadata"
 Documentation: |
-  Collect information about AWS cloud
+  Collect information from cloud metadata API
 Tasks:
   - "cloud-inspect"
 Meta:

--- a/cloud-wrappers/tasks/cloud-cleanup.yaml
+++ b/cloud-wrappers/tasks/cloud-cleanup.yaml
@@ -14,7 +14,7 @@ Templates:
       set -e
       {{template "setup.tmpl" .}}
 
-      items="cloud/instance-id cloud/instance-type cloud/placement/availability-zone cloud/public-hostname cloud/public-ipv4"
+      items="cloud/dmi-hypervisor cloud/instance-id cloud/instance-type cloud/placement/availability-zone cloud/public-hostname cloud/public-ipv4"
       for p in $items; do
         echo "removing param $p from {{ .Machine.Name }}"
         drpcli machines remove $RS_UUID param $p || true

--- a/cloud-wrappers/tasks/cloud-inspect.yaml
+++ b/cloud-wrappers/tasks/cloud-inspect.yaml
@@ -20,6 +20,19 @@ Templates:
       # Ubuntu Path is different than Centos Path - fix it.
       export PATH=$PATH:/usr/bin:/usr/sbin:/bin:/sbin
 
+      {{ if .ParamExists "gohai-inventory" }}
+        {{ $gohai := .Param "gohai-inventory" }}
+        {{ $dmi := get $gohai "DMI"}}
+        {{ $hypervisor := get $dmi "Hypervisor"}}
+        {{ $bios := get $dmi "BIOS"}}
+        {{ $manu := get $bios "Vendor"}}
+        echo "Using Gohai Inventory to set cloud/dmi-hypervisor to {{coalesce $hypervisor $manu "unknown"}}"
+        drpcli machines set $RS_UUID param cloud/dmi-hypervisor to '{{coalesce $hypervisor $manu "unknown"}}' > /dev/null
+      {{ else }}
+        echo "No Gohai Inventory - setting cloud/dmi-hypervisor to missing"
+        drpcli machines set $RS_UUID param cloud/dmi-hypervisor to 'missing' > /dev/null
+      {{ end }}
+
       {{ if eq "aws" $cloud }}
       echo "============================= AWS INSPECT ============================="
       INSTANCEID=$(curl -sfL http://169.254.169.254/latest/meta-data/instance-id)
@@ -77,7 +90,7 @@ Templates:
       {{ end }}
 
       {{ if eq "azure" $cloud }}
-      echo "============================= LINODE INSPECT ============================="
+      echo "============================= AZURE INSPECT ============================="
 
         {{ if .ParamExists "terraform-var/instance_id" }}
         drpcli machines set $RS_UUID param cloud/instance-id to "\"{{ int (.Param "terraform-var/instance_id") }}\""

--- a/cloud-wrappers/templates/cloud-provision-reference.tf.tmpl
+++ b/cloud-wrappers/templates/cloud-provision-reference.tf.tmpl
@@ -51,17 +51,20 @@ resource "azurerm_network_security_group" "security_group" {
     location            = azurerm_resource_group.main.location
     resource_group_name = azurerm_resource_group.main.name
 
+    {{ range $i, $p := (.Param "network/firewall-ports") }}
+    {{- $portdef := split "/" $p -}}
     security_rule {
-        name                       = "SSH"
-        priority                   = 1001
+        name                       = "nfp-{{$i}}_"
+        priority                   = {{add $i 1}}00
         direction                  = "Inbound"
         access                     = "Allow"
-        protocol                   = "Tcp"
+        protocol                   = "{{coalesce $portdef._1 "Tcp"}}"
         source_port_range          = "*"
-        destination_port_range     = "22"
+        destination_port_range     = "{{$portdef._0}}"
         source_address_prefix      = "*"
         destination_address_prefix = "*"
     }
+    {{ end }}
 }
 
 resource "azurerm_network_interface" "machine_nic" {
@@ -247,20 +250,16 @@ resource "aws_security_group" "digitalrebar_basic" {
 
 	name_prefix 	= "drp_"
 	description		= "Digital Rebar Cloud Wrapper"
+  {{ range $i, $p := (.Param "network/firewall-ports") }}
+  {{- $portdef := split "/" $p -}}
 	ingress {
-		description = "SSH"
-		from_port   = 22
-		to_port     = 22
-		protocol    = "tcp"
+		description = "network/firewall-ports[{{$i}}]"
+		from_port   = {{$portdef._0}}
+		to_port     = {{$portdef._0}}
+		protocol    = "{{coalesce $portdef._1 "tcp"}}"
 		cidr_blocks = ["0.0.0.0/0"]
 	}
-	ingress {
-		description = "HTTPS"
-		from_port   = 443
-		to_port     = 443
-		protocol    = "tcp"
-		cidr_blocks = ["0.0.0.0/0"]
-	}
+  {{ end }}
 	egress {
 		from_port   = 0
 		to_port     = 0

--- a/task-library/tasks/bootstrap-contexts.yaml
+++ b/task-library/tasks/bootstrap-contexts.yaml
@@ -59,7 +59,7 @@ Templates:
 
       if ! which podman ; then
         FAMILY=$(grep "^ID=" /etc/os-release | tr -d '"' | cut -d '=' -f 2)
-        echo "Installing Podman"
+        echo "Installing Podman for $FAMILY"
         case $FAMILY in
           redhat|centos)
             if which yum > /dev/null 2>&1
@@ -78,14 +78,25 @@ Templates:
             curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
             sudo apt-get update -qq; sudo apt-get -qq -y install podman
             ;;
+          alpine)
+            apk add podman
+            ;;
+          amzn)
+            sudo curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_7/devel:kubic:libcontainers:stable.repo
+            sudo yum -y install yum-plugin-copr
+            sudo yum -y copr enable lsm5/container-selinux
+            sudo yum -y install podman
+            ;;
           *) >&2 echo "Unsupported package manager family '$FAMILY'."
              exit 1
             ;;
         esac
+      echo
+        echo "Detected podman version: $(podman verseion)"
       fi
 
       echo "Relax SELinux - not for production!"
-      setenforce Permissive
+      setenforce Permissive || true
 
       echo "Podman installed successfully"
 

--- a/task-library/tasks/dr-server-install.yaml
+++ b/task-library/tasks/dr-server-install.yaml
@@ -109,13 +109,13 @@ Templates:
             when: services["dr-provision.service"] is not defined
 
           - name: "change rocketskates password"
-            shell: "drpcli -P {{ .Param "dr-server/initial-password" }} -U {{ .Param "dr-server/initial-user" }} users password rocketskates {{ .Param "dr-server/initial-password" }}"
+            shell: "/usr/local/bin/drpcli -P {{ .Param "dr-server/initial-password" }} -U {{ .Param "dr-server/initial-user" }} users password rocketskates {{ .Param "dr-server/initial-password" }}"
             ignore_errors: true
             when: services["dr-provision.service"] is not defined
 
           - name: "upgrading.... via drpcli system upgrade"
             become: true
-            shell: "drpcli -P {{ .Param "dr-server/initial-password" }} -U {{ .Param "dr-server/initial-user" }} system upgrade dr-provision.zip"
+            shell: "/usr/local/bin/drpcli -P {{ .Param "dr-server/initial-password" }} -U {{ .Param "dr-server/initial-user" }} system upgrade dr-provision.zip"
             when: services["dr-provision.service"] is defined
             ignore_errors: true
             register: shell_result2
@@ -126,11 +126,13 @@ Templates:
             when: services["dr-provision.service"] is defined
 
           - name: "make sure license is uploaded"
-            shell: "drpcli -P {{ .Param "dr-server/initial-password" }} -U {{ .Param "dr-server/initial-user" }} contents upload rackn-license.json"
+            become: true
+            shell: "/usr/local/bin/drpcli -P {{ .Param "dr-server/initial-password" }} -U {{ .Param "dr-server/initial-user" }} contents upload rackn-license.json"
             ignore_errors: true
 
           - name: "retrieve version of dr-provision"
-            shell: "drpcli  -P {{ .Param "dr-server/initial-password" }} -U {{ .Param "dr-server/initial-user" }} info get"
+            become: true
+            shell: "/usr/local/bin/drpcli  -P {{ .Param "dr-server/initial-password" }} -U {{ .Param "dr-server/initial-user" }} info get"
             register: drp_version
 
           - name: "version of dr-provision"
@@ -138,6 +140,7 @@ Templates:
               var: (drp_version.stdout | from_json).version
 
           - name: check for dr-provision pids (makes sure we started)
+            become: true
             shell: pidof dr-provision
             register: drprovision_pids
             ignore_errors: true

--- a/task-library/tasks/network-firewall.yaml
+++ b/task-library/tasks/network-firewall.yaml
@@ -29,30 +29,33 @@ Templates:
     esac
 
     # just in case, try starting firewalld
-    systemctl start firewalld
+    if systemctl status firewalld | grep Loaded ; then
 
-    {{range $index, $port := .Param "network/firewall-ports" }}
-      {{ if contains "/" $port }}
-      PORT={{$port}}
-      {{ else }}
-      PORT={{$port}}/tcp
-      {{ end }}
-      echo "Rule {{$index}}: add-port $PORT"
+      {{range $index, $port := .Param "network/firewall-ports" }}
+        {{ if contains "/" $port }}
+        PORT={{$port}}
+        {{ else }}
+        PORT={{$port}}/tcp
+        {{ end }}
+        echo "Rule {{$index}}: add-port $PORT"
+        case $osfamily in
+          redhat|centos) firewall-cmd --permanent --add-port=$PORT ;;
+          debian|ubuntu) sudo ufw allow $PORT ;;
+        esac
+      {{else}}
+        echo "No network/firewall-ports defined"
+      {{end}}
+
+      echo "restart firewall"
       case $osfamily in
-        redhat|centos) firewall-cmd --permanent --add-port=$PORT ;;
-        debian|ubuntu) sudo ufw allow $PORT ;;
+        redhat|centos) firewall-cmd --reload ;;
+        debian|ubuntu) sudo ufw reload ;;
       esac
-    {{else}}
-      echo "No network/firewall-ports defined"
-    {{end}}
-
-    echo "restart firewall"
-    case $osfamily in
-      redhat|centos) firewall-cmd --reload ;;
-      debian|ubuntu) sudo ufw reload ;;
-    esac
     
-    {{ end }}
+      {{ end }}
+    else
+      echo "WARNING: no firewalld found, skipping network config"
+    fi
 
     echo "done"
 


### PR DESCRIPTION
updates required so that DRP will install on AWS Linux 2
note: also needs update to install.sh script (will be it's own patch)

included:
1) cloud-wrapper terraform now opens assigned network/ports during provisioning
2) capture the type of hypervisor as a top level param in cloudwrap
3) use AWS Linux 2 by default (instead of Linux 1)
4) make dr-install more resilient