### PR TITLE
refactor(dev-library) start move of reboot workflow to dev-lib

### DIFF
--- a/dev-library/params/dev-reboot-workflow.yaml
+++ b/dev-library/params/dev-reboot-workflow.yaml
@@ -1,0 +1,12 @@
+---
+Name: "dev/reboot-workflow"
+Description: "Workflow to set before rebooting system."
+Documentation: |
+  Workflow to set before rebooting system.
+Schema:
+  type: "string"
+  default: "discover-base"
+Meta:
+  color: "blue"
+  icon: "recycle"
+  title: "Community Content Copyright RackN 2021"

--- a/dev-library/tasks/dev-reboot-workflow.yaml
+++ b/dev-library/tasks/dev-reboot-workflow.yaml
@@ -1,0 +1,40 @@
+---
+Description: "A task to reboot to a workflow specifed by the dev/reboot-workflow"
+Name: "dev-reboot-workflow"
+Documentation: |
+  A task to reboot to a workflow specifed by the dev/reboot-workflow.
+RequiredParameters:
+  - dev/reboot-workflow
+Templates:
+  - Name: "reboot-it"
+    Path: ""
+    Contents: |
+      #!/usr/bin/env bash
+
+      {{ template "setup.tmpl" . }}
+
+      drpcli machines workflow $RS_UUID "" >/dev/null
+      drpcli machines workflow $RS_UUID {{ .Param "dev/reboot-workflow" }} >/dev/null
+
+      # this is going to look like a reboot, fake a powercycle
+      # MUST BE AFTER other machine updates or it will be over-written by next event
+      if drpcli events post '{
+        "Action": "powercycle",
+        "Key": "{{ .Machine.Uuid }}",
+        "Object": {{ .Machine | toJson }},
+        "Principal": "runner:{{ .Machine.Uuid }}",
+        "Type": "machines"
+      }' > /dev/null; then
+        echo "Sending Reboot Event (powercycle)"
+        sleep 5
+      else
+        echo "Warning: failed trying to post Reboot Event (powercycle)"
+      fi
+
+      echo "reboot exit code..."
+      exit 192
+Meta:
+  icon: "recycle" 
+  color: "orange"
+  title: "Community Content"
+  copyright: "RackN 2021"


### PR DESCRIPTION
this was part of Edge-Lab, moving it here makes it more broadly accessible.
this is step one of migrating out of edge-lab