### PR TITLE
enhance(drp-community-content): Add Ubuntu 20.04.2 bootenv

### DIFF
--- a/content/bootenvs/ubuntu-20.04-install.yml
+++ b/content/bootenvs/ubuntu-20.04-install.yml
@@ -7,21 +7,22 @@ Documentation: |
   Enablement) version, please use the Stage "ubuntu-20.04-hwe-install".
   Both amd64 and arm64 architectures are supported.
 
-  NOTE - Default Ubuntu ISOs will attempt to check internet repositories, this
-  can cause problems during provisioning if your environment does not have
-  outbound access.  Workaround this by defining Options 3 (Gateway) and 6 (DNS)
-  for your Subnet settings.  See https://provision.readthedocs.io/en/latest/doc/kb/kb-00033.html
+  .. note:: Default Ubuntu ISOs will attempt to check internet repositories, this
+            can cause problems during provisioning if your environment does not have
+            outbound access.  Workaround this by defining Options 3 (Gateway) and 6 (DNS)
+            for your Subnet settings.  See https://provision.readthedocs.io/en/latest/doc/kb/kb-00033.html
 
-  ``part-scheme`` can be used to inject a storage section.
+  The Param named ``part-scheme`` can be used to inject a storage section.
+  Set the param to a value that will be used to locate a template containing
+  the YAML ``storage`` definition.
 
-
-  The template would be named "part-scheme-<Value of part-scheme>".
+  The template would be named "part-scheme-``<Value of part-scheme>``.tmpl".
 
   The format should be:
 
     ::
 
-      Note Indentation matters with the extra two spaces.
+      # Note Indentation matters with the extra two spaces.
 
         storage:
           swap:
@@ -30,6 +31,11 @@ Documentation: |
             name: direct
             match:
               ssd: yes
+
+  Documentation for ``storage`` format and options can be found at:
+
+    * https://provision.readthedocs.io/en/latest/doc/content-packages/image-deploy.html#curtin-partitions
+    * https://curtin.readthedocs.io/en/latest/topics/storage.html
 
 Meta:
   color: "purple"
@@ -43,9 +49,9 @@ OS:
   Version: "20.04"
   SupportedArchitectures:
     amd64:
-      IsoFile: "ubuntu-20.04.1-live-server-amd64.iso"
-      IsoUrl: "https://rackn-repo.s3.amazonaws.com/isos/canonical/ubuntu/20.04/ubuntu-20.04.1-live-server-amd64.iso"
-      IsoSha256: "443511f6bf12402c12503733059269a2e10dec602916c0a75263e5d990f6bb93"
+      IsoFile: "ubuntu-20.04.2-live-server-amd64.iso"
+      IsoUrl: "https://rackn-repo.s3.amazonaws.com/isos/canonical/ubuntu/20.04/ubuntu-20.04.2-live-server-amd64.iso"
+      IsoSha256: "d1f2bf834bbe9bb43faf16f9be992a6f3935e65be0edece1dee2aa6eb1767423"
       Kernel: "casper/vmlinuz"
       Initrds:
         - "casper/initrd"

--- a/content/bootenvs/ubuntu-20.04.0-install.yml
+++ b/content/bootenvs/ubuntu-20.04.0-install.yml
@@ -7,21 +7,22 @@ Documentation: |
   Enablement) version, please use the Stage "ubuntu-20.04-hwe-install".
   Both amd64 and arm64 architectures are supported.
 
-  NOTE - Default Ubuntu ISOs will attempt to check internet repositories, this
-  can cause problems during provisioning if your environment does not have
-  outbound access.  Workaround this by defining Options 3 (Gateway) and 6 (DNS)
-  for your Subnet settings.  See https://provision.readthedocs.io/en/latest/doc/kb/kb-00033.html
+  .. note:: Default Ubuntu ISOs will attempt to check internet repositories, this
+            can cause problems during provisioning if your environment does not have
+            outbound access.  Workaround this by defining Options 3 (Gateway) and 6 (DNS)
+            for your Subnet settings.  See https://provision.readthedocs.io/en/latest/doc/kb/kb-00033.html
 
-  ``part-scheme`` can be used to inject a storage section.
+  The Param named ``part-scheme`` can be used to inject a storage section.
+  Set the param to a value that will be used to locate a template containing
+  the YAML ``storage`` definition.
 
-
-  The template would be named "part-scheme-<Value of part-scheme>".
+  The template would be named "part-scheme-``<Value of part-scheme>``.tmpl".
 
   The format should be:
 
     ::
 
-      Note Indentation matters with the extra two spaces.
+      # Note Indentation matters with the extra two spaces.
 
         storage:
           swap:
@@ -30,6 +31,11 @@ Documentation: |
             name: direct
             match:
               ssd: yes
+
+  Documentation for ``storage`` format and options can be found at:
+
+    * https://provision.readthedocs.io/en/latest/doc/content-packages/image-deploy.html#curtin-partitions
+    * https://curtin.readthedocs.io/en/latest/topics/storage.html
 
 Meta:
   color: "purple"

