### PR TITLE
Script to create a WinPE based on Windows ADK 10

### DIFF
--- a/tools/windows/AddFiles_WinPE_64/Windows/System32/shutdown.cmd
+++ b/tools/windows/AddFiles_WinPE_64/Windows/System32/shutdown.cmd
@@ -1,0 +1,2 @@
+@echo %* | find /i "/s" > nul
+@if %errorlevel% equ 0 (wpeutil Shutdown) else (wpeutil Reboot)

--- a/tools/windows/Build-WinPEx64.cmd
+++ b/tools/windows/Build-WinPEx64.cmd
@@ -1,0 +1,119 @@
+@ECHO OFF
+REM This script is based on https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/winpe-mount-and-customize
+REM This script will build a sample 64-bit WinPE ISO for use with RackN Digital Rebar
+
+:VERIFY_ADMIN_PRIV
+REM This script calls commands, like DISM, that require administrative privileges
+REM This tries to get some output from NET SESSION which requires admin privileges and errors out if it doesn't
+NET SESSION > nul 2>&1
+IF ERRORLEVEL 1 GOTO NO_ADMIN_PRIV
+
+:VERIFY_REQS
+REM Even ADK for Windows 11 uses the below path currently. Might need to be adjusted at some point in time.
+SET ADK_PATH=%ProgramFiles(x86)%\Windows Kits\10\Assessment and Deployment Kit
+IF NOT EXIST "%ADK_PATH%\Deployment Tools\DandISetEnv.bat" GOTO NO_ADK_INSTALLED
+IF NOT EXIST "%ADK_PATH%\Windows Preinstallation Environment\copype.cmd" GOTO NO_ADK_INSTALLED
+
+:SET_PE_ENV
+SETLOCAL
+
+SET PEScriptRoot=%~dp0
+CALL "%ADK_PATH%\Deployment Tools\DandISetEnv.bat"
+
+IF EXIST "%DISMRoot%" GOTO HAVE_ADK_PE_ROOT
+
+ECHO The ADK root folder could not be determined.
+ECHO.
+ECHO Is the correct version of ADK installed?
+ECHO.
+GOTO NO_ADK_INSTALLED
+
+:HAVE_ADK_PE_ROOT
+SET TEMP_PE_FOLDER=%SYSTEMDRIVE%\WINPE_X64_BUILDER
+SET LOGFILE="%TEMP_PE_FOLDER%\winpe_log.txt"
+
+IF EXIST "%TEMP_PE_FOLDER%" RMDIR /S /Q "%TEMP_PE_FOLDER%"
+
+:COPY_WINPE_FILES
+CALL "%WinPERoot%\copype.cmd" amd64 "%TEMP_PE_FOLDER%"
+
+:MOUNT_WINPE
+SET TEMP_MOUNT_FOLDER=%TEMP_PE_FOLDER%\mount
+"%DISMRoot%\dism.exe" /Mount-Wim /LogPath:%LOGFILE% /WimFile:"%TEMP_PE_FOLDER%\media\sources\boot.wim" /index:1 /MountDir:"%TEMP_MOUNT_FOLDER%"
+
+:ADD_PACKAGES
+ECHO.
+ECHO Adding WinPE component packages
+ECHO.
+"%DISMRoot%\dism.exe" /image:"%TEMP_MOUNT_FOLDER%" /LogPath:%LOGFILE% /Add-Package /PackagePath:"%WinPERoot%\amd64\WinPE_OCs\WinPE-WMI.cab"
+"%DISMRoot%\dism.exe" /image:"%TEMP_MOUNT_FOLDER%" /LogPath:%LOGFILE% /Add-Package /PackagePath:"%WinPERoot%\amd64\WinPE_OCs\WinPE-NetFX.cab"
+"%DISMRoot%\dism.exe" /image:"%TEMP_MOUNT_FOLDER%" /LogPath:%LOGFILE% /Add-Package /PackagePath:"%WinPERoot%\amd64\WinPE_OCs\WinPE-Scripting.cab"
+"%DISMRoot%\dism.exe" /image:"%TEMP_MOUNT_FOLDER%" /LogPath:%LOGFILE% /Add-Package /PackagePath:"%WinPERoot%\amd64\WinPE_OCs\WinPE-PowerShell.cab"
+"%DISMRoot%\dism.exe" /image:"%TEMP_MOUNT_FOLDER%" /LogPath:%LOGFILE% /Add-Package /PackagePath:"%WinPERoot%\amd64\WinPE_OCs\WinPE-DismCmdlets.cab"
+"%DISMRoot%\dism.exe" /image:"%TEMP_MOUNT_FOLDER%" /LogPath:%LOGFILE% /Add-Package /PackagePath:"%WinPERoot%\amd64\WinPE_OCs\WinPE-SecureBootCmdlets.cab"
+"%DISMRoot%\dism.exe" /image:"%TEMP_MOUNT_FOLDER%" /LogPath:%LOGFILE% /Add-Package /PackagePath:"%WinPERoot%\amd64\WinPE_OCs\WinPE-SecureStartup.cab"
+"%DISMRoot%\dism.exe" /image:"%TEMP_MOUNT_FOLDER%" /LogPath:%LOGFILE% /Add-Package /PackagePath:"%WinPERoot%\amd64\WinPE_OCs\WinPE-PlatformId.cab"
+"%DISMRoot%\dism.exe" /image:"%TEMP_MOUNT_FOLDER%" /LogPath:%LOGFILE% /Add-Package /PackagePath:"%WinPERoot%\amd64\WinPE_OCs\WinPE-MDAC.cab"
+"%DISMRoot%\dism.exe" /image:"%TEMP_MOUNT_FOLDER%" /LogPath:%LOGFILE% /Add-Package /PackagePath:"%WinPERoot%\amd64\WinPE_OCs\WinPE-RNDIS.cab"
+"%DISMRoot%\dism.exe" /image:"%TEMP_MOUNT_FOLDER%" /LogPath:%LOGFILE% /Add-Package /PackagePath:"%WinPERoot%\amd64\WinPE_OCs\WinPE-HTA.cab"
+"%DISMRoot%\dism.exe" /image:"%TEMP_MOUNT_FOLDER%" /LogPath:%LOGFILE% /Add-Package /PackagePath:"%WinPERoot%\amd64\WinPE_OCs\WinPE-Dot3Svc.cab"
+
+ECHO.
+ECHO Verifying all installed component packages (Pending is OK)
+"%DISMRoot%\dism.exe" /image:"%TEMP_MOUNT_FOLDER%" /LogPath:%LOGFILE% /Get-Packages
+
+:INJECT_DRIVERS
+SET DRIVER_ROOT_FOLDER=%PEScriptRoot%Drivers_WinPE_v10_64
+ECHO DRIVER_ROOT_FOLDER=%DRIVER_ROOT_FOLDER%
+ECHO.
+ECHO Injecting drivers, this will take even longer...
+"%DISMRoot%\dism.exe" /Image:"%TEMP_MOUNT_FOLDER%" /LogPath:%LOGFILE% /Add-Driver /Driver:"%DRIVER_ROOT_FOLDER%" /Recurse /ForceUnsigned
+
+:INJECT_ADDITIONAL_FILES
+SET ADDEDFILES=%PEScriptRoot%AddFiles_WinPE_64
+ECHO ADDEDFILES=%ADDEDFILES%
+ECHO.
+ECHO Adding additonal files to WinPE image
+XCOPY "%ADDEDFILES%" "%TEMP_MOUNT_FOLDER%" /Y /E /I
+
+IF EXIST "%TEMP_MOUNT_FOLDER%\Windows\System32\winpeshl.ini" REN "%TEMP_MOUNT_FOLDER%\Windows\System32\winpeshl.ini" winpeshl.ini.disabled
+
+:UNMOUNT_WINPE
+ECHO.
+ECHO Committing and unmounting the modified WinPE
+"%DISMRoot%\Dism" /unmount-Wim /LogPath:%LOGFILE% /MountDir:"%TEMP_MOUNT_FOLDER%" /Commit
+
+:CREATE_ISO
+ECHO.
+CALL "%WinPERoot%\MakeWinPEMedia.cmd" /ISO /F "%TEMP_PE_FOLDER%" "%PEScriptRoot%winpe.iso"
+ECHO SHA256 for %PEScriptRoot%winpe.iso:
+PowerShell -NoProfile -Command "(Get-FileHash -Path '%PEScriptRoot%winpe.iso' -Algorithm SHA256).Hash.ToLower()"
+
+:CLEANUP
+ECHO.
+ECHO The DISM log file is located at:
+ECHO %LOGFILE%
+ECHO.
+ECHO Removing temporary folder and log files, press CTRL-C to abort or
+PAUSE
+RMDIR /S /Q "%TEMP_PE_FOLDER%"
+
+ENDLOCAL
+EXIT /B 0
+
+:NO_ADK_INSTALLED
+ECHO.
+ECHO The ADK for Windows 10 or higher does not appear to be installed, exiting...
+ECHO.
+ECHO The ADK and WinPE add-on can be downloaded from
+ECHO https://docs.microsoft.com/en-us/windows-hardware/get-started/adk-install
+PAUSE
+EXIT /B 1
+
+:NO_ADMIN_PRIV
+ECHO.
+ECHO This script requires to be run with administrative privileges!
+ECHO Run this script again as Administrator.
+ECHO.
+PAUSE
+EXIT /B 1

