### PR TITLE
fix(task-library): zip file logic was reversed

### DIFF
--- a/cloud-wrappers/params/linode-instance-type.yaml
+++ b/cloud-wrappers/params/linode-instance-type.yaml
@@ -3,6 +3,8 @@ Name: "linode/instance-type"
 Description: "linode Instance Type"
 Documentation: |
   Provision Linode allocation size
+
+  retrieve with ``curl https://api.linode.com/v4/linode/types | jq '.data.[].id'``
 Schema:
   type: "string"
   default: "g6-standard-1"

--- a/dev-library/params/dev-counter.yaml
+++ b/dev-library/params/dev-counter.yaml
@@ -1,0 +1,11 @@
+---
+Name: "dev/counter"
+Description: "Handy counter for repeated operations"
+Documentation: |
+  Increments when dev-counter task is run
+Schema:
+  type: "number"
+Meta:
+  color: "blue"
+  icon: "sort numeric up"
+  title: "RackN Content"

--- a/dev-library/params/dev-wait-time.yaml
+++ b/dev-library/params/dev-wait-time.yaml
@@ -8,7 +8,7 @@ Documentation: |
 Schema:
   type: "number"
   default: 1.0
-  minimum: 0.1
+  minimum: -1
 Meta:
   color: "yellow"
   icon: "hourglass half"

--- a/dev-library/tasks/dev-counter.yaml
+++ b/dev-library/tasks/dev-counter.yaml
@@ -1,0 +1,29 @@
+---
+Name: dev-counter
+Description: "Increment dev/counter"
+Documentation: |
+  When run, will add 1 to the dev/counter
+OptionalParams:
+  - dev/counter
+Templates:
+- Contents: |-
+    #!/usr/bin/env bash
+
+    set -e
+
+    {{template "setup.tmpl" .}}
+
+    echo "incrementing dev/counter.  new value is:"
+    {{ if .ParamExists "dev/counter" }}
+    drpcli machines set $RS_UUID param dev/counter to {{ add1 (.Param "dev/counter") }}
+    {{ else }}
+    drpcli machines add $RS_UUID param dev/counter to 1 
+    {{ end }}
+
+    echo "done"
+    exit 0
+  Name: dev-counter
+Meta:
+  title: "RackN Content"
+  color: orange
+  icon: "sort numeric up"

--- a/dev-library/tasks/wait-time.yaml
+++ b/dev-library/tasks/wait-time.yaml
@@ -29,14 +29,19 @@ Templates:
       icon='black'
     fi
 
-    {{ $wait := (.Param "dev/wait-time") }}
+    wait={{ (.Param "dev/wait-time") }}
+    if [[ $wait -lt 0 ]]; then
+      wait=$((1 + $RANDOM % 10))
+    fi
+
     {{ range $index, $icon := (.Param "dev/wait-icons") -}}
-      echo "wait cycle {{$index}}"
+      echo "wait $wait cycle {{$index}}"
       drpcli machines meta set $RS_UUID key icon to "{{$icon}}"
       drpcli machines meta set $RS_UUID key color to "brown"
-      sleep {{ $wait }}
+      sleep $wait
     {{ else -}}
-      echo "no icons defined, no wait"
+      echo "no icons defined, just wait $wait once"
+      sleep $wait
       exit 0
     {{ end -}}
 

--- a/task-library/tasks/dr-server-install.yaml
+++ b/task-library/tasks/dr-server-install.yaml
@@ -104,13 +104,13 @@ Templates:
           - name: "run install.sh script install mode (download ZIP)"
             become: true
             shell: "./install.sh --startup --drp-id={{`{{drpid}}`}} --no-content --systemd --bootstrap --zip-file=dr-provision.zip --no-content --start-runner --drp-password={{ .Param "dr-server/initial-password" }} --drp-user={{ .Param "dr-server/initial-user" }} --initial-contents=\"./rackn-license.json\" install"
-            when: services["dr-provision.service"] is not defined and has_zip == "false"
+            when: services["dr-provision.service"] is not defined and has_zip == "true"
             register: shell_result1
 
           - name: "run install.sh script install mode (use local ZIP)"
             become: true
             shell: "./install.sh --startup --drp-id={{`{{drpid}}`}} --no-content --systemd --bootstrap --no-content --start-runner --drp-password={{ .Param "dr-server/initial-password" }} --drp-user={{ .Param "dr-server/initial-user" }} --initial-contents=\"./rackn-license.json\" install"
-            when: services["dr-provision.service"] is not defined and has_zip == "true"
+            when: services["dr-provision.service"] is not defined and has_zip == "false"
             register: shell_result1
 
           - name: "install output log"


### PR DESCRIPTION
also, includes dev-library adds:
1) a task that helps developers count workflows
2) wait can be random 1-9 secs.