### PR TITLE
fix(task-library): Amazon Linux does not like yum podman now

### DIFF
--- a/cloud-wrappers/params/cloud-provider.yaml
+++ b/cloud-wrappers/params/cloud-provider.yaml
@@ -15,6 +15,7 @@ Schema:
     - "linode"
     - "azure"
     - "digitalocean"
+    - "unknown"
 Meta:
   type: "value"
   icon: "cloud"

--- a/task-library/tasks/bootstrap-contexts.yaml
+++ b/task-library/tasks/bootstrap-contexts.yaml
@@ -10,13 +10,13 @@ Documentation: |
   * Stage installs Podman and the Docker-Context Plugin even if you do not have Docker-Contexts defined
   * Contexts are a licensed feature (the stage will abort if no license is exists)
 
-  1. Installs Podman on DRP Host
+  1. Installs Podman/Docker on DRP Host
   1. Installs the Docker-Context from Catalog
   1. Creates the runner context if missing
   1. Attempts to build & upload images for all Docker-Contexts
-  1. Initializes Podman for all Contexts
+  1. Initializes Podman/Docker for all Contexts
 
-  Podman build files are discovered in the following precidence order:
+  Podman/Docker build files are discovered in the following precidence order:
   1. using Container Buildfile from files/contexts/docker-build/[contextname]
   1. using URL from Meta.Imagepull
   1. using Container  Buildfile downloaded Context Meta.Dockerfile
@@ -57,9 +57,10 @@ Templates:
         echo "No Docker Contexts"
       fi
 
-      if ! which podman ; then
+      tool="podman"
+      if ! which podman || ! which docker ; then
         FAMILY=$(grep "^ID=" /etc/os-release | tr -d '"' | cut -d '=' -f 2)
-        echo "Installing Podman for $FAMILY"
+        echo "Installing Podman/Docker for $FAMILY"
         case $FAMILY in
           redhat|centos)
             if which yum > /dev/null 2>&1
@@ -82,23 +83,24 @@ Templates:
             apk add podman
             ;;
           amzn)
-            sudo curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_7/devel:kubic:libcontainers:stable.repo
-            sudo yum -y install yum-plugin-copr
-            sudo yum -y copr enable lsm5/container-selinux
-            sudo yum -y install podman
+            sudo amazon-linux-extras install -y docker
+            sudo service docker start
+            sudo usermod -a -G docker ec2-user
+            sudo systemctl enable --now docker
+            tool="docker"
             ;;
           *) >&2 echo "Unsupported package manager family '$FAMILY'."
              exit 1
             ;;
         esac
       echo
-        echo "Detected podman version: $(podman verseion)"
+        echo "Detected $tool version: $($tool version)"
       fi
 
       echo "Relax SELinux - not for production!"
       setenforce Permissive || true
 
-      echo "Podman installed successfully"
+      echo "$tool installed successfully"
 
       echo "Install Docker-Context"
       pv="tip"
@@ -151,21 +153,21 @@ Templates:
             if [[ "$dockerbuild" != "" ]]; then
               echo "    pulling dockerfile from contexts/docker-build/$context"
               drpcli files download contexts/docker-build/$context > $context-dockerfile
-              podman build --tag=$image --file="$context-dockerfile" .
+              $tool build --tag=$image --file="$context-dockerfile" .
             elif [[ "$dockerfile" != "null" ]]; then
               echo "    pulling docker build from $dockerfile"
               curl -fsSL $dockerfile -o $context-dockerfile
-              podman build --tag=$image --file="$context-dockerfile" .
+              $tool build --tag=$image --file="$context-dockerfile" .
             elif [[ "$dockerpull" != "null" ]]; then
               echo "    pulling container image from $dockerpull"
-              podman pull $dockerpull
+              $tool pull $dockerpull
               echo "    tagging $dockerpull as $image"
-              podman tag $dockerpull $image
+              $tool tag $dockerpull $image
             else
               echo "!! Stopping context-bootstrap - missing container image for $context"
               exit 1
             fi
-            podman save $image > /root/$context.tar
+            $tool save $image > /root/$context.tar
             gzip /root/$context.tar
             echo "  Uploading Container from /root/$context.tar.gz"
             drpcli files upload /root/$context.tar.gz as "contexts/docker-context/$image"
@@ -175,9 +177,9 @@ Templates:
           fi
         else
           echo "  Found $container_sum in files/contexts/docker-context, skipping upload"
-          if podman images | grep -q localhost/$image ; then
+          if $tool images | grep -q localhost/$image ; then
             echo   "  localhost/$image is installed, removing to ensure correct download"
-            podman rmi localhost/$image
+            $tool rmi localhost/$image
           else
             echo   "  localhost/$image does NOT exist locally, no action"
           fi

