### PR TITLE
fix(debian-base): Remove inadvertent dependency on task-library.

### DIFF
--- a/content/workflows/debian-base.yaml
+++ b/content/workflows/debian-base.yaml
@@ -15,7 +15,7 @@ Documentation: |
 
 Stages:
   - debian-10-install
-  - runner-service
+  - drp-agent
   - finish-install
   - complete
 Meta:


### PR DESCRIPTION
drp-community-content has a drp-agent stage which installs drpcli
running in agent mode,  Replace the reference in the debian-base
workflow to runner-service with drp-agent