### PR TITLE
refactor(content): pre-release cleanups to cloud-wrapper, bootstrap-ssh, dr-server-install

### DIFF
--- a/cloud-wrappers/params/cloud-provider.yaml
+++ b/cloud-wrappers/params/cloud-provider.yaml
@@ -2,11 +2,18 @@
 Name: "cloud/provider"
 Description: "Cloud Provider"
 Documentation: |
-  The cloud provider detected by join-up script in discovery
+  The cloud provider detected by join-up script in cloud-provision
 
   Custom types are supported by adding Terraform plan template 'cloud-provision-[provider].tf.tmpl'
 
-  Implemented types: aws, google, linode, azure, digitalocean
+  Implemented types: 
+
+    * aws (Amazon Web Services)
+    * google (Google Compute Engine)
+    * linode
+    * azure (Microsoft Cloud)
+    * digitalocean
+    * pnap (Phoenix NAP)
 
   Expand this list as new types are added!
 Schema:

--- a/cloud-wrappers/params/pnap-client-id.yaml
+++ b/cloud-wrappers/params/pnap-client-id.yaml
@@ -1,0 +1,14 @@
+---
+Name: "pnap/client-id"
+Description: "Client ID for Phoenix NAP API operations"
+Documentation: |
+  The ID required by cloud provider to act aginst the API
+Schema:
+  type: "string"
+Meta:
+  type: "value"
+  icon: "user"
+  color: "blue"
+  title: "Digital Rebar Community Content"
+  cloud: "pnap"
+  clipboard: "cut"

--- a/cloud-wrappers/params/pnap-client-secret.yaml
+++ b/cloud-wrappers/params/pnap-client-secret.yaml
@@ -1,0 +1,15 @@
+---
+Name: "pnap/client-secret"
+Description: "Security Token for Phoenix NAP API operations"
+Documentation: |
+  The token required by cloud provider to act aginst the API
+Secure: true
+Schema:
+  type: "string"
+Meta:
+  type: "token"
+  icon: "key"
+  color: "blue"
+  title: "Digital Rebar Community Content"
+  password: "showable"
+  cloud: "pnap"

--- a/cloud-wrappers/params/pnap-location.yaml
+++ b/cloud-wrappers/params/pnap-location.yaml
@@ -1,0 +1,14 @@
+---
+Name: "pnap/location"
+Description: "Phoenix NAP Instance Location"
+Documentation: |
+  Provision PNAP location
+Schema:
+  type: "string"
+  default: "PHX"
+Meta:
+  type: "setting"
+  color: "black"
+  icon: "map outline"
+  title: "RackN Content"
+  cloud: "pnap"

--- a/cloud-wrappers/params/pnap-os.yaml
+++ b/cloud-wrappers/params/pnap-os.yaml
@@ -1,0 +1,14 @@
+---
+Name: "pnap/os"
+Description: "Phoenix NAP Instance OS"
+Documentation: |
+  Provision Phoenix NSP O/S Image from available list
+Schema:
+  type: "string"
+  default: "ubuntu/bionic"
+Meta:
+  type: "os"
+  color: "black"
+  icon: "disk outline"
+  title: "RackN Content"
+  cloud: "linode"

--- a/cloud-wrappers/params/pnap-type.yaml
+++ b/cloud-wrappers/params/pnap-type.yaml
@@ -1,0 +1,14 @@
+---
+Name: "pnap/type"
+Description: "Phoenix NAP Instance Type"
+Documentation: |
+  Provision PNAP allocation size
+Schema:
+  type: "string"
+  default: "s1.c1.small"
+Meta:
+  type: "setting"
+  color: "black"
+  icon: "box"
+  title: "RackN Content"
+  cloud: "pnap"

--- a/cloud-wrappers/stages/cloud-provision.yaml
+++ b/cloud-wrappers/stages/cloud-provision.yaml
@@ -6,9 +6,9 @@ Params:
 BootEnv: "sledgehammer"
 Tasks:
   - "context:drpcli-runner"