--- a/tools/cloud-profiles.sh
+++ b/tools/cloud-profiles.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# RackN Copyright 2021
+# Upload Local Cloud Credentials
+
+export PATH=$PATH:$PWD
+
+echo "RackN Digital Rebar Cloud Credentials Uploader (v1.0 Feb 2021)"
+echo "=============================================================="
+echo "1/3 Checking Cloudwapper Prereqs"
+
+if ! which drpcli > /dev/null ; then
+  echo "MISSING: drpcli required!"
+  exit 1
+else
+  echo "  verified drpcli is installed"
+fi
+
+if ! which jq > /dev/null ; then
+  echo "  adding jq via drpcli as soft link in current directory"
+  ln -s $(which drpcli) jq >/dev/null
+else
+  echo "  verified jq is installed"
+fi
+
+if ! drpcli info get > /dev/null ; then
+  echo "MISSING: set RS_ENDPOINT and RS_KEY!"
+  exit 1
+else
+  drpid=$(drpcli info get | jq -r .id | sed 's/:/-/g')
+  echo "  verified drp $drpid access and credentials"
+fi
+
+if ! drpcli contents exists rackn-license > /dev/null 2>/dev/null ; then
+  echo "MISSING: rackn-license.  Install using UX"
+  exit 1
+else
+  echo "  verified rackn-license is available"
+fi
+
+if ! drpcli contents exists cloud-wrappers > /dev/null 2>/dev/null ; then
+  echo "  INSTALLING: missing cloud-wrappers content pack"
+  drpcli catalog item install cloud-wrappers --version=tip >/dev/null
+else
+  echo "  verified cloud-wrappers is available"
+fi
+
+if drpcli machines exists Name:$drpid > /dev/null 2>/dev/null ; then
+  echo "  Self-Runner Detected - using bootstrap-advanced to install docker-context"
+  drpcli machines update Name:$drpid '{"Locked":false}' > /dev/null
+  drpcli machines workflow Name:$drpid "" > /dev/null
+  drpcli machines workflow Name:$drpid bootstrap-advanced > /dev/null
+  drpcli machines run Name:$drpid > /dev/null
+  echo "    up can monitor progress via the UX"
+  echo "    waiting up to 60 seconds for workflow to complete..."
+  drpcli machines wait Name:$drpid WorkflowComplete true 60
+else
+  if ! drpcli plugins exists docker-context > /dev/null 2>/dev/null ; then
+    echo "  INSTALLING: missing docker-context plugin, installing"
+    drpcli catalog item install docker-context --version=tip >/dev/null
+  else
+    echo "  verified docker-context is available.  Restarting"
+    drpcli plugins runaction docker-context restartProvider >/dev/null
+  fi
+  echo "  Checking for Context Images"
+  contexts=$(drpcli contexts list | jq -r .[].Name)
+  for c in $contexts; do
+    o=$(drpcli contexts show $c)  
+    image=$(jq -r .Image <<< "$o")
+    source=$(jq -r .Meta.Imagepull <<< "$o")
+    if [[ $source ]] ; then
+      if drpcli plugins runaction docker-context imageExists context/image-name ${image} >/dev/null 2>/dev/null ; then
+        echo "    image file for $c exists, no action"
+      else
+        echo "    INSTALLING: Image file for $c missing (may be slow....)"
+        drpcli files upload "$source" as "contexts/docker-context/$image" >/dev/null
+        drpcli plugins runaction docker-context imageUpload \
+          context/image-name ${c} \
+          context/image-path files/contexts/docker-context/${image}
+      fi
+    else
+      echo "  WARNING: no Imagepull defined for $c"
+    fi
+  done
+fi
+
+echo "2/3 Building Cloudwapper Profiles"
+
+if [[ -f ~/.aws/credentials ]]; then
+  if drpcli profiles exists aws > /dev/null 2>/dev/null ; then
+    echo "  Skipping AWS, already exists"
+  else
+    echo "  Adding AWS profile for cloud-wrap"
+    drpcli profiles create - >/dev/null << EOF
+---
+Name: "aws"
+Description: "AWS Credentials"
+Params:
+  "cloud/provider": "aws"
+  "rsa/key-user": "ec2-user"
+Meta:
+  color: "blue"
+  icon: "amazon"
+  title: "generated"
+EOF
+    drpcli profiles add aws param "aws/secret-key" to "$(awk '/aws_secret_access_key/{ print $3}' ~/.aws/credentials)" > /dev/null
+    drpcli profiles add aws param "aws/access-key-id" to "$(awk '/aws_access_key_id/{ print $3}' ~/.aws/credentials)" > /dev/null
+  fi
+else
+  echo "  no AWS credentials, skipping"
+fi
+
+# upload aws & google credentials
+google=$(ls ~/.gconf/desktop/*.json || echo "none")
+if [[ -f $google ]]; then
+  if drpcli profiles exists google > /dev/null 2>/dev/null ; then
+    echo "  Skipping Google, already exists"
+  else
+      echo "  Adding Google profile for cloud-wrap"
+      gconf=$(cat $google) > /dev/null
+      drpcli profiles create - >/dev/null << EOF
+{
+  "Name": "google",
+  "Description": "GCE Credentials",
+  "Params": {
+    "cloud/provider": "google",
+    "google/project-id": "$(jq -r .project_id <<< "$gconf")",
+    "rsa/key-user": "rob",
+  },
+  "Meta": {
+    "color": "blue",
+    "icon": "google",
+    "title": "generated"
+  }
+}
+EOF
+    drpcli profiles add google param "google/credential" to - >/dev/null <<< $(cat $google)
+  fi
+else
+  echo "  no Google credentials, skipping"
+fi
+
+if [[ $DO_TOKEN ]]; then
+  if drpcli profiles exists digitalocean > /dev/null 2>/dev/null ; then
+    echo "  Skipping Digital Ocean, already exists"
+  else
+    echo "  upload digital ocean credentials"
+      drpcli profiles create - >/dev/null << EOF
+---
+Name: "digitalocean"
+Description: "Digital Ocean Credentials"
+Params:
+  "cloud/provider": "digitalocean"
+Meta:
+  color: "green"
+  icon: "digital ocean"
+  title: "generated"
+EOF
+    drpcli profiles add digitalocean param "digitalocean/token" to "$DO_TOKEN" > /dev/null
+  fi
+else
+  echo "  Skipping Digital Ocean, no token DO_TOKEN"
+fi
+
+if [[ $LINODE_TOKEN ]]; then
+  if drpcli profiles exists linode > /dev/null 2>/dev/null ; then
+    echo "  Skipping Linode, already exists"
+  else
+    echo "  upload linode credentials"
+    drpcli profiles create - >/dev/null << EOF
+---
+Name: "linode"
+Description: "Linode Credentials"
+Params:
+  "cloud/provider": "linode"
+  "linode/instance-image": "linode/centos8"
+  "linode/instance-type": "g6-standard-2"
+Meta:
+  color: "blue"
+  icon: "linode"
+  title: "generated"
+EOF
+    drpcli profiles add linode param "linode/root-password" to "r0cketsk8ts" > /dev/null
+    drpcli profiles add linode param "linode/token" to "$LINODE_TOKEN" > /dev/null
+  fi
+else
+  echo "  Skipping Linode, no token LINODE_TOKEN"
+fi
+
+if which az > /dev/null ; then
+  if drpcli profiles exists azure > /dev/null 2>/dev/null ; then
+    echo "  Skipping Azure, already exists"
+  else
+    if az vm list > /dev/null ; then
+      echo "  Azure login verified"
+    else
+      if ! az login > /dev/null ; then
+        echo "  WARNING: no azure credentials!"
+      fi
+    fi
+    if az account list > /dev/null ; then
+      # see https://www.terraform.io/docs/providers/azurerm/guides/service_principal_client_secret.html
+      azure_subscription_id=$(az account list | jq -r '.[0].id')
+      azure_resource=$(az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/$azure_subscription_id")
+      drpcli profiles create - >/dev/null << EOF
+{
+  "Name": "azure",
+  "Description": "Azure Credentials",
+  "Params": {
+    "cloud/provider": "azure",
+    "azure/subscription_id": "$azure_subscription_id",
+    "azure/appId": "$(jq -r .appId <<< "$azure_resource")",
+    "azure/tenant": "$(jq -r .tenant <<< "$azure_resource")",
+    "rsa/key-user": "rob"
+  },
+  "Meta": {
+    "color": "blue",
+    "icon": "microsoft",
+    "title": "generated"
+  }
+}
+EOF
+      drpcli profiles add azure param "azure/password" to "$(jq -r .password <<< "$azure_resource")" > /dev/null
+    else
+      echo "  WARNING: az account list failed"
+    fi
+  fi
+else
+  echo "  Skipping Azure, no az cli installed"
+fi
+
+echo "3/3 Touch cloud-wrappers to ensure reload"
+cw=$(drpcli contents show cloud-wrappers)
+drpcli contents update cloud-wrappers - <<< "$cw" > /dev/null
+
+echo "Done!"
+
+


### PR DESCRIPTION
Also, includes new tool that uploads local cloud credentials into profiles on an endpoint and sets up docker-context.

This is part of making it easier to setup AWS DR-Server for testing