### PR TITLE
enhance(task-library): allow 'bootstrap-tools' to Compose

### DIFF
--- a/task-library/profiles/bootstrap-drp-endpoint.yaml
+++ b/task-library/profiles/bootstrap-drp-endpoint.yaml
@@ -3,22 +3,27 @@ Name: bootstrap-drp-endpoint
 Description: Profile to perform a full bootstrap DRP Endpoint
 Documentation: |
   Bootstrap Digital Rebar server with the bootstrap operations for:
-  
-    * ``bootstrap-tools`` - install additional packages
+
+    * ``bootstrap-tools`` - install additional packages (*)
     * ``bootstrap-ipmi`` - install ``ipmitool`` package and ipmi plugin provider if needed
     * ``bootstrap-contexts`` - install ``docker-context`` plugin_providder, and contexts in installed content
-    
+
   Intended to be driven by a bootstrapping workflow on the DRP Endpoint
-  (like ``universal--bootstrap``).
+  (like ``universal-bootstrap``).
+
+  .. note:: ``(*)``  The ``bootstrap-tools`` specification exists in the ``bootstrap-ipmi``
+            Profile definition.  It is not explicitly called out here, as that would duplicate
+            the pockage install process needlessly.
+
+            The ``bootstrap-ipmi`` Profile defines the Param ``bootstrap-tools`` to
+            contain ``ipmitool``.  The Param is a composable Param, so all instances
+            of the Param will be aggregated together in one list, instead of the
+            regular order of precedence.
 
 Meta:
   color: blue
   icon: boxes
   title: Digital Rebar Provision
-Params:
-  bootstrap-tools:
-    - ipmitool
-  universal/bootstrap-post-flexiflow:
-    - bootstrap-tools
-    - bootstrap-ipmi
-    - bootstrap-contexts
+Profiles:
+  - bootstrap-ipmi
+  - bootstrap-contexts

--- a/task-library/templates/bootstrap-tools.sh.tmpl
+++ b/task-library/templates/bootstrap-tools.sh.tmpl
@@ -15,8 +15,15 @@ echo ">>> There are not bootstrap tools listed in Param 'bootstrap-tools'.  Exit
 exit 0
 {{ end -}}
 
-{{ $pkgs := ( .Param "bootstrap-tools" ) | join " " -}}
+###
+#  Package list is built with the ComposeParam template construct, so
+#  it's an aggregate list of all occurences of the values on the
+#  system for the Machine.
+###
+{{ $pkgs := ( .ComposeParam "bootstrap-tools" ) | join " " -}}
 PKGS="{{ $pkgs }}"
+echo ">>> Package list was composed to the following packages:"
+echo "    $PKGS"
 FAMILY=$(grep "^ID=" /etc/os-release | tr -d '"' | cut -d '=' -f 2)
 
 # figure out if we need to try and use 'sudo' to run package installers
@@ -25,6 +32,7 @@ if which sudo > /dev/null 2>&1 ; then
   [[ "$ID" == "0" ]] && SUDO="" || SUDO="sudo"
 fi
 
+echo ">>> Beginning package install process"
 case $FAMILY in
   rhel|redhat|centos|photon|amzn)
     if which tdnf > /dev/null 2>&1 ; then


### PR DESCRIPTION
Enhances the `bootstrap-tools` Param to be composed, so Operator can append and build up the list of packages to install.

Clean up the documentation.

Remove the `bootstrap-tools` explicitly set in `bootstrap-drp-endpoint`, as it's redundant to the `bootstrap-ipmi` Param/Task which uses the `bootstrap-tools`.