### PR TITLE
Fix issue provisioning Debian 8/9 and possible Ubuntu when machine is in UEFI mode.  

### DIFF
--- a/content/templates/net-seed.tmpl
+++ b/content/templates/net-seed.tmpl
@@ -48,6 +48,7 @@ d-i clock-setup/ntp boolean false
 d-i time/zone string UTC
 
 # Partitioner Label Default (GPT)
+d-i partman-efi/non_efi_system boolean true
 d-i partman/choose_label string gpt
 d-i partman-basicfilesystems/choose_label string gpt
 d-i partman-partitioning/choose_label string gpt


### PR DESCRIPTION
This fixes the following error message that shows when a machine is provisioned in UEFI mode (note that is already addressed in Debian 10):

This machine's firmware has started the installer in UEFI mode but it looks like there may be existing operating System already installed using BIOS compatiblity mode. If you continue to install Debian in UEFI mode, it might be difficult to reboot the machine into any BIOS-mode operating system later.

If you wish to install UEFI mode and don't care about keeping the ability to boot one of the existing systems, you have the option to force that here. If you wish to keep the option to boot an existing operating system you should choose NOT to force UEFI installtion here.

Force UEFI installation?

![Debian 9 - UEFI](https://user-images.githubusercontent.com/1029250/124812188-4b05e080-df31-11eb-8bd6-fb117add2217.png)
