### PR TITLE
fix(drp-community-content): Fix Ubuntu 20.04 SSH keys not present

### DIFF
--- a/content/bootenvs/ubuntu-20.04-install.yml
+++ b/content/bootenvs/ubuntu-20.04-install.yml
@@ -109,40 +109,9 @@ Templates:
   - ID: "default-grub.tmpl"
     Name: "grub-mac"
     Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'
-  - Name: "autoinstall"
+  - ID: "ubuntu-autoinstall-userdata.tmpl"
+    Name: "autoinstall"
     Path: "{{.Machine.Path}}/autoinstall/user-data"
-    Contents: |
-      #cloud-config
-      autoinstall:
-        version: 1
-        {{ if .ParamExists "proxy-servers" -}}
-        proxy: "{{ index (.Param "proxy-servers") 0 }}"
-        {{ end }}
-        identity:
-          hostname: {{.Machine.Name}}
-          password: "{{if .ParamExists "provisioner-default-password-hash"}}{{.Param "provisioner-default-password-hash"}}{{else}}$6$drprocksdrprocks$upAIK9ynEEdFmaxJ5j0QRvwmIu2ruJa1A1XB7GZjrnYYXXyNr4qF9FttxMda2j.cmh.TSiLgn4B/7z0iSHkDC1{{end}}"
-          username: {{if .ParamExists "provisioner-default-user"}}{{.Param "provisioner-default-user"}}{{else}}rocketskates{{end}}
-        ssh:
-          install-server: yes
-          authorized-keys:
-            {{range $key := .Param "access-keys" }}
-            - "{{$key}}"
-            {{end}}
-          {{ if .ParamExists "access-ssh-root-mode" }}
-          allow-pw: {{.Param "access-ssh-root-mode"}}
-          {{end}}
-        keyboard:
-          layout: us
-        locale: en_US
-      {{ if .ParamExists "part-scheme" }}
-      {{ $templateName := (printf "part-scheme-%s.tmpl" (.Param "part-scheme")) }}
-      {{ .CallTemplate $templateName . }}
-      {{ end }}
-        late-commands:
-          - wget --no-proxy {{.Machine.Url}}/post-install.sh -O /target/net-post-install.sh
-          - chmod +x /target/net-post-install.sh
-          - curtin in-target --target=/target /net-post-install.sh
-
   - Name: meta-data
     Path: '{{.Machine.Path}}/autoinstall/meta-data'
     Contents: |

--- a/content/bootenvs/ubuntu-20.04.0-install.yml
+++ b/content/bootenvs/ubuntu-20.04.0-install.yml
@@ -109,40 +109,9 @@ Templates:
   - ID: "default-grub.tmpl"
     Name: "grub-mac"
     Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'
-  - Name: "autoinstall"
+  - ID: "ubuntu-autoinstall-userdata.tmpl"
+    Name: "autoinstall"
     Path: "{{.Machine.Path}}/autoinstall/user-data"
-    Contents: |
-      #cloud-config
-      autoinstall:
-        version: 1
-        {{ if .ParamExists "proxy-servers" -}}
-        proxy: "{{ index (.Param "proxy-servers") 0 }}"
-        {{ end }}
-        identity:
-          hostname: {{.Machine.Name}}
-          password: "{{if .ParamExists "provisioner-default-password-hash"}}{{.Param "provisioner-default-password-hash"}}{{else}}$6$drprocksdrprocks$upAIK9ynEEdFmaxJ5j0QRvwmIu2ruJa1A1XB7GZjrnYYXXyNr4qF9FttxMda2j.cmh.TSiLgn4B/7z0iSHkDC1{{end}}"
-          username: {{if .ParamExists "provisioner-default-user"}}{{.Param "provisioner-default-user"}}{{else}}rocketskates{{end}}
-        ssh:
-          install-server: yes
-          authorized-keys:
-            {{range $key := .Param "access-keys" }}
-            - "{{$key}}"
-            {{end}}
-          {{ if .ParamExists "access-ssh-root-mode" }}
-          allow-pw: {{.Param "access-ssh-root-mode"}}
-          {{end}}
-        keyboard:
-          layout: us
-        locale: en_US
-      {{ if .ParamExists "part-scheme" }}
-      {{ $templateName := (printf "part-scheme-%s.tmpl" (.Param "part-scheme")) }}
-      {{ .CallTemplate $templateName . }}
-      {{ end }}
-        late-commands:
-          - wget --no-proxy {{.Machine.Url}}/post-install.sh -O /target/net-post-install.sh
-          - chmod +x /target/net-post-install.sh
-          - curtin in-target --target=/target /net-post-install.sh
-
   - Name: meta-data
     Path: '{{.Machine.Path}}/autoinstall/meta-data'
     Contents: |

