### PR TITLE
fix(burnin): Tweak the disk stress test task.

### DIFF
--- a/burnin/params/burnin-disk-max-errors.yml
+++ b/burnin/params/burnin-disk-max-errors.yml
@@ -1,0 +1,11 @@
+---
+Name: "burnin-disk-max-errors"
+Description: "The number disk errors before giving up.  0 means never give up."
+Schema:
+  type: "number"
+  default: 0
+Meta:
+  type: "input"
+  color: "blue"
+  icon: "fire"
+  title: "RackN Content"

--- a/burnin/tasks/disk_stress.yml
+++ b/burnin/tasks/disk_stress.yml
@@ -31,7 +31,7 @@ Templates:
     echo "Starting disk stress test"
     TEST_SSDS={{.Param "burnin-disk-test-ssd"}}
     DESTRUCTIVE={{.Param "burnin-disk-destructive"}}
-    BBARGS="-s -v -b 4096 -c 4096"
+    BBARGS="-v -b 4096 -c 256 -e {{.Param "burnin-disk-max-errors"}}"
     if [[ $DESTRUCTIVE = true ]]; then
         # Nuke it all.
         declare vg pv maj min blocks name
@@ -85,11 +85,13 @@ Templates:
                 echo "passed "
             else
                 echo "failed"
-            fi > "test-${i##*/}"
+            fi 2>&1 | gzip > "test-${i##*/}.gz"
             exit
-        ) &
+        )  &
     done
     wait
-    cat test-*
+    for f in test-*.gz; do
+        gunzip < "$f"
+    done
     grep -q failed test-* && exit 1 || exit 0
 


### PR DESCRIPTION
Ditch incremental status updates when running badblocks.  We run them
all in parallel in the background, and status messages are kinda
pointless in that mode.

Expose a param that lets badblocks bail early after a set number of errors.
The default is to have it try to scan everything anyways.