### PR TITLE
fix(image-builder): fixed ubuntu 18 image building

### DIFF
--- a/image-builder/tasks/image-install-cloud-init.yaml
+++ b/image-builder/tasks/image-install-cloud-init.yaml
@@ -19,6 +19,24 @@ Templates:
       # origin: rackn/image-builder
       {{template "setup.tmpl" .}}
 
-      install cloud-init
+      case $OS_FAMILY in
+        debian)
+          export DEBIAN_FRONTEND=noninteractive
+          faketty () {
+              script -qfce "$(printf "%q " "$@")"
+          }
+          if grep -q devpts /proc/mounts ; then
+              faketty apt-get install -y cloud-init
+          else
+              mount -t devpts devpts /dev/pts
+              faketty apt-get install -y cloud-init
+              umount /dev/pts
+          fi
+          ;;
+        rhel)
+            install cloud-init
+        ;;
+      esac
+      exit 0
     Name: image-install-cloud-init
     Path: ""


### PR DESCRIPTION
Added conditional to detect if OS is debian based, if so devpts gets mounted
a fake tty is made and cloud-init gets installed.

Signed-off-by: Michael Rice <michael@michaelrice.org>