--- a/content/bootenvs/ubuntu-20.04.1-install.yml
+++ b/content/bootenvs/ubuntu-20.04.1-install.yml
@@ -109,40 +109,9 @@ Templates:
   - ID: "default-grub.tmpl"
     Name: "grub-mac"
     Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'
-  - Name: "autoinstall"
+  - ID: "ubuntu-autoinstall-userdata.tmpl"
+    Name: "autoinstall"
     Path: "{{.Machine.Path}}/autoinstall/user-data"
-    Contents: |
-      #cloud-config
-      autoinstall:
-        version: 1
-        {{ if .ParamExists "proxy-servers" -}}
-        proxy: "{{ index (.Param "proxy-servers") 0 }}"
-        {{ end }}
-        identity:
-          hostname: {{.Machine.Name}}
-          password: "{{if .ParamExists "provisioner-default-password-hash"}}{{.Param "provisioner-default-password-hash"}}{{else}}$6$drprocksdrprocks$upAIK9ynEEdFmaxJ5j0QRvwmIu2ruJa1A1XB7GZjrnYYXXyNr4qF9FttxMda2j.cmh.TSiLgn4B/7z0iSHkDC1{{end}}"
-          username: {{if .ParamExists "provisioner-default-user"}}{{.Param "provisioner-default-user"}}{{else}}rocketskates{{end}}
-        ssh:
-          install-server: yes
-          authorized-keys:
-            {{range $key := .Param "access-keys" }}
-            - "{{$key}}"
-            {{end}}
-          {{ if .ParamExists "access-ssh-root-mode" }}
-          allow-pw: {{.Param "access-ssh-root-mode"}}
-          {{end}}
-        keyboard:
-          layout: us
-        locale: en_US
-      {{ if .ParamExists "part-scheme" }}
-      {{ $templateName := (printf "part-scheme-%s.tmpl" (.Param "part-scheme")) }}
-      {{ .CallTemplate $templateName . }}
-      {{ end }}
-        late-commands:
-          - wget --no-proxy {{.Machine.Url}}/post-install.sh -O /target/net-post-install.sh
-          - chmod +x /target/net-post-install.sh
-          - curtin in-target --target=/target /net-post-install.sh
-
   - Name: meta-data
     Path: '{{.Machine.Path}}/autoinstall/meta-data'
     Contents: |

--- a/content/bootenvs/ubuntu-20.04.2-install.yml
+++ b/content/bootenvs/ubuntu-20.04.2-install.yml
@@ -109,40 +109,9 @@ Templates:
   - ID: "default-grub.tmpl"
     Name: "grub-mac"
     Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'
-  - Name: "autoinstall"
+  - ID: "ubuntu-autoinstall-userdata.tmpl"
+    Name: "autoinstall"
     Path: "{{.Machine.Path}}/autoinstall/user-data"