-  - "cloud-validate"
   - "rsa-key-create"
   - "context:terraform"
+  - "cloud-validate"
   - "terraform-apply"
   - "context:ansible"
   - "ansible-join-up"

--- a/cloud-wrappers/tasks/cloud-inspect.yaml
+++ b/cloud-wrappers/tasks/cloud-inspect.yaml
@@ -89,6 +89,19 @@ Templates:
 
       {{ end }}
 
+      {{ if eq "pnap" $cloud }}
+      echo "============================= PNAP INSPECT ============================="
+
+        {{ if .ParamExists "terraform-var/instance_id" }}
+        drpcli machines set $RS_UUID param cloud/instance-id to "\"{{ int (.Param "terraform-var/instance_id") }}\""
+        {{ end }}
+
+        {{ if .ParamExists "terraform-var/machine_ip" }}
+        drpcli machines set $RS_UUID param cloud/public-ipv4  to "{{ .Param "terraform-var/machine_ip" }}"
+        {{ end }}
+
+      {{ end }}
+
       {{ else }}
         echo "You must define which cloud is being used!"
         drpcli machines update $RS_UUID '{"Description":"ERROR: You must define the cloud/provider!"}'

--- a/cloud-wrappers/tasks/cloud-validate.yaml
+++ b/cloud-wrappers/tasks/cloud-validate.yaml
@@ -110,6 +110,25 @@ Templates:
 
         {{ end }}
 
+        {{ if eq "pnap" $cloud }}
+          echo "pnap/* check..."
+          {{ if .ParamExists "pnap/client-secret" }}
+            echo "  required secret is set"
+          {{ else }}
+            echo "  ERROR: you must set the pnap/client-secret for {{ .Param "cloud/provider" }}"
+            drpcli machines update $RS_UUID '{"Description":"ERROR: You must define the pnap/client-secret!"}' > /dev/null
+            exit 1
+          {{ end }}
+          {{ if .ParamExists "pnap/client-id" }}
+            echo "  required secret is set"
+          {{ else }}
+            echo "  ERROR: you must set the pnap/client-id"
+            drpcli machines update $RS_UUID '{"Description":"ERROR: You must define the pnap/client-id!"}' > /dev/null
+            exit 1
+          {{ end }}
+
+        {{ end }}
+
         {{ if eq "digitalocean" $cloud }}
           echo "digitalocean/token check..."
           {{ if .ParamExists "digitalocean/token" }}

--- a/cloud-wrappers/tasks/cloud-validate.yaml
+++ b/cloud-wrappers/tasks/cloud-validate.yaml
@@ -126,7 +126,12 @@ Templates:
             drpcli machines update $RS_UUID '{"Description":"ERROR: You must define the pnap/client-id!"}' > /dev/null
             exit 1
           {{ end }}
-
+          echo "  PNAP requires a local config file, build that right here"
+          mkdir ~/.pnap
+          tee ~/.pnap/config.yaml > /dev/null << EOF
+      clientId: {{ .Param "pnap/client-id" }}
+      clientSecret: {{ .Param "pnap/client-secret" }}
+      EOF
         {{ end }}
 
         {{ if eq "digitalocean" $cloud }}

