### PR TITLE
Remove redundant allow-pw option from ubuntu autoinstall

### DIFF
--- a/content/templates/ubuntu-autoinstall-userdata.tmpl
+++ b/content/templates/ubuntu-autoinstall-userdata.tmpl
@@ -12,7 +12,6 @@ autoinstall:
     username: {{ if .ParamExists "provisioner-default-user" }}{{ .Param "provisioner-default-user" }}{{ else }}rocketskates{{ end }}
   ssh:
     install-server: yes
-{{- if .ParamExists "access-ssh-root-mode" }}{{ printf "\n" }}    allow-pw: {{ .Param "access-ssh-root-mode" }}{{ end }}
     {{- if .ParamExists "access-keys" }}
     authorized-keys:
       {{ range $key := .Param "access-keys" -}}


### PR DESCRIPTION
The Ubuntu autoinstall [schema](https://ubuntu.com/server/docs/install/autoinstall-schema#Schema) dictates that allow-pw is a boolean. Unless we explicitly parse the `access-ssh-root-mode` param, and spit out a boolean, we risk the user crashing the installer by specifying a non-boolean. That consideration aside, `allow-pw` in this context has nothing to do with root - it's applicable to all SSH logins, and so removing it makes more sense than trying to shoehorn a kickstart parameter into an Ubuntu autoinstall (as I discovered to my detriment!)