### PR TITLE
enhance(drp-community-content,os-other): Add Rocky 8 Linux to DRPCC and os-other

### DIFF
--- a/content/bootenvs/rocky-8-install.yaml
+++ b/content/bootenvs/rocky-8-install.yaml
@@ -1,0 +1,91 @@
+---
+Name: rocky-8-install
+Description: Rocky-8 installer that points to the latest Rocky 8 release.
+Documentation: |
+  This BootEnv installs the Rocky 8 DVD operating system.  The *minimal* ISO
+  is currently (May 2021) built incorrectly and does not carry all appropriate
+  packages to Kickstart successfully.
+
+  ISOs can be downloaded from:
+
+    * https://download.rockylinux.org/pub/rocky/
+
+  The *DVD* ISO is well over 8 GB in size.  This will require at least 24 GB of
+  free disk space on the DRP Endpoint to be exploded out correctly.
+
+Meta:
+  color: green
+  feature-flags: change-stage-v2
+  icon: linux
+  title: Digital Rebar Community Content
+  type: os
+Kernel: ''
+Initrds: []
+BootParams: ''
+RequiredParams: []
+OptionalParams:
+  - operating-system-disk
+  - provisioner-default-password-hash
+  - kernel-console
+  - kernel-options
+  - proxy-servers
+  - select-kickseed
+OnlyUnknown: false
+Loaders:
+  amd64-uefi: EFI/BOOT/BOOTX64.EFI
+
+OS:
+  Name: rocky-8
+  Family: redhat
+  Codename: rocky
+  Version: '8'
+  IsoFile: ''
+  IsoSha256: ''
+  IsoUrl: ''
+  SupportedArchitectures:
+    x86_64:
+      IsoFile: Rocky-8.3-x86_64-dvd1.iso
+      Sha256: ""
+      IsoUrl: >-
+        https://download.rockylinux.org/pub/rocky/8.3/isos/x86_64/Rocky-8.3-x86_64-dvd1.iso
+      Kernel: images/pxeboot/vmlinuz
+      Initrds:
+        - images/pxeboot/initrd.img
+      BootParams: >-
+        ksdevice=bootif ks={{.Machine.Url}}/compute.ks
+        method={{.Env.InstallUrl}} inst.geoloc=0 {{.Param "kernel-options"}} --
+        {{.Param "kernel-console"}}
+      Loader: ''
+Templates:
+  - Name: kexec
+    Path: '{{.Machine.Path}}/kexec'
+    ID: kexec.tmpl
+  - Name: pxelinux
+    Path: 'pxelinux.cfg/{{.Machine.HexAddress}}'
+    ID: default-pxelinux.tmpl
+  - Name: ipxe
+    Path: '{{.Machine.Address}}.ipxe'
+    ID: default-ipxe.tmpl
+  - Name: pxelinux-mac
+    Path: 'pxelinux.cfg/{{.Machine.MacAddr "pxelinux"}}'
+    ID: default-pxelinux.tmpl
+  - Name: ipxe-mac
+    Path: '{{.Machine.MacAddr "ipxe"}}.ipxe'
+    ID: default-ipxe.tmpl
+  - Name: grub
+    Path: 'grub/{{.Machine.Address}}.cfg'
+    ID: default-grub.tmpl
+  - Name: grub-mac
+    Path: 'grub/{{.Machine.MacAddr "grub"}}.cfg'
+    ID: default-grub.tmpl
+  - Name: grub-secure-mac
+    Path: >-
+      {{.Env.PathFor "tftp" ""}}/EFI/BOOT/grub.cfg-{{.Machine.MacAddr
+      "pxelinux"}}
+    ID: default-grub.tmpl
+  - Name: grub-secure
+    Path: '{{.Env.PathFor "tftp" ""}}/EFI/BOOT/grub.cfg-{{.Machine.HexAddress}}'
+    ID: default-grub.tmpl
+  - Name: compute.ks
+    Path: '{{.Machine.Path}}/compute.ks'
+    ID: select-kickseed.tmpl

--- a/content/params/kickstart-base-packages.yaml
+++ b/content/params/kickstart-base-packages.yaml
@@ -40,6 +40,15 @@ Schema:
       - curl
       - efibootmgr
       - tar
+    rocky:
+      - "@core"
+      - trousers
+      - fipscheck
+      - device-mapper-multipath
+      - openssh
+      - curl
+      - efibootmgr
+      - tar
     fedora:
       - "@core"
       - fipscheck

--- a/content/stages/rocky-8-install.yaml
+++ b/content/stages/rocky-8-install.yaml
@@ -1,0 +1,23 @@
+---
+Name: rocky-8-install
+BootEnv: rocky-8-install
+Description: Rocky 8 install stages.  References the latest Rocky 8 release
+Documentation: ""
+Meta:
+  color: green
+  icon: download
+  title: Digital Rebar Community Content
+  type: os
+OptionalParams: []
+Params: {}
+Partial: false
+Profiles: []
+Reboot: false
+RequiredParams: []
+Templates: []
+Tasks:
+- set-hostname
+- centos-drp-only-repos
+- ssh-access
+- configure-network
+

