### PR TITLE
fix(drp-community-content): Fix net-seed typo for proxy and ntp-servers

### DIFF
--- a/content/templates/net-seed.tmpl
+++ b/content/templates/net-seed.tmpl
@@ -32,7 +32,7 @@ d-i mirror/country string manual
 {{end -}}
 
 {{if .ParamExists "proxy-servers" -}}
-d-i mirror/http/proxy string {{index (.Param "proxy-servers") 0}}
+d-i mirror/http/proxy string {{index (.Param "proxy-servers") -}}
 {{else -}}
 d-i mirror/http/proxy string
 {{end -}}
@@ -41,7 +41,7 @@ d-i mirror/http/proxy string
 d-i clock-setup/utc boolean true
 {{if .ParamExists "ntp-servers" -}}
 d-i clock-setup/ntp boolean true
-d-i clock-setup/ntp-server string {{index (.Param "ntp-servers") 0}}
+d-i clock-setup/ntp-server string {{index (.Param "ntp-servers") -}}
 {{else -}}
 d-i clock-setup/ntp boolean false
 {{end -}}


### PR DESCRIPTION
Fixes egregious typo in golang template construct for the `net-seed.tmpl` for `ntp-servers` and for `proxy-servers`. 