### PR TITLE
enhance(proxmox): Minor cleanups and new config options.

### DIFF
--- a/proxmox/content/params/proxmox-debconf-selections-template.yaml
+++ b/proxmox/content/params/proxmox-debconf-selections-template.yaml
@@ -1,0 +1,21 @@
+---
+Name: proxmox/debconf-selections-template
+Description: Defines which template to use for the debconf-set-selections configuration.
+Documentation: |
+  Defines the template to use during installation for the debconf-set-selections
+  process.  To customize, create a new template with the correctly formatted
+  debconf-set-selections values, and set this Param to the name of your custom
+  template.
+
+  By defaul the template named ``proxmox-debconf-set-selections.tmpl`` will
+  be used.
+
+Meta:
+  color: blue
+  icon: database
+  title: Digital Rebar Community Content
+Schema:
+  default: proxmox-debconf-set-selections.tmpl
+  type: string
+Secure: false
+

--- a/proxmox/content/params/proxmox-package-selections.yaml
+++ b/proxmox/content/params/proxmox-package-selections.yaml
@@ -1,0 +1,32 @@
+---
+Name: proxmox/package-selections
+Description: Defines the packages selected to be installed in Debian.
+Documentation: |
+  This parameter defines the Package selection list to install initially.
+  This list should contain at least ``proxmox-ve`` and any necessary
+  supporting packages.
+
+  If the operator overrides the Default values specified in this Param,
+  all packages must be specified in the updated Param values.
+
+  The list is a space separated string that must contain valid Debian
+  package names.  These packages must be available in the default repos
+  unless additional ``apt`` repos have been setup and initialized prior
+  to this task run.
+
+  .. note:: The default workflows assume ``postfix`` and ``samba`` packages
+            are installed (as specified by proxmox requirements).  There are
+            special tasks for staging ``apt-set-selections`` to automate these
+            package installation successfully.  If additional packages requiring
+            input are added, the operator must implement a set of ``apt-set-selections``
+            appropriate to that package.
+
+Meta:
+  color: blue
+  icon: database
+  title: Digital Rebar Community Content
+Schema:
+  default: "proxmox-ve postfix openvswitch-switch open-iscsi vim wget curl jq ifupdown2"
+  type: string
+Secure: false
+

--- a/proxmox/content/params/proxmox-strip-kernel-packages.yaml
+++ b/proxmox/content/params/proxmox-strip-kernel-packages.yaml
@@ -1,0 +1,25 @@
+---
+Name: proxmox/strip-kernel-packages
+Description: "The list of packages to remove if proxmox/strip-kernel is set to 'true'."
+Documentation: |
+  The default package list to remove from the final installed system.  The
+  Proxmox install guides optional suggests removing the stock kernel
+  packages.  By default, this installer workflow does NOT strip these
+  packages.  To strip them, set ``proxmox/strip-kernel`` to ``true``, and
+  ensure this Param has the correct set of values for your installation.
+
+  The default value is ``linux-image-amd64 linux-image-4.19*``.
+
+  .. note:: If a regex is used, you must single quote protect the regex
+            from the shell interpretting it as a wildcard.  See the ``default``
+            value setting for this param as a valid example.
+
+Meta:
+  color: blue
+  icon: database
+  title: Digital Rebar Community Content
+Schema:
+  default: "linux-image-amd64 'linux-image-4.19*'"
+  type: string
+Secure: false
+

--- a/proxmox/content/params/proxmox-strip-kernel.yaml
+++ b/proxmox/content/params/proxmox-strip-kernel.yaml
@@ -1,0 +1,19 @@
+---
+Name: proxmox/strip-kernel
+Description: If set to true, strip the stock Debian kernels in favor of the customized Proxmox ones.
+Documentation: |
+  Setting this Param value to ``true`` will cause the installer to remove the
+  packages specified by the ``proxmox/strip-kernel-packages`` param.  This is
+  an optional step and not required for Proxmox installation.
+
+  The default value is ``false`` (do NOT strip the kernel packages off of the system).
+
+Meta:
+  color: blue
+  icon: database
+  title: Digital Rebar Community Content
+Schema:
+  default: false
+  type: boolean
+Secure: false
+

--- a/proxmox/content/tasks/proxmox-buster-installer.yaml
+++ b/proxmox/content/tasks/proxmox-buster-installer.yaml
@@ -22,10 +22,20 @@ Templates:
   - Name: proxmox-buster-install.sh.tmpl
     Contents: |
       #!/usr/bin/env bash
-
       # Install Debian 10 (Buster) and latest Proxmox VE
 
+      ###
+      #  This install script is loosely based on the Proxmox described install
+      #  process, which can be found at:
+      #
+      #    * https://pve.proxmox.com/wiki/Install_Proxmox_VE_on_Debian_Buster
+      ###
+
       {{ template "setup.tmpl" . }}
+
+      # get the packages selected for installation, extra space is intentionally
+      # injected here for grep pattern checks below
+      PKGS=' {{ .Param "proxmox/package-selections" }} '
 
       # PROXMOX is extremely intolerant of hostname changes ... basically, you can't
       # and you must have the hostname in /etc/hosts ...
@@ -42,7 +52,7 @@ Templates:
       echo "deb http://download.proxmox.com/debian/pve buster pve-no-subscription" > /etc/apt/sources.list.d/pve-install-repo.list
 
       ENT="/etc/apt/sources.list.d/pve-enterprise.list"