--- a/tools/windows/README.md
+++ b/tools/windows/README.md
@@ -1,47 +1,50 @@
-# Windows PE Boot Image#
+# Windows PE Boot Image
 
 This directory contains the script needed to build a Windows PE
-ISO image that can be booted sued for management tasks that require
+ISO image that can be booted and used for management tasks that require
 a Windows environment.
 
-## Prerequisites Required to Create Image ##
+## Prerequisites Required to Create Image
 
-* A Windows 7, 8, or 10 system to act as a technician workstation.
-* The technician workstation must have the Windows 8.1 AIK installed
-  to the default location.  You can download the AIK from:
-  https://www.microsoft.com/en-us/download/details.aspx?id=39982
+* A Windows 10 or newer system to act as a technician workstation.
+* The technician workstation must have the Windows ADK as well as the
+  WinPE add-on for ADK installed to the default location.
+  You can download the ADK from:
+  https://docs.microsoft.com/en-us/windows-hardware/get-started/adk-install
+  The latest version of ADK for Windows 10 or newer is fine.
 * Any drivers needed to enable WinPE to function on target systems.
 
-## Creating a Rebar-compatible Windows PE boot image ##
+## Creating a Rebar-compatible Windows PE boot image
 All these steps should take place on the technician workstation, and
-assume that the user is logged in to the Administrator account.  They
-also assume that you are working from
+assume that the user is able to open up an elevated instance of the Command
+Prompt.  They also assume that you are working from
 `C:\Users\Administrator\Desktop\winpe`, and they will refer to it as `winpe`.
 
 * Copy the entire contents of the directory containing this README into `winpe`.
