### PR TITLE
fix(drp-community-content): Fix ubuntu 20.04 ISO kernel options to use template expansion

### DIFF
--- a/content/bootenvs/ubuntu-20.04-install.yml
+++ b/content/bootenvs/ubuntu-20.04-install.yml
@@ -53,7 +53,7 @@ OS:
         root=/dev/ram0
         ramdisk_size=1500000
         ip=dhcp
-        url={{.ProvisionerURL}}/isos/ubuntu-20.04-live-server-amd64.iso
+        url={{.ProvisionerURL}}/isos/{{.Env.OS.SupportedArchitectures.amd64.IsoFile}}
         autoinstall
         ds=nocloud-net;s={{.Machine.Url}}/autoinstall/
 #        {{.Param "kernel-options"}}

--- a/content/bootenvs/ubuntu-20.04.0-install.yml
+++ b/content/bootenvs/ubuntu-20.04.0-install.yml
@@ -53,7 +53,7 @@ OS:
         root=/dev/ram0
         ramdisk_size=1500000
         ip=dhcp
-        url={{.ProvisionerURL}}/isos/ubuntu-20.04-live-server-amd64.iso
+        url={{.ProvisionerURL}}/isos/{{.Env.OS.SupportedArchitectures.amd64.IsoFile}}
         autoinstall
         ds=nocloud-net;s={{.Machine.Url}}/autoinstall/
 #        {{.Param "kernel-options"}}

--- a/content/bootenvs/ubuntu-20.04.1-install.yml
+++ b/content/bootenvs/ubuntu-20.04.1-install.yml
@@ -53,7 +53,7 @@ OS:
         root=/dev/ram0
         ramdisk_size=1500000
         ip=dhcp
-        url={{.ProvisionerURL}}/isos/ubuntu-20.04-live-server-amd64.iso
+        url={{.ProvisionerURL}}/isos/{{.Env.OS.SupportedArchitectures.amd64.IsoFile}}
         autoinstall
         ds=nocloud-net;s={{.Machine.Url}}/autoinstall/
 #        {{.Param "kernel-options"}}


### PR DESCRIPTION
Ubuntu 20.04 bootenvs were busted for 20.04.1 - using hard coded ISO path for 20.04 (no patch version).

This PR changes the bootenvs to use a template construct to template render the correct ISO File name.  NOTE that adding ARM based architectures in the future will require using the right template expansion for those SupportedArchitectures.