-      [[ -r "$ENT" ]] && { echo "Removing injected enterprise repo."; rm -f "$ENT"; } || echo "Good. No enterprise repo repo list found."
+      [[ -r "$ENT" ]] && { echo "Removing injected enterprise repo."; rm -f "$ENT"; } || echo "Good. No enterprise repo list found."
 
       echo ">>> get the GPG key for the repo"
       wget http://download.proxmox.com/debian/proxmox-ve-release-6.x.gpg -O /etc/apt/trusted.gpg.d/proxmox-ve-release-6.x.gpg
@@ -53,9 +63,21 @@ Templates:
       echo ">>> preseed the samba and postfix package questions"
       debconf-set-selections /root/proxmox-debconf-set-selections
 
-      echo ">>> install proxmox"
-      apt -y install proxmox-ve postfix open-iscsi vim wget curl jq ifupdown2
+      echo ">>> install proxmox with these package selections: $PKGS"
+      apt -y install $PKGS
 
+      # recommended by install guide - see URL above for reference
       echo ">>> remove the OS prober package"
       apt -y remove os-prober
+
+      {{ if .Param "proxmox/strip-kernel" -}}
+      echo ">>> strip the Debian stock kernel packages"
+      apt -y remove {{ .Param "proxmox/strip-kernel-packages" }}
+
+      if [[ "$?" == "0" ]]
+      then
+        echo ">>> updating the grub bootloader"
+        update-grub
+      fi
+      {{ end }}
 

--- a/proxmox/content/tasks/proxmox-debconf-set-selections.yaml
+++ b/proxmox/content/tasks/proxmox-debconf-set-selections.yaml
@@ -1,23 +1,38 @@
 ---
 Name: proxmox-debconf-set-selections
 Description: ''
-Documentation: ''
+Documentation: |
+  This task provides the Debian Package preset configuration input values
+  needed to ensure automated installation of the samba and postfix packages.
+  It also allows the operator to pre-seed and package configurations for
+  any installed value.
+
+  Set the ``proxmox/debconf-selections-template`` template to the name of
+  your custom settings, which must conform to the debconf-set-selections
+  structure.
+
+  The template will be saved on the Machine under ``/root/proxmox-debconf-set-selections``
+  and read in prior to package installation.
+
 Meta:
   color: orange
   feature-flags: sane-exit-codes
   icon: expand arrows alternate
   title: RackN Content
 RequiredParams: []
-OptionalParams: []
+OptionalParams:
+  - proxmox/debconf-selections-template
 Prerequisites: []
 Templates:
   - Name: proxmox-debconf-set-selections
-    Path: /root/proxmox-debconf-set-selections
+    ID: proxmox-debconf-set-selections
     Contents: |
-      samba-common    samba-common/do_debconf boolean true
-      samba-common    samba-common/dhcp       boolean false
-      samba-common    samba-common/workgroup  string  WORKGROUP
-      postfix postfix/main_mailer_type        select  Local only
-      postfix postfix/mailname        string  {{.Machine.Name}}
-      postfix postfix/destinations    string  $myhostname, {{.Machine.Name}}, localhost.kvm-test.local, localhost
+      #!/usr/bin/env bash
+      # Get the debconf selections template and save it to /root/proxmox-debconf-set-selections
+
+      {{ $tmpl := ( printf "%s" ( .Param "proxmox/debconf-selections-template") ) -}}
+
+      cat << 'EOTMPL' > /root/proxmox-debconf-set-selections
+      {{ .CallTemplate $tmpl . }}
+      EOTMPL
 

--- a/proxmox/content/templates/proxmox-debconf-set-selections.tmpl
+++ b/proxmox/content/templates/proxmox-debconf-set-selections.tmpl
@@ -1,0 +1,17 @@
+###
+#  The default set of debconf selections to pre-answer packages during
+#  Debian and Proxmox package installations.
+#
+#  Specifically - samba and postfix require human intervention unless
+#  these values are preset via the selections.
+#
+#  This template is specified by the "proxmox/debconf-selections-template"
+#  Param.  A custom template can be created, and then the Param set to
+#  the name of your custom template.
+###
+samba-common    samba-common/do_debconf boolean true
+samba-common    samba-common/dhcp       boolean false
+samba-common    samba-common/workgroup  string  WORKGROUP
+postfix postfix/main_mailer_type        select  Local only
+postfix postfix/mailname        string  {{.Machine.Name}}
+postfix postfix/destinations    string  $myhostname, {{.Machine.Name}}, localhost

--- a/proxmox/content/workflows/proxmox-buster-install.yaml
+++ b/proxmox/content/workflows/proxmox-buster-install.yaml
@@ -37,11 +37,6 @@ Documentation: |
   enslaved by the bridge, but also bring up a NAT Masquerade bridge
   to attach machines to.
 
-  **ToDo**:
-  Future implementations should provide customized injection of the
-  preseed selections answers, and allow specifying the version of
-  Proxmox VE to install.
-
 Meta:
   color: orange
   icon: expand arrows alternate

--- a/proxmox/content/workflows/proxmox-only-install.yaml
+++ b/proxmox/content/workflows/proxmox-only-install.yaml
@@ -35,11 +35,6 @@ Documentation: |
   enslaved by the bridge, but also bring up a NAT Masquerade bridge
   to attach machines to.
 
-  **ToDo**:
-  Future implementations should provide customized injection of the
-  preseed selections answers, and allow specifying the version of
-  Proxmox VE to install.
-
 Meta:
   color: orange
   icon: expand arrows alternate


### PR DESCRIPTION
Some minor cleanup and enhancements based on community feedback on some issues.
- Move `debconf-set-selections` to an external Template
- Allow override template to be defined for the `debconf-set-selections`
- Allow customization of the Packages selected at Proxmox install time
- Optionally allow stripping the stock Debian kernels (default is False)
- Remove the ToDo notes about setselecions