-    Contents: |
-      #cloud-config
-      autoinstall:
-        version: 1
-        {{ if .ParamExists "proxy-servers" -}}
-        proxy: "{{ index (.Param "proxy-servers") 0 }}"
-        {{ end }}
-        identity:
-          hostname: {{.Machine.Name}}
-          password: "{{if .ParamExists "provisioner-default-password-hash"}}{{.Param "provisioner-default-password-hash"}}{{else}}$6$drprocksdrprocks$upAIK9ynEEdFmaxJ5j0QRvwmIu2ruJa1A1XB7GZjrnYYXXyNr4qF9FttxMda2j.cmh.TSiLgn4B/7z0iSHkDC1{{end}}"
-          username: {{if .ParamExists "provisioner-default-user"}}{{.Param "provisioner-default-user"}}{{else}}rocketskates{{end}}
-        ssh:
-          install-server: yes
-          authorized-keys:
-            {{range $key := .Param "access-keys" }}
-            - "{{$key}}"
-            {{end}}
-          {{ if .ParamExists "access-ssh-root-mode" }}
-          allow-pw: {{.Param "access-ssh-root-mode"}}
-          {{end}}
-        keyboard:
-          layout: us
-        locale: en_US
-      {{ if .ParamExists "part-scheme" }}
-      {{ $templateName := (printf "part-scheme-%s.tmpl" (.Param "part-scheme")) }}
-      {{ .CallTemplate $templateName . }}
-      {{ end }}
-        late-commands:
-          - wget --no-proxy {{.Machine.Url}}/post-install.sh -O /target/net-post-install.sh
-          - chmod +x /target/net-post-install.sh
-          - curtin in-target --target=/target /net-post-install.sh
-
   - Name: meta-data
     Path: '{{.Machine.Path}}/autoinstall/meta-data'
     Contents: |

--- a/content/templates/ubuntu-autoinstall-userdata.tmpl
+++ b/content/templates/ubuntu-autoinstall-userdata.tmpl
@@ -1,0 +1,30 @@
+#cloud-config
+autoinstall:
+  version: 1
+  {{ if .ParamExists "proxy-servers" -}}
+  proxy: "{{ index (.Param "proxy-servers") 0 }}"
+  {{ end -}}
+  identity:
+    hostname: {{.Machine.Name}}
+    password: "{{ if .ParamExists "provisioner-default-password-hash" }}{{ .Param "provisioner-default-password-hash" }}{{ else }}$6$drprocksdrprocks$upAIK9ynEEdFmaxJ5j0QRvwmIu2ruJa1A1XB7GZjrnYYXXyNr4qF9FttxMda2j.cmh.TSiLgn4B/7z0iSHkDC1{{ end }}"
+    username: {{ if .ParamExists "provisioner-default-user" }}{{ .Param "provisioner-default-user" }}{{ else }}rocketskates{{ end }}
+  ssh:
+    install-server: yes
+{{- if .ParamExists "access-ssh-root-mode" }}{{ printf "\n" }}    allow-pw: {{ .Param "access-ssh-root-mode" }}{{ end }}
+    {{- if .ParamExists "access-keys" }}
+    authorized-keys:
+      {{ range $key := .Param "access-keys" -}}
+      - "{{ $key }}"
+      {{ end -}}
+    {{- end }}
+  keyboard:
+    layout: us
+  locale: en_US
+{{ if .ParamExists "part-scheme" -}}
+{{ $templateName := (printf "part-scheme-%s.tmpl" (.Param "part-scheme")) -}}
+{{ .CallTemplate $templateName . }}
+{{- end }}
+  late-commands:
+    - wget --no-proxy {{.Machine.Url}}/post-install.sh -O /target/net-post-install.sh
+    - chmod +x /target/net-post-install.sh
+    - curtin in-target --target=/target /net-post-install.sh


### PR DESCRIPTION
Fixes the Ubuntu 20.04 autoinstall Template to not inject a bad YAML stanza if there are no SSH keys defined on `access-keys`.

Moves the `autoinstall` template to an external template, and each of the Ubuntu 20.04 bootenvs now utilize the external template.

Validated and tested with ssh access-keys set/unset, access-ssh-root-mode set/unset, and storage stanzas set/unset.  YAML rendering is correct in all variations.  Test installs of Ubuntu 20.04.2 successful.