--- a/content/bootenvs/ubuntu-20.04.2-install.yml
+++ b/content/bootenvs/ubuntu-20.04.2-install.yml
@@ -1,8 +1,8 @@
 ---
-Name: "ubuntu-20.04.1-install"
-Description: "Ubuntu-20.04.1 install"
+Name: "ubuntu-20.04.2-install"
+Description: "Ubuntu-20.04.2 install"
 Documentation: |
-  Installs Ubuntu Focal Fossa (20.04.1) LTS version.  This BootEnv will install
+  Installs Ubuntu Focal Fossa (20.04.2) LTS version.  This BootEnv will install
   the General Available (GA) kernel.  If you wish to install the HWE (Hardware
   Enablement) version, please use the Stage "ubuntu-20.04-hwe-install".
   Both amd64 and arm64 architectures are supported.
@@ -43,15 +43,15 @@ Meta:
   icon: "linux"
   title: "Digital Rebar Community Content"
 OS:
-  Name: "ubuntu-20.04.1"
+  Name: "ubuntu-20.04.2"
   Family: "ubuntu"
   Codename: "Focal Fossa"
   Version: "20.04"
   SupportedArchitectures:
     amd64:
-      IsoFile: "ubuntu-20.04.1-live-server-amd64.iso"
-      IsoUrl: "https://rackn-repo.s3.amazonaws.com/isos/canonical/ubuntu/20.04/ubuntu-20.04.1-live-server-amd64.iso"
-      IsoSha256: "443511f6bf12402c12503733059269a2e10dec602916c0a75263e5d990f6bb93"
+      IsoFile: "ubuntu-20.04.2-live-server-amd64.iso"
+      IsoUrl: "https://rackn-repo.s3-us-west-2.amazonaws.com/isos/canonical/ubuntu/20.04/ubuntu-20.04.2-live-server-amd64.iso"
+      IsoSha256: "d1f2bf834bbe9bb43faf16f9be992a6f3935e65be0edece1dee2aa6eb1767423"
       Kernel: "casper/vmlinuz"
       Initrds:
         - "casper/initrd"

--- a/content/stages/ubuntu-20.04.2.yaml
+++ b/content/stages/ubuntu-20.04.2.yaml
@@ -1,0 +1,24 @@
+---
+Name: ubuntu-20.04.2-install
+BootEnv: ubuntu-20.04.2-install
+Description: Ubuntu 20.04.2 installation stage.
+Documentation: |
+  Installs the GA (General Availability) kernel by default.  To install
+  the HWE kernel, please set the "ubuntu-hwe-kernel" Param on your machine
+  and set it to "true" (use Param, Profile, or "global" Profile).
+
+  Note for HWE kernel, the BootEnv ".Env.OS.Version" value is used to set
+  the HWE preseed option correctly.  Please verify that the preseed syntax
+  is valid for your version of Ubuntu (this was tested working with 18.04).
+
+Meta:
+  type: "os"
+  color: yellow
+  icon: download
+  title: Digital Rebar Community Content
+Tasks:
+- ssh-access
+- "configure-network"
+
+
+

--- a/task-library/workflows/ubuntu-20.04-base.yaml
+++ b/task-library/workflows/ubuntu-20.04-base.yaml
@@ -3,7 +3,7 @@ Description: "Basic Ubuntu 20.04 Install Workflow + Runner"
 Documentation: |
   .. warning:: DEPRECATED - This workflow will be removed from future versions of
                DRP.  Please use the ``universal`` content pack and workflows.  See
-               :ref:`_deploy_linux_with_universal`.
+               :ref:`deploy_linux_with_universal`.
 
   This workflow includes the DRP Runner in Ubuntu provisioning process for DRP.
 

--- a/task-library/workflows/ubuntu-20.04-base.yaml
+++ b/task-library/workflows/ubuntu-20.04-base.yaml
@@ -1,6 +1,10 @@
 Name: "ubuntu-20.04-base"
 Description: "Basic Ubuntu 20.04 Install Workflow + Runner"
 Documentation: |
+  .. warning:: DEPRECATED - This workflow will be removed from future versions of
+               DRP.  Please use the ``universal`` content pack and workflows.  See
+               :ref:`_deploy_linux_with_universal`.
+
   This workflow includes the DRP Runner in Ubuntu provisioning process for DRP.
 
   After the install completes, the workflow installs the runner
@@ -10,7 +14,7 @@ Documentation: |
   .. note:: To enable, upload the Ubuntu-20.04 ISO as per the ubuntu-20.04 BootEnv
 
 Stages:
-  - ubuntu-20.04-install
+  - ubuntu-20.04.2-install
   - drp-agent
   - finish-install
   - complete


### PR DESCRIPTION
Adds the minor point release for Ubuntu 20.04.2 to DRP Community Content.  Updates the Task Library workflow to point directly at the `ubuntu-20.04.2-install` Stage.

Includes v4.6 deprecation notice of the Linux install *base* workflows.