### PR TITLE
enhance(drp-community-content): Allow Discovery to customize how HOSTNAME is handled.

### DIFF
--- a/content/bootenvs/discovery.yml
+++ b/content/bootenvs/discovery.yml
@@ -345,12 +345,39 @@ Templates:
           fi
       fi
       if [[ ! $HOSTNAME ]]; then
-          # Try DNS reverse lookup
-          candidate="$(getent hosts $IP |awk "/$IP/ {print \$2}" |head -1)"
-          if [[ $candidate && $candidate != localhost* ]]; then
-              # Found a sane one
-              HOSTNAME="$candidate"
-          else
+          case {{ .Param "discovery-hostname-selector" }} in
+            d-mac) echo "Using default dMAC hostname method, skipping reverse IP lookup."
+            ;;
+            reverse-dns)
+              # Try DNS reverse lookup
+              candidate="$(getent hosts $IP |awk "/$IP/ {print \$2}" |head -1)"
+              [[ $candidate && $candidate != localhost* ]] && HOSTNAME="$candidate" || true
+              [[ -z "$HOSTNAME" ]] \
+                && echo "No reverse DNS record found for '$IP', reverting to default dMAC hostname." \
+                || echo "Reverse DNS record lookup candidate of '$HOSTNAME' found..."
+            ;;
+            external-template)
+              {{ if .Param "discovery-hostname-template" -}}
+              {{ $templateName := (.Param "discovery-hostname-template") -}}
+              echo "Using external template '{{ $templateName }}' to set hostname."
+
+              {{ .CallTemplate $templateName .}}
+
+              [[ -z "$HOSTNAME" ]] && echo "External template did not set HOSTNAME, falling back to dMAC hostname." || true
+              {{ else -}}
+              echo "WARNING: No 'discovery-hostname-template' set. Defaulting to dMAC hostname."
+              {{ end -}}
+            ;;
+            random)
+              echo "Starting random hostname generation."
+              HOSTNAME=$(pwmake 256 | tr -dc 'a-zA-Z' | fold -w 8 | head -n 1)
+              echo "Setting HOSTNAME to random value of '$HOSTNAME'."
+            ;;
+          *) echo "NOTICE: unsupported 'discovery-default-hostname-selector', falling through to dMAC hostname."
+            ;;
+          esac
+
+          if [[ -z $HOSTNAME ]]; then
               # Go with the default.
               default_host=true
               HOSTNAME="d${MAC//:/-}"

--- a/content/params/discovery-hostname-selector.yaml
+++ b/content/params/discovery-hostname-selector.yaml
@@ -1,0 +1,46 @@
+---
+Name: "discovery-hostname-selector"
+Description: "Sets the Discovery BootEnv default hostname selection method."
+Documentation: |
+  This param sets the Discovery BootEnv (typically used to discover and
+  create new machine objects when a Machine is Unknown to DRP) mechanism
+  for assigning a machine hostname.
+
+  The configurable values are:
+
+    * ``reverse-dns`` (the default): Attempt a Reverse IP lookup of the Machines assigned IP address, and use that
+    * ``d-mac`` use the MAC address in the form ``d00-00-00-12-34-56``
+    * ``external-template``: allow operator to provide custom template to assign hostname
+    * ``random``: Generates an 8 character random string for the hostname
+
+  In all cases, if the selected mechanism fails, then the fall-through default
+  behavior of using the *dMAC* process (eg. ``d00-00-00-12-34-56``) will be
+  used.  This allows Discovery to complete successfully.
+
+  For the ``external-template`` method, please review the Documentation
+  of the ``discovery-hostname-template`` Param on how to correctly use it.
+  You *MUST* specify an external template on the system to use this value,
+  otherwise, the *dMAC* assignment for hostname and Machine object Name
+  will be used.
+
+  .. note:: If a hostname is specified in the DHCP lease mechanism, this
+            will be honored and take precedence over any settings used
+            by this Param.
+
+  .. note:: This param will generally have to be applied at the Global profile level, as the Discovery BootEnv is used to create new
+            machine objects for Unknown Machines.
+
+Schema:
+  type: "string"
+  default: "reverse-dns"
+  enum:
+    - "d-mac"
+    - "reverse-dns"
+    - "external-template"
+    - "random"
+
+Meta:
+  type: "value"
+  icon: "server"
+  color: "blue"
+  title: "Digital Rebar Community Content"

--- a/content/params/discovery-hostname-template.yaml
+++ b/content/params/discovery-hostname-template.yaml
@@ -1,0 +1,48 @@
+---
+Name: "discovery-hostname-template"
+Description: "External template that gets the hostname for Machine."
+Documentation: |
+  If a system needs a customized way to get the hostname, which is
+  subsequently used to initially set the Machine object Name field,
+  then set the Param ``discovery-hostname-selector`` to the value of
+  ``external-template`` and set this Param to the name of a BASH
+  based template that sets the Shell Variable ``HOSTNAME`` to a
+  validly formed name.
+
+  This template will be injected inside of a BASH ``case`` statement.
+  It must be valid BASH, and ultimately it must set the Shell variable
+  ``HOSTNAME`` correctly.
+
+  An example External Template that generates a random 8 character
+  string which would be set to the HOSTNAME might look like:
+
+    ::
+
+      # do not use /dev/urandom directly - not enough entropy on VMs
+      HOSTNAME=$(pwmake 256 | tr -dc 'a-zA-Z' | fold -w 8 | head -n 1)
+
+  Setting the two Params as described above with a template like this
+  has the effect of setting the Discovery/Sledgehammer hostname to
+  the random string, and the newly created machine object ``Name``
+  field will also be set to this string.
+
+  .. note:: If the ``discovery-hostname-selector`` is set to use
+            ``external-template``, but no template is specified in the
+            ``discovery-hostname-template`` Param, then the default
+            behavior of using the dMAC (eg 'd00-00-00-12-34-56') value
+            will be used.  This allows the discovery process to continue
+            successfully.
+
+  .. warning:: If the injecte external template produces BASH shell
+               errors, the ``start-up.sh`` script will fail, and no new
+               Machine object will be created.
+
+Schema:
+  type: "string"
+  default: ""
+
+Meta:
+  type: "value"
+  icon: "time"
+  color: "blue"
+  title: "Digital Rebar Community Content"


### PR DESCRIPTION
Allows the Discovery BootEnv to allow customization to how HOSTNAME and subsequently Machine object Name fields are populated on discovery.

Default behaviors operate exactly as they used to.  Each of the newly customized values was extensively tested to validate that Discovery was successful in all usage scenarios.

Existing DHCP Lease HOSTNAME settings are honored as per previous behavior.