### PR TITLE
fix(content): configure-network should no-op for contexts

### DIFF
--- a/content/tasks/configure-network.yaml
+++ b/content/tasks/configure-network.yaml
@@ -10,11 +10,15 @@ Templates:
   - Name: write-network-config
     Contents: |
       #!/usr/bin/env bash
+      {{ if eq .Machine.Context "" }}
       if ! grep -q autogen < <(drpcli net); then
           echo "drpcli net autogen is not a valid command"
           exit 1
       fi
       drpcli net autogen {{.Machine.UUID}}
+      {{ else }}
+      echo "NO ACTION TAKEN - skip networking configure if in Context {{ .Machine.Context }}"
+      {{ end }}
 Meta:
   type: "config"
   icon: "talk"


### PR DESCRIPTION
including this stage in `discover-base` makes sense, but Contexts fail when trying to run this task