--- a/cloud-wrappers/templates/cloud-provision-aws.tf.tmpl
+++ b/cloud-wrappers/templates/cloud-provision-aws.tf.tmpl
@@ -27,7 +27,7 @@ resource "aws_security_group" "digitalrebar_basic" {
 
 	name_prefix 	= "drp_"
 	description		= "Digital Rebar Cloud Wrapper"
-  {{ range $i, $p := (.ComposeParam "network/firewall-ports") }}
+  {{ range $i, $p := (.ComposeParam "network/firewall-ports" | uniq) }}
   {{- $portdef := split "/" $p -}}
 	ingress {
 		description = "network/firewall-ports[{{$i}}]"

--- a/cloud-wrappers/templates/cloud-provision-azure.tf.tmpl
+++ b/cloud-wrappers/templates/cloud-provision-azure.tf.tmpl
@@ -46,7 +46,7 @@ resource "azurerm_network_security_group" "security_group" {
     location            = azurerm_resource_group.main.location
     resource_group_name = azurerm_resource_group.main.name
 
-    {{ range $i, $p := (.ComposeParam "network/firewall-ports") }}
+    {{ range $i, $p := (.ComposeParam "network/firewall-ports" | uniq) }}
     {{- $portdef := split "/" $p -}}
     security_rule {
         name                       = "nfp-{{$i}}_"

--- a/cloud-wrappers/templates/cloud-provision-pnap.tf.tmpl
+++ b/cloud-wrappers/templates/cloud-provision-pnap.tf.tmpl
@@ -1,0 +1,32 @@
+# Configure the PhoenixNAP provider
+terraform {
+  required_providers {
+    pnap = {
+      source = "phoenixnap/pnap"
+      version = ">= 0.6.0"
+    }
+  }
+}
+
+# Create a serve
+resource "pnap_server" "drp_node" {
+    hostname = "{{ .Machine.Name }}"
+    os = "{{ .Param "pnap/os" }}"
+    type = "{{ .Param "pnap/type" }}"
+    location = "{{ .Param "pnap/location" }}"
+	{{ if .ParamExists "rsa/key-public" }}
+    ssh_keys = ["{{ .Param "rsa/key-public" }}"]
+	{{ end }}
+    #allowed actions are: reboot, reset, powered-on, powered-off, shutdown
+    action = "powered-on"
+}
+
+output "machine_ip" {
+	value       = element(compact(pnap_server.drp_node.public_ip_addresses),0)
+	description = "The IP of Machine"
+}
+
+output "instance_id" {
+	value       = pnap_server.drp_node.id
+	description = "PNAP Instance ID"
+}

--- a/content/tasks/bootstrap-ssh.yaml
+++ b/content/tasks/bootstrap-ssh.yaml
@@ -26,11 +26,16 @@ Templates:
         echo "SSH key pair already exists"
       fi
 
-      if [[ "$(drpcli profiles get global param access-keys)" == "null" ]] ; then
-        PUB_KEY="$(cat ~/.ssh/id_rsa.pub)"
-        drpcli profiles set global param access-keys to "{ \"dr-provision\": \"$PUB_KEY\" }"
+      PUB_KEY="$(cat ~/.ssh/id_rsa.pub)"
+      MY_KEY="\"$(drpcli info get | jq -r .id)\": \"$PUB_KEY\""
+      GLOBAL_KEY="$(drpcli profiles get global param access-keys)"
+      if [[ "$GLOBAL_KEY" == "null" ]] ; then
+        echo "Adding global access-keys.  First key is this endpoint"
+        drpcli profiles add global param access-keys to "{ $MY_KEY }" >/dev/null
       else
-        echo "SSH access-keys already exists.  Not updating it...."
+        echo "Updating global access-keys.  Adding this endpoint's key...."
+        GLOBAL_KEY=$(jq ". + { $MY_KEY }" <<< "$GLOBAL_KEY")
+        drpcli profiles set global param access-keys to "$GLOBAL_KEY" >/dev/null
       fi
 
       echo "done"

--- a/integrations/docker-context/ansible-dockerfile
+++ b/integrations/docker-context/ansible-dockerfile
@@ -5,9 +5,10 @@ RUN echo "===> Adding Python runtime..."  && \
     apk --no-cache --update add --virtual build-dependencies \
                 python3-dev libffi-dev openssl-dev build-base  && \
     apk add py3-pip && \
+    pip3 install cryptography==3.1.1 && \
     pip3 install --upgrade pip cffi
 RUN echo "===> Installing Ansible..."  && \
-    pip3 install ansible==2.9.1         && \
+    pip3 install ansible==3.2.0         && \
     echo "===> Removing package list..."  && \
     apk del build-dependencies            && \
     rm -rf /var/cache/apk/*
@@ -25,11 +26,7 @@ RUN echo "===> Installing Libraries..."  && \
         openssh-keygen && \
     rm -rf /var/cache/apk/*
 RUN pip3 install --no-cache-dir --upgrade yq
-# AWS EC2
-RUN pip3 install --no-cache-dir --upgrade mitogen boto3
-# Linode
-RUN pip3 install --no-cache-dir --upgrade linode-api4
-RUN curl -o /usr/bin/drpcli https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.5.0/amd64/linux/drpcli && \
+RUN curl -o /usr/bin/drpcli https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.5.4/amd64/linux/drpcli && \
     chmod 755 /usr/bin/drpcli && \
     ln -s /usr/bin/drpcli /usr/bin/jq && \
     ln -s /usr/bin/drpcli /usr/bin/drpjq && \

--- a/integrations/docker-context/runner-dockerfile
+++ b/integrations/docker-context/runner-dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:latest
 RUN apk --no-cache add bash curl openssh-keygen
-RUN curl -o /usr/bin/drpcli https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.5.0/amd64/linux/drpcli && \
+RUN curl -o /usr/bin/drpcli https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.5.4/amd64/linux/drpcli && \
     chmod 755 /usr/bin/drpcli && \
     ln -s /usr/bin/drpcli /usr/bin/jq && \
     ln -s /usr/bin/drpcli /usr/bin/drpjq && \

--- a/integrations/docker-context/terraform-dockerfile
+++ b/integrations/docker-context/terraform-dockerfile
@@ -1,6 +1,7 @@
 FROM hashicorp/terraform:light
+RUN terraform version
 RUN apk --no-cache add bash curl
-RUN curl -o /usr/bin/drpcli https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.5.0/amd64/linux/drpcli && \
+RUN curl -o /usr/bin/drpcli https://s3-us-west-2.amazonaws.com/rebar-catalog/drpcli/v4.5.4/amd64/linux/drpcli && \
     chmod 755 /usr/bin/drpcli && \
     ln -s /usr/bin/drpcli /usr/bin/jq && \
     ln -s /usr/bin/drpcli /usr/bin/drpjq && \

--- a/integrations/docker-context/test-build.sh
+++ b/integrations/docker-context/test-build.sh
@@ -6,6 +6,9 @@ set -e
 
 echo "Testing Container Build Process"
 
+docker rmi hashicorp/terraform:light || true
+docker rmi alpine:latest || true
+
 files="$(ls *-dockerfile)"
 
 for f in $files; do

--- a/task-library/tasks/ansible-join-up.yaml
+++ b/task-library/tasks/ansible-join-up.yaml
@@ -17,7 +17,20 @@ Documentation: |
 RequiredParams:
   - rsa/key-private
   - rsa/key-user
-Templates:
+Templates:  
+  - ID: discovery-common-bootstrap.sh.tmpl
+    Name: discovery-common-bootstrap.sh
+    Path: discovery-common-bootstrap.sh
+  - Contents: |-
+      #!/bin/bash
+      # replaces join-up.sh via the /machines/join-up.sh
+      export PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
+      set -x
+      . discovery-common-bootstrap.sh
+      find_by_saved_uuid
+      switch_to_control
+    Name: join-up.sh
+    Path: join-up.sh
   - Contents: |-
       #!/bin/bash
       # RackN Copyright 2020
@@ -68,13 +81,17 @@ Templates:
               dest: /etc/rs-uuid
             when: "'drpcli.service' not in services"
 
-          - name: download join-up script
-            become: true
-            get_url:
-              url: "{{.ProvisionerURL}}/machines/join-up.sh"
+          - name: "transfer join-up script"
+            copy:
+              src: "./join-up.sh"
               dest: "./join-up.sh"
               mode: 0755
-            when: "'drpcli.service' not in services"
+
+          - name: "transfer discovery-common-bootstrap.sh script"
+            copy:
+              src: "./discovery-common-bootstrap.sh"
+              dest: "./discovery-common-bootstrap.sh"
+              mode: 0755
 
           - name: run join-up script
             become: true

--- a/task-library/tasks/ansible-join-up.yaml
+++ b/task-library/tasks/ansible-join-up.yaml
@@ -39,6 +39,11 @@ Templates:
 
       {{template "setup.tmpl" .}}
 
+      {{ if empty .Machine.Address }}
+      echo "ERROR: missing Machine Address - cannot proceed"
+      exit 1
+      {{ end }}
+      
       # we need a keypair for Ansible
       echo "Retrieving SSH key from Machine Params rsa/key-*"
       tee rsa-{{.Machine.Name}} >/dev/null << EOF

--- a/task-library/tasks/dr-server-install.yaml
+++ b/task-library/tasks/dr-server-install.yaml
@@ -37,14 +37,17 @@ OptionalParams:
   - "dr-server/install-drpid"
   - "dr-server/initial-password"
   - "dr-server/initial-user"
+RequiredParams:
+  - "rsa/key-user"
+  - "rsa/key-private"
 Templates:
   - Name: "playbook.yaml"
     Path: "playbook.yaml"
     Contents: |-
-      ---
+      ---{{ $user := .Param "rsa/key-user" }}
       ### Run DRP Install/Upgrade via Ansible
       - hosts: all
-        remote_user: "{{ .Param "rsa/key-user" }}"
+        remote_user: "{{$user}}"
         connection: "ssh"
         gather_facts: false
         debugger: {{ if .Param "rs-debug-enable" }}on_failed{{ else }}never{{ end }}
@@ -55,6 +58,36 @@ Templates:
           - name: Wait for the instances to boot by checking the ssh port
             wait_for_connection:
               timeout: 300
+
+          {{if .ParamExists "access-keys"}}
+          {{range $name, $key := .Param "access-keys"}}
+          - name: Set authorized key from access-keys
+            authorized_key:
+              user: "{{$user}}"
+              state: present
+              key: "{{$key}}"
+          {{end}}
+          {{end}}
+
+          {{if .ParamExists "access-keys-global"}}
+          {{range $name, $key := .Param "access-keys-global"}}
+          - name: Set authorized key from access-keys-global
+            authorized_key:
+              user: "{{$user}}"
+              state: present
+              key: "{{$key}}"
+          {{end}}
+          {{end}}
+
+          {{if .ParamExists "access-keys-shared"}}
+          {{range $name, $key := .Param "access-keys-shared"}}
+          - name: Set authorized key from access-keys-shared
+            authorized_key:
+              user: "{{$user}}"
+              state: present
+              key: "{{$key}}"
+          {{end}}
+          {{end}}
 
           - name: "What is my DRP ID?"
             debug:
@@ -68,7 +101,7 @@ Templates:
               msg: "DRP status is {{`{{ services['dr-provision.service'].status }}`}}"
             when: services["dr-provision.service"] is defined
 
-          {{range $index, $port := .Param "network/firewall-ports" }}
+          {{range $index, $port := (.ComposeParam "network/firewall-ports" | uniq)}}
           - name: "enable firewall ports... enable {{$port}} for DRP server"
             {{ if contains "/" $port -}}
             shell: "firewall-cmd --permanent --add-port={{$port}}"

--- a/task-library/tasks/terraform-apply.yaml
+++ b/task-library/tasks/terraform-apply.yaml
@@ -171,7 +171,7 @@ Templates:
         echo "Uploading other keys from terraform output"
         for key in $(jq -r 'keys[]' <<< ${out}); do
           echo "  adding $key to machine"
-          drpcli machines set $RS_UUID param "terraform-var/$key" to "\"$(jq -r ".$key.value" <<< ${out})\""  > /dev/null
+          drpcli machines set $RS_UUID param "terraform-var/$key" to "\"$(jq -cr ".$key.value" <<< ${out})\""  > /dev/null
         done
 
         {{ else }}

--- a/tools/bundle-and-upload.sh
+++ b/tools/bundle-and-upload.sh
@@ -7,13 +7,18 @@ changed="$1 $(git status -s | awk 'match($0, /\sM\s([a-z,\-]+)/, arr) { print ar
 echo "Bundle and Update to $RS_ENDPOINT ..."
 
 for b in $changed; do
-    if [[ ! -f "$b/$b.yaml" ]]; then
-        cd $b
-        echo "  updating $b/$b.yaml"
-        drpcli contents bundle $b.yaml > /dev/null
-        drpcli contents upload $b.yaml > /dev/null
-        cd ..
-    fi
+    case "$b" in
+    	"integrations"|"tools") echo "  skipping $b (not content)";;
+	*)
+	    if [[ ! -f "$b/$b.yaml" ]]; then
+	        cd $b
+	        echo "  updating $b/$b.yaml"
+	        drpcli contents bundle $b.yaml > /dev/null
+	        drpcli contents upload $b.yaml > /dev/null
+	        cd ..
+        fi
+    ;;
+	esac
 done
 
 for b in $changed; do

--- a/tools/cloud-profiles.sh
+++ b/tools/cloud-profiles.sh
@@ -202,6 +202,7 @@ Name: "pnap"
 Description: "Phoenix NAP Credentials"
 Params:
   "cloud/provider": "pnap"
+  "rsa/key-user": "ubuntu"
   "pnap/client-id": "$(cat ~/.pnap/config.yaml | grep "clientId:" | awk '{split($0,a,": "); print a[2]}')"
 Meta:
   color: "blue"

--- a/tools/cloud-profiles.sh
+++ b/tools/cloud-profiles.sh
@@ -191,6 +191,30 @@ else
   echo "  Skipping Linode, no token LINODE_TOKEN"
 fi
 
+if [[ -f ~/.pnap/config.yaml ]]; then
+  if drpcli profiles exists pnap > /dev/null 2>/dev/null ; then
+    echo "  Skipping Phoenix NAP, already exists"
+  else
+    echo "  upload Phoenix NAP (pnap) credentials"
+    drpcli profiles create - >/dev/null << EOF
+---
+Name: "pnap"
+Description: "Phoenix NAP Credentials"
+Params:
+  "cloud/provider": "pnap"
+  "pnap/client-id": "$(cat ~/.pnap/config.yaml | grep "clientId:" | awk '{split($0,a,": "); print a[2]}')"
+Meta:
+  color: "blue"
+  icon: "cloud"
+  title: "generated"
+EOF
+    drpcli profiles add pnap param "pnap/client-secret" to "$(cat ~/.pnap/config.yaml | grep "clientSecret:" | awk '{split($0,a,": "); print a[2]}')" > /dev/null
+  fi
+else
+  echo "  Skipping Phoenix NAP, no ~/.pnap/config.yaml"
+fi
+
+
 if which az > /dev/null ; then
   if drpcli profiles exists azure > /dev/null 2>/dev/null ; then
     echo "  Skipping Azure, already exists"


### PR DESCRIPTION
Mainly cleanups to the content packs covering
* bootstrap-ssh updated to add keys (was right approach anyway, but required for HA)
* dr-site-create stage includes required port 8092 so that it cannot be overlooked
* dr-site-create will add SSH keys from access-keys when installing on new server (handy since agent does not run there)
* adding 8092 to param via stage required cleanup of handling ports
* change so cloud wrapper to not require port 8091 (which is not open by default now)
* added Phoenix NAP to test cloud-wrapper on new platform
* updated Ansible and Terraform Contexts to have most recent versions (updated in repo.rackn.io also)
* 