--- a/content/templates/rocky-8.ks.tmpl
+++ b/content/templates/rocky-8.ks.tmpl
@@ -1,0 +1,66 @@
+# DigitalRebar Provision Rocky-8 (and related distros) kickstart
+
+{{range .InstallRepos}}
+{{ .Install }}
+{{end}}
+# key --skip
+# Disable geolocation for language and timezone
+# Currently broken by https://bugzilla.redhat.com/show_bug.cgi?id=1111717
+# geoloc 0
+timezone Etc/UTC --isUtc
+lang en_US
+keyboard us
+# rebar
+rootpw --iscrypted {{if .ParamExists "provisioner-default-password-hash"}}{{.Param "provisioner-default-password-hash"}}{{else}}$6$drprocksdrprocks$upAIK9ynEEdFmaxJ5j0QRvwmIu2ruJa1A1XB7GZjrnYYXXyNr4qF9FttxMda2j.cmh.TSiLgn4B/7z0iSHkDC1{{end}}
+firewall --disabled
+auth --passalgo=sha512 --enableshadow
+selinux --disabled
+
+{{if .ParamExists "part-scheme" -}}
+{{$templateName := (printf "part-scheme-%s.tmpl" (.Param "part-scheme")) -}}
+{{.CallTemplate $templateName .}}
+{{else -}}
+{{template "part-scheme-default.tmpl" .}}
+{{end -}}
+
+text
+skipx
+reboot {{if .Param "kexec-ok" }}--kexec{{end}}
+
+%packages
+# match packages in kickstart-base-packages based on the BootEnv OS Codename equal to "rocky"
+# fallback to "FamilyName" (generally "redhat"), then "unknown" package list
+{{ $packages := index (.Param "kickstart-base-packages") .Env.OS.Codename -}}
+{{ if not $packages -}}
+{{ $packages = index (.Param "kickstart-base-packages") .Env.OS.FamilyName -}}
+{{ end -}}
+{{ if not $packages -}}
+{{ $packages = index (.Param "kickstart-base-packages") "unknown" -}}
+{{ end -}}
+{{ range $index, $element := $packages -}}
+{{$element}}
+{{ end -}}
+{{if .ParamExists "extra-packages" -}}
+{{ range $index, $element := (.Param "extra-packages") -}}
+{{$element}}
+{{end -}}
+{{end -}}
+%end
+
+%pre
+{{ range $intf := .Param "kickstart/extra-ifs" }}
+nmcli con add type ethernet con-name {{ $intf }} ifname {{ $intf }}
+{{end}}
+%end
+
+%post
+
+exec > /root/post-install.log 2>&1
+set -x
+export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]}): '
+
+{{template "reset-workflow.tmpl" .}}
+{{template "runner.tmpl" .}}
+
+sync
+%end

--- a/content/templates/select-kickseed.tmpl
+++ b/content/templates/select-kickseed.tmpl
@@ -30,6 +30,8 @@
   {{ if ( eq "redhat" .Env.OS.FamilyName ) -}}
     {{ if ( eq .Env.OS.Codename "photon" ) -}}
       {{ template "photon.json.tmpl" .}}
+    {{ else if ( eq .Env.OS.Codename "rocky" ) -}}
+      {{ template "rocky-8.ks.tmpl" .}}
     {{ else -}}
       {{ if ( regexMatch ".*rhel-server.*" .Env.OS.Name ) -}}
         {{ if ( .Env.OS.VersionEq "8" ) -}}

--- a/os-other/workflows/rocky-server-8-dvd-install.yaml
+++ b/os-other/workflows/rocky-server-8-dvd-install.yaml
@@ -1,0 +1,22 @@
+---
+Name: rocky-server-8-install
+Description: 'Basic Rocky Install Workflow + Runner'
+Documentation: |
+  This workflow includes the DRP Runner in Rocky provisioning process for DRP.
+
+  After the install completes, the workflow installs the runner
+  in a waiting state so that DRP will automatically detect and start a
+  new workflow if the *Machine.Workflow* is updated.
+
+  .. note:: To enable, upload the Rocky ISO as per the rocky-8 BootEnv
+
+Meta:
+  color: green
+  icon: download
+  title: RackN Content
+ReadOnly: true
+Stages:
+- rocky-8-install
+- drp-agent
+- finish-install
+- complete


### PR DESCRIPTION
Adds Rocky 8 (_release candidate_) Linux to DRP Community Content and os-other (for workflow).  Rocky 8 has been added to Universal content as well, and it is preferred to use Universal for deployment of this OS.

Tested successfully.

**_WARNING_**
DRP backend `package-repositories` handling has not been added to support Rocky Linux natively.  DRP is currently using CentOS package repositories information for package handling.  This PR does not address `package-repositories`