### PR TITLE
enhance(flash): Provide Manufacturer override

### DIFF
--- a/flash/params/flash-manufacturer-override.yml
+++ b/flash/params/flash-manufacturer-override.yml
@@ -1,0 +1,36 @@
+---
+Name: flash-manufacturer-override
+Description: Force override the manufacturer value to flash system.
+Documentation: |
+  .. warning:: This is a potentially dangerous thing to do.  Only use this as a
+               very **last** resort to force the Manufacturer to be identified for
+               the flash process.
+
+  This Param allows the operator to override the default discovered Manufacturer
+  for the flash process.  Some system DMI data structures are not correclty
+  filled out, and the flash process will fail.
+
+  **First**, verify that the gohai-inventory Param exists on the Machine object,
+  and that it the ``DMI --> System --> Manufacturer`` does not have a value
+  set in it.  If there is no ``gohai-inventory`` param, run the Machine through
+  a proper Discovery workflow first.
+
+  The flash system uses the following command to get the manufacturer from the DMI data:
+
+    * ``drpcli gohai |jq -r '.DMI | .System | .Manufacturer'`
+
+  In some cases, the vendor may iterate a different Manufacturer value than is
+  tested for in the script.  However, in these cases, please check with RackN
+  to verify if the system is compatible with the Flash process.
+
+  Review the ``flash-discover`` task.  Observe the BASH ``case`` statement for the
+  exact values that are supported.  Some examples include, but this list may
+  not be the most up to date, are:
+
+    * ``Dell Inc.``
+    * ``HP`` or ``HPE``
+    * ``Lenovo``
+
+Schema:
+  type: string
+  default: ""

--- a/flash/params/flash-manufacturer-override.yml
+++ b/flash/params/flash-manufacturer-override.yml
@@ -11,21 +11,23 @@ Documentation: |
   filled out, and the flash process will fail.
 
   **First**, verify that the gohai-inventory Param exists on the Machine object,
-  and that it the ``DMI --> System --> Manufacturer`` does not have a value
-  set in it.  If there is no ``gohai-inventory`` param, run the Machine through
-  a proper Discovery workflow first.
+  and that the ``DMI --> System --> Manufacturer`` does not have a value
+  set in it, or is not matching correctly.  If there is no ``gohai-inventory``
+  param, run the Machine through a proper Discovery workflow first, then re-verify
+  the Manufacturer value.
 
   The flash system uses the following command to get the manufacturer from the DMI data:
 
-    * ``drpcli gohai |jq -r '.DMI | .System | .Manufacturer'`
+    * ``drpcli gohai | jq -r '.DMI | .System | .Manufacturer'`
+
+  The *drpcli gohai* command must be run on the target Machine.
 
   In some cases, the vendor may iterate a different Manufacturer value than is
   tested for in the script.  However, in these cases, please check with RackN
   to verify if the system is compatible with the Flash process.
 
-  Review the ``flash-discover`` task.  Observe the BASH ``case`` statement for the
-  exact values that are supported.  Some examples include, but this list may
-  not be the most up to date, are:
+  Review the ``flash-discover`` task.  Observe the BASH ``case $mfgr in`` statement
+  for the exact values that are supported.  Some possible examples include:
 
     * ``Dell Inc.``
     * ``HP`` or ``HPE``
@@ -33,4 +35,3 @@ Documentation: |
 
 Schema:
   type: string
-  default: ""

--- a/flash/tasks/flash-discover.yml
+++ b/flash/tasks/flash-discover.yml
@@ -7,8 +7,16 @@ Templates:
   - Name: discover
     Contents: |
       #!/usr/bin/env bash
+
       {{ template "setup.tmpl"  .}}
+
       mfgr="$(drpcli gohai |jq -r '.DMI | .System | .Manufacturer')"
+      {{ if "flash-manufacturer-override" -}}
+      old="$mfgr"
+      mfgr="{{ .Param "flash-manufacturer-override" }}"
+      echo ">>> WARNING: 'flash-manufacturer-override' forced to '$mfgr'."
+      echo "              Overriding discovered value of '$old'."
+      {{ end -}}
 
       {{if eq (.Param "flash-method") "list" }}
       {{ if .ParamExists "flash-list" }}
@@ -31,6 +39,8 @@ Templates:
       APPEND="-list"
       {{ end }}
       {{end}}
+
+      [[ -z "$mfgr" ]] && echo ">>> WARNING:  Discovered Manufacturer has no value." || true
 
       case $mfgr in
           "Dell Inc.") drpcli machines tasks add {{.Machine.UUID}} at 0 dell-firmware-flash${APPEND};;

--- a/flash/tasks/flash-discover.yml
+++ b/flash/tasks/flash-discover.yml
@@ -11,7 +11,7 @@ Templates:
       {{ template "setup.tmpl"  .}}
 
       mfgr="$(drpcli gohai |jq -r '.DMI | .System | .Manufacturer')"
-      {{ if "flash-manufacturer-override" -}}
+      {{ if ( .ParamExists "flash-manufacturer-override" ) -}}
       old="$mfgr"
       mfgr="{{ .Param "flash-manufacturer-override" }}"
       echo ">>> WARNING: 'flash-manufacturer-override' forced to '$mfgr'."


### PR DESCRIPTION
Several Dell systems in the wild often have DMI -> System -> Manufacturer not set in the DMI.  This leads to the Flash tools (and likely others) failing to identify and flash the system correctly.  

This provides an override param that can be set to help correct this issue on systems in the field.  There are (hopefully) sufficient warnings in the Param that this is not a good thing to do generally.

The new Param is `flash-manufacturer-override`, which must be set exactly to one of the BASH `case` statement checks found in the `flash-discover` Task.