### PR TITLE
fix(rhel): Remove links to rhel iso files.

### DIFF
--- a/os-other/bootenvs/rhel-server-7.7-install.yaml
+++ b/os-other/bootenvs/rhel-server-7.7-install.yaml
@@ -30,7 +30,6 @@ OS:
       Initrds:
       - images/pxeboot/initrd.img
       IsoFile: rhel-server-7.7-x86_64-dvd.iso
-      IsoUrl: "https://rackn-repo.s3.amazonaws.com/isos/redhat/rhel/7/rhel-server-7.7-x86_64-dvd.iso"
       Kernel: images/pxeboot/vmlinuz
       Loader: ""
       Sha256: 88b42e934c24af65e78e09f0993e4dded128d74ec0af30b89b3cdc02ec48f028

--- a/os-other/bootenvs/rhel-server-7.9-install.yaml
+++ b/os-other/bootenvs/rhel-server-7.9-install.yaml
@@ -30,7 +30,6 @@ OS:
       Initrds:
       - images/pxeboot/initrd.img
       IsoFile: rhel-server-7.9-x86_64-dvd.iso
-      IsoUrl: "https://rackn-repo.s3-us-west-2.amazonaws.com/isos/redhat/rhel/7/rhel-server-7.9-x86_64-dvd.iso"
       Kernel: images/pxeboot/vmlinuz
       Loader: ""
       Sha256: 19d653ce2f04f202e79773a0cbeda82070e7527557e814ebbce658773fbe8191

--- a/os-other/bootenvs/rhel-server-8-boot-install.yaml
+++ b/os-other/bootenvs/rhel-server-8-boot-install.yaml
@@ -26,7 +26,6 @@ OS:
       Initrds:
         - images/pxeboot/initrd.img
       IsoFile: rhel-8.2-x86_64-boot.iso
-      IsoUrl: "https://rackn-repo.s3.amazonaws.com/isos/redhat/rhel/8/rhel-8.2-x86_64-boot.iso"
       Kernel: images/pxeboot/vmlinuz
       Loader: ""
       Sha256: "d30989c6b3f3b81c262dfbf6e8f711e0d49a6828eb77833c34859e694c24e981"

--- a/os-other/bootenvs/rhel-server-8-dvd-install.yaml
+++ b/os-other/bootenvs/rhel-server-8-dvd-install.yaml
@@ -39,7 +39,6 @@ OS:
       Initrds:
         - images/pxeboot/initrd.img
       IsoFile: "rhel-8.3-x86_64-dvd.iso"
-      IsoUrl: "https://rackn-repo.s3.amazonaws.com/isos/redhat/rhel/8/rhel-8.3-x86_64-dvd.iso"
       Kernel: images/pxeboot/vmlinuz
       Loader: ""
       Sha256: "30fd8dff2d29a384bd97886fa826fa5be872213c81e853eae3f9d9674f720ad0"

--- a/os-other/bootenvs/rhel-server-8.2-dvd-install.yaml
+++ b/os-other/bootenvs/rhel-server-8.2-dvd-install.yaml
@@ -39,7 +39,6 @@ OS:
       Initrds:
         - images/pxeboot/initrd.img
       IsoFile: "rhel-8.2-x86_64-dvd.iso"
-      IsoUrl: "https://rackn-repo.s3.amazonaws.com/isos/redhat/rhel/8/rhel-8.2-x86_64-dvd.iso"
       Kernel: images/pxeboot/vmlinuz
       Loader: ""
       Sha256: "7fdfed9c7cced4e526a362e64ed06bcdc6ce0394a98625a40e7d05db29bf7b86"


### PR DESCRIPTION
They should never have been added in the first place.