-
 * Copy any drivers that are required to run WinPE on your target hardware 
-  into winpe/Drivers.  You can copy any number of drivers into that directory,
-  as long as they are for Windows winpe amd64.  The drivers must be expanded -- 
-  they should have the .inf and .sys files, and there should be one driver per 
-  directory under the Drivers directory.  The drivers will be installed by the
-  Add-WindowsDriver powershell cmdlet -- see the documentation for that cmdlet
-  if you encounter any difficulties.  If you will be testing in a VM, you will
-  need to include the appropriate drivers.  For KVM or Xen-based vms, the 
-  virtio drivers from https://fedoraproject.org/wiki/Windows_Virtio_Drivers
-  will come in handy.
-  
-* Ensure that the `build-winpe-iso.ps1` command from this directory is
-  present in `winpe`.
-  
-* Open a command prompt, and cd into `winpe`.
+  into `winpe\Drivers_WinPE_v10_64`.  You can copy any number of drivers 
+  into that directory, as long as they are for Windows winpe amd64.
+  The drivers must be expanded -- they should have the .inf and .sys files, 
+  and there should be one driver per directory under the Drivers directory.
+  The drivers will be installed by DISM  -- see [the documentation](https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/add-and-remove-drivers-to-an-offline-windows-image)
+  for that tool if you encounter any difficulties.
 
-* Run the following command:
-  `powershell -executionpolicy bypass build-winpe-iso.ps1`
-  
+  > If you will be testing in a VM, you will need to include the appropriate
+  > drivers.  For KVM or Xen-based hypervisors, the virtio drivers from
+  > https://fedoraproject.org/wiki/Windows_Virtio_Drivers will come in handy.
+* If you need to add any additional executables to the WinPE image, they
+  can be placed in the `winpe\AddFiles_WinPE_64` folder. Just be mindful
+  that any executable you add to the image must be a true 64-bit application.
+* Ensure that the `build-winpex64.cmd` script from this directory is
+  present in `winpe`.
+* Open an administrative command prompt, and cd into `winpe`.
+* Run the script:
+  `build-winpex64.cmd`
+
   It will take several minutes to finish, and at the end you will have an
   ISO named `winpe.iso`. Upload this ISO to a Digital Rebar endpoint, and you should
   be able to boot to the `windows-pe` boot environment
-
-* Note: This image is not compatible with UEFI Secure Boot for now.
-
+* The script will also output the SHA256 hash which you will need to provide when
+  uploading the ISO.
+* **Note:** This ISO is compatible with UEFI Secure Boot, but the `wimboot` method
+  of loading it, is not.


### PR DESCRIPTION
This script will build a basic WinPE based on the Windows 10 ADK.
It supports adding drivers and additional files to the WinPE image
to enable advanced template execution.
The readme file has been update to include instructions to use the
script.
The shutdown batch file is there to support the remote shutdown and
reboot functionality of the drpcli agent, which is not natively
supported